### PR TITLE
Add activity tracking, List output optimization and color opt-out, add version command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,15 +28,15 @@ get-deps: .gobuild
 .gobuild:
 	@mkdir -p $(GS_PATH)
 	@rm -f $(GS_PATH)/$(PROJECT) && cd "$(GS_PATH)" && ln -s ../../../.. $(PROJECT)
-	#builder get dep -b branch-name https://github.com/giantswarm/gsclientgen.git $(GS_PATH)/gsclientgen
-	go get -v github.com/giantswarm/gsclientgen
-	go get -v github.com/giantswarm/api-schema
+	builder get dep -b add-headers https://github.com/giantswarm/gsclientgen.git $(GS_PATH)/gsclientgen
+	#go get -v github.com/giantswarm/gsclientgen
 	go get -v github.com/bradfitz/slice
 	go get -v github.com/fatih/color
+	go get -v github.com/giantswarm/api-schema
+	go get -v github.com/giantswarm/columnize
 	go get -v github.com/go-resty/resty
 	go get -v github.com/howeyc/gopass
 	go get -v github.com/inconshreveable/mousetrap
-	go get -v github.com/ryanuber/columnize
 	go get -v github.com/spf13/cobra/cobra
 	go get -v gopkg.in/yaml.v2
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,15 @@ sudo cp gsctl-0.1.0-linux-amd64/gsctl /usr/local/bin/
 - Download [`gsctl` for Windows (64 Bit)](http://downloads.giantswarm.io/gsctl/0.1.0/gsctl-0.1.0-windows-amd64.zip) or [32 Bit](http://downloads.giantswarm.io/gsctl/0.1.0/gsctl-0.1.0-windows-386.zip)
 - Copy the contained `gsctl.exe` to a convenient location
 
+## Configuration
+
+`gsctl` keeps it's own settings under `$HOME/.gsctl/config.yaml`.
+
+Additionally, the following environment variables can be used:
+
+- `GSCTL_DISABLE_COLORS`: When this variable is set to any non-empty string, all terminal output will be monochrome.
+- `GSCTL_DISABLE_CMDLINE_TRACKING`: When this variable is set to any non-empty string, command lines won't be submitted to the API. Otherwise command lines are submitted to learn about the tool's usage and find ways to improve.
+
 ## Changelog
 
 See [Releases](https://github.com/giantswarm/gsctl/releases)

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -2,6 +2,13 @@ package commands
 
 // This file defines some variables to be available in all commands
 
+import (
+	"math/rand"
+	"os"
+	"strings"
+	"time"
+)
+
 var (
 	// token flag
 	cmdToken string
@@ -17,4 +24,33 @@ var (
 
 	// TTL (time to live) flag
 	cmdTTLDays int
+
+	randomStringCharset = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+	requestIDHeader string
+	cmdLine         string
 )
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+	requestIDHeader = randomRequestID()
+	cmdLine = getCommandLine()
+}
+
+// randomRequestID returns a new request ID
+func randomRequestID() string {
+	size := 14
+	b := make([]rune, size)
+	for i := range b {
+		b[i] = randomStringCharset[rand.Intn(len(randomStringCharset))]
+	}
+	return string(b)
+}
+
+// getCommandLine returns the command line that has been called
+func getCommandLine() string {
+	if os.Getenv("GSCTL_DISABLE_CMDLINE_TRACKING") == "" {
+		return strings.Join(os.Args, " ")
+	}
+	return ""
+}

--- a/commands/create.go
+++ b/commands/create.go
@@ -49,6 +49,9 @@ const (
 
 	// windows download page
 	kubectlWindowsInstallURL string = "https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG.md"
+
+	addKeyPairActivityName       string = "add-keypair"
+	createKubeconfigActivityName string = "create-kubeconfig"
 )
 
 func init() {
@@ -71,7 +74,7 @@ func checkAddKeypair(cmd *cobra.Command, args []string) error {
 	}
 	if cmdClusterID == "" {
 		// use default cluster if possible
-		clusterID, _ := config.GetDefaultCluster()
+		clusterID, _ := config.GetDefaultCluster(requestIDHeader, addKeyPairActivityName, cmdLine)
 		if clusterID != "" {
 			cmdClusterID = clusterID
 		} else {
@@ -89,7 +92,7 @@ func addKeypair(cmd *cobra.Command, args []string) {
 	authHeader := "giantswarm " + config.Config.Token
 	ttlHours := int32(cmdTTLDays * 24)
 	addKeyPairBody := gsclientgen.AddKeyPairBody{Description: cmdDescription, TtlHours: ttlHours}
-	keypairResponse, _, err := client.AddKeyPair(authHeader, cmdClusterID, addKeyPairBody)
+	keypairResponse, _, err := client.AddKeyPair(authHeader, cmdClusterID, addKeyPairBody, requestIDHeader, addKeyPairActivityName, cmdLine)
 
 	if err != nil {
 		log.Fatal(err)
@@ -138,7 +141,7 @@ func checkCreateKubeconfig(cmd *cobra.Command, args []string) error {
 	}
 	if cmdClusterID == "" {
 		// use default cluster if possible
-		clusterID, _ := config.GetDefaultCluster()
+		clusterID, _ := config.GetDefaultCluster(requestIDHeader, createKubeconfigActivityName, cmdLine)
 		if clusterID != "" {
 			cmdClusterID = clusterID
 		} else {
@@ -163,7 +166,7 @@ func createKubeconfig(cmd *cobra.Command, args []string) {
 
 	fmt.Println("Creating new key-pair…")
 
-	keypairResponse, _, err := client.AddKeyPair(authHeader, cmdClusterID, addKeyPairBody)
+	keypairResponse, _, err := client.AddKeyPair(authHeader, cmdClusterID, addKeyPairBody, requestIDHeader, createKubeconfigActivityName, cmdLine)
 
 	if err != nil {
 		fmt.Println(color.RedString("Error in createKubeconfig:"))

--- a/commands/info.go
+++ b/commands/info.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
-	"github.com/ryanuber/columnize"
+	"github.com/giantswarm/columnize"
 	"github.com/spf13/cobra"
 
 	"github.com/giantswarm/gsctl/config"

--- a/commands/list.go
+++ b/commands/list.go
@@ -54,6 +54,12 @@ var (
 	}
 )
 
+const (
+	listKeypairsActivityName      string = "list-keypairs"
+	listClustersActivityName      string = "list-clusters"
+	listOrganizationsActivityName string = "list-organizations"
+)
+
 func init() {
 	ListKeypairsCommand.Flags().StringVarP(&cmdClusterID, "cluster", "c", "", "ID of the cluster to list key-pairs for")
 	// subcommands
@@ -79,7 +85,7 @@ func listOrgs(cmd *cobra.Command, args []string) {
 		authHeader = "giantswarm " + cmdToken
 	}
 
-	orgsResponse, apiResponse, err := client.GetUserOrganizations(authHeader)
+	orgsResponse, apiResponse, err := client.GetUserOrganizations(authHeader, requestIDHeader, listOrganizationsActivityName, cmdLine)
 	if err != nil {
 		fmt.Println("Error details:")
 		log.Fatal(err)
@@ -114,7 +120,7 @@ func checkListClusters(cmd *cobra.Command, args []string) error {
 func listClusters(cmd *cobra.Command, args []string) {
 	client := gsclientgen.NewDefaultApi()
 	authHeader := "giantswarm " + config.Config.Token
-	orgsResponse, apiResponse, err := client.GetUserOrganizations(authHeader)
+	orgsResponse, apiResponse, err := client.GetUserOrganizations(authHeader, requestIDHeader, listClustersActivityName, cmdLine)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -126,7 +132,7 @@ func listClusters(cmd *cobra.Command, args []string) {
 			sort.Strings(organizations)
 			output := []string{color.YellowString("Id") + "|" + color.YellowString("Name") + "|" + color.YellowString("Created") + "|" + color.YellowString("Organization")}
 			for _, orgName := range organizations {
-				clustersResponse, _, err := client.GetOrganizationClusters(authHeader, orgName)
+				clustersResponse, _, err := client.GetOrganizationClusters(authHeader, orgName, requestIDHeader, listClustersActivityName, cmdLine)
 				if err != nil {
 					log.Fatal(err)
 				}
@@ -154,7 +160,7 @@ func checkListKeypairs(cmd *cobra.Command, args []string) error {
 	}
 	if cmdClusterID == "" {
 		// use default cluster if possible
-		clusterID, _ := config.GetDefaultCluster()
+		clusterID, _ := config.GetDefaultCluster(requestIDHeader, listKeypairsActivityName, cmdLine)
 		if clusterID != "" {
 			cmdClusterID = clusterID
 		} else {
@@ -167,7 +173,7 @@ func checkListKeypairs(cmd *cobra.Command, args []string) error {
 func listKeypairs(cmd *cobra.Command, args []string) {
 	client := gsclientgen.NewDefaultApi()
 	authHeader := "giantswarm " + config.Config.Token
-	keypairsResponse, _, err := client.GetKeyPairs(authHeader, cmdClusterID)
+	keypairsResponse, _, err := client.GetKeyPairs(authHeader, cmdClusterID, requestIDHeader, listKeypairsActivityName, cmdLine)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/commands/list.go
+++ b/commands/list.go
@@ -10,8 +10,8 @@ import (
 	"github.com/bradfitz/slice"
 	"github.com/fatih/color"
 	apischema "github.com/giantswarm/api-schema"
+	"github.com/giantswarm/columnize"
 	"github.com/giantswarm/gsclientgen"
-	"github.com/ryanuber/columnize"
 	"github.com/spf13/cobra"
 
 	"github.com/giantswarm/gsctl/config"
@@ -97,9 +97,9 @@ func listOrgs(cmd *cobra.Command, args []string) {
 			fmt.Println(color.YellowString("No organizations available"))
 		} else {
 			sort.Strings(organizations)
-			fmt.Println(color.YellowString("Organization"))
+			fmt.Println(color.CyanString("ORGANIZATION"))
 			for _, orgName := range organizations {
-				fmt.Println(color.CyanString(orgName))
+				fmt.Println(orgName)
 			}
 		}
 	} else {
@@ -130,7 +130,7 @@ func listClusters(cmd *cobra.Command, args []string) {
 			fmt.Println(color.YellowString("No organizations available"))
 		} else {
 			sort.Strings(organizations)
-			output := []string{color.YellowString("Id") + "|" + color.YellowString("Name") + "|" + color.YellowString("Created") + "|" + color.YellowString("Organization")}
+			output := []string{color.CyanString("ID") + "|" + color.CyanString("NAME") + "|" + color.CyanString("CREATED") + "|" + color.CyanString("ORGANIZATION")}
 			for _, orgName := range organizations {
 				clustersResponse, _, err := client.GetOrganizationClusters(authHeader, orgName, requestIDHeader, listClustersActivityName, cmdLine)
 				if err != nil {
@@ -139,10 +139,10 @@ func listClusters(cmd *cobra.Command, args []string) {
 				for _, cluster := range clustersResponse.Data.Clusters {
 					created := util.ShortDate(util.ParseDate(cluster.CreateDate))
 					output = append(output,
-						color.CyanString(cluster.Id)+"|"+
-							color.CyanString(cluster.Name)+"|"+
-							color.CyanString(created)+"|"+
-							color.CyanString(orgName))
+						cluster.Id+"|"+
+							cluster.Name+"|"+
+							created+"|"+
+							orgName)
 				}
 			}
 			fmt.Println(columnize.SimpleFormat(output))
@@ -184,16 +184,16 @@ func listKeypairs(cmd *cobra.Command, args []string) {
 		})
 
 		// create output
-		output := []string{color.YellowString("Created") + "|" + color.YellowString("Expires") + "|" + color.YellowString("Id") + "|" + color.YellowString("Description")}
+		output := []string{color.CyanString("CREATED") + "|" + color.CyanString("EXPIRES") + "|" + color.CyanString("ID") + "|" + color.CyanString("DESCRIPTION")}
 		for _, keypair := range keypairsResponse.Data.KeyPairs {
 			created := util.ShortDate(util.ParseDate(keypair.CreateDate))
 			expires := util.ParseDate(keypair.CreateDate).Add(time.Duration(keypair.TtlHours) * time.Hour)
 
 			// skip if expired
-			output = append(output, color.CyanString(created)+"|"+
-				color.CyanString(util.ShortDate(expires))+"|"+
-				color.CyanString(util.Truncate(util.CleanKeypairID(keypair.Id), 10))+"|"+
-				color.CyanString(keypair.Description))
+			output = append(output, created+"|"+
+				util.ShortDate(expires)+"|"+
+				util.Truncate(util.CleanKeypairID(keypair.Id), 10)+"|"+
+				keypair.Description)
 		}
 		fmt.Println(columnize.SimpleFormat(output))
 

--- a/commands/login.go
+++ b/commands/login.go
@@ -16,6 +16,10 @@ import (
 	"github.com/giantswarm/gsctl/config"
 )
 
+const (
+	loginActivityName string = "login"
+)
+
 var (
 	// password given via command line flag
 	password string
@@ -72,7 +76,7 @@ func login(cmd *cobra.Command, args []string) {
 
 	client := gsclientgen.NewDefaultApi()
 	requestBody := gsclientgen.LoginBodyModel{Password: string(encodedPassword)}
-	loginResponse, apiResponse, err := client.UserLogin(email, requestBody)
+	loginResponse, apiResponse, err := client.UserLogin(email, requestBody, requestIDHeader, loginActivityName, cmdLine)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/commands/logout.go
+++ b/commands/logout.go
@@ -13,6 +13,10 @@ import (
 	"github.com/giantswarm/gsctl/config"
 )
 
+const (
+	logoutActivityName string = "login"
+)
+
 var (
 	// LogoutCommand performs a logout
 	LogoutCommand = &cobra.Command{
@@ -44,7 +48,7 @@ func logout(cmd *cobra.Command, args []string) {
 		authHeader = "giantswarm " + cmdToken
 	}
 
-	logoutResponse, apiResponse, err := client.UserLogout(authHeader)
+	logoutResponse, apiResponse, err := client.UserLogout(authHeader, requestIDHeader, logoutActivityName, cmdLine)
 	if err != nil {
 		fmt.Println("Info: The client doesn't handle the API's 401 response yet.")
 		fmt.Println("Seeing this error likely means: The passed token was no longer valid.")

--- a/commands/logout.go
+++ b/commands/logout.go
@@ -21,7 +21,7 @@ var (
 	// LogoutCommand performs a logout
 	LogoutCommand = &cobra.Command{
 		Use:     "logout",
-		Short:   "Sign out the current user",
+		Short:   "Sign the current user out",
 		Long:    `This will terminate the current user's session and invalidate the authentication token.`,
 		PreRunE: checkLogout,
 		Run:     logout,

--- a/commands/version.go
+++ b/commands/version.go
@@ -1,0 +1,41 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/gsctl/config"
+)
+
+var (
+	// VersionCommand is the "version" go command
+	VersionCommand = &cobra.Command{
+		Use:   "version",
+		Short: "Print version number",
+		Long: `Prints the gsctl version number.
+
+When executed with the --verbose flag, the build date is printed in addition.`,
+		Run: printVersion,
+	}
+)
+
+func init() {
+	RootCommand.AddCommand(VersionCommand)
+}
+
+// printInfo prints some information on the current user and configuration
+func printVersion(cmd *cobra.Command, args []string) {
+	if config.Version != "" {
+		fmt.Println(config.Version)
+	} else {
+		fmt.Println("Info: version number is only available in a built binary")
+	}
+	if cmdVerbose {
+		if config.BuildDate != "" {
+			fmt.Println(config.BuildDate)
+		} else {
+			fmt.Println("Info: build date/time is only available in a built binary")
+		}
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -9,9 +9,8 @@ import (
 	"strings"
 	"time"
 
-	yaml "gopkg.in/yaml.v2"
-
 	"github.com/giantswarm/gsclientgen"
+	yaml "gopkg.in/yaml.v2"
 )
 
 // struct used for YAML serialization of settings
@@ -151,9 +150,14 @@ func getKubeconfigPaths(homeDir string) []string {
 	return nil
 }
 
-// GetDefaultCluster determines which is the default cluster. This can be either
-// the only cluster accessible, or a cluster selected explicitly.
-func GetDefaultCluster() (clusterID string, err error) {
+// GetDefaultCluster determines which is the default cluster
+//
+// This can be either the only cluster accessible, or a cluster selected explicitly.
+//
+// @param requestIDHeader  Request ID to pass with API requests
+// @param activityName     Name of the activity calling this function (for tracking)
+// @param cmdLine          Command line content used to run the CLI (for tracking)
+func GetDefaultCluster(requestIDHeader, activityName, cmdLine string) (clusterID string, err error) {
 	// Check selected cluster
 	if Config.Cluster != "" {
 		return Config.Cluster, nil
@@ -164,7 +168,7 @@ func GetDefaultCluster() (clusterID string, err error) {
 	}
 	client := gsclientgen.NewDefaultApi()
 	authHeader := "giantswarm " + Config.Token
-	orgsResponse, _, err := client.GetUserOrganizations(authHeader)
+	orgsResponse, _, err := client.GetUserOrganizations(authHeader, requestIDHeader, activityName, cmdLine)
 	if err != nil {
 		return "", err
 	}
@@ -172,7 +176,7 @@ func GetDefaultCluster() (clusterID string, err error) {
 		if len(orgsResponse.Data) > 0 {
 			clusterIDs := []string{}
 			for _, orgName := range orgsResponse.Data {
-				clustersResponse, _, err := client.GetOrganizationClusters(authHeader, orgName)
+				clustersResponse, _, err := client.GetOrganizationClusters(authHeader, orgName, requestIDHeader, activityName, cmdLine)
 				if err != nil {
 					return "", err
 				}

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"runtime"
 
 	"github.com/fatih/color"
@@ -14,7 +15,7 @@ func init() {
 	columnizeConfig.Glue = "   "
 
 	// disable color on windows, as it is super slow
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == "windows" || os.Getenv("GSCTL_DISABLE_COLORS") != "" {
 		color.NoColor = true
 	}
 }

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"runtime"
 
 	"github.com/fatih/color"
-	"github.com/ryanuber/columnize"
+	"github.com/giantswarm/columnize"
 
 	"github.com/giantswarm/gsctl/commands"
 )


### PR DESCRIPTION
This PR adds two unrelated changes:

## Activity Tracking

Add tracking of user actions ("activities") via request headers, which helps us to understand what users do with the CLI. This submits two request headers to the API:

(1) a request ID, which will also be helpful when debugging requests in the future.

(2) the complete command line. Part (2) can be deactivated using the `GSCTL_DISABLE_CMDLINE_TRACKING` environment variable (see README).

## Output improvements

These changes are based on user feedback (thanks @teemow!)

- Colors can now be turned off by setting the environment variable `GSCTL_DISABLE_COLORS`.
- Table output for the commands `gsctl list clusters`, `gsctl list organizations`, and `gsctl list keypairs` has been changed so that only headers are printed in color, while data rows use the default terminal color.
- To make table column headers easier to distinguish from data rows, even with colors disabled, they are now CAPITALIZED.

## Version command

- The `gsctl version` command has been added, with the purpose to simply output the version number (and build date when used with `--verbose`). See #4.

## TODO

- [ ] When https://github.com/giantswarm/gsclientgen/pull/4 is merged, set the branch used back to master