### PR TITLE
Removing go 1.6 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ services:
 language: go
 
 go:
-    - 1.6
     - 1.7
 
 notifications:


### PR DESCRIPTION
We build in go 1.7. Testing 1.6 only takes twice the time and has no additional value.