### PR TITLE
Fix keypair description

### DIFF
--- a/commands/create.go
+++ b/commands/create.go
@@ -88,6 +88,10 @@ func checkAddKeypair(cmd *cobra.Command, args []string) error {
 }
 
 func addKeypair(cmd *cobra.Command, args []string) {
+	if cmdDescription == "" {
+		cmdDescription = "Added by user " + config.Config.Email + " using 'gsctl create keypair'"
+	}
+
 	client := gsclientgen.NewDefaultApiWithBasePath(cmdAPIEndpoint)
 	authHeader := "giantswarm " + config.Config.Token
 	ttlHours := int32(cmdTTLDays * 24)

--- a/commands/create.go
+++ b/commands/create.go
@@ -159,7 +159,7 @@ func createKubeconfig(cmd *cobra.Command, args []string) {
 	// parameters given by the user
 	ttlHours := int32(cmdTTLDays * 24)
 	if cmdDescription == "" {
-		cmdDescription = "Added by user " + config.Config.Email + " using 'g8m create kubeconfig'"
+		cmdDescription = "Added by user " + config.Config.Email + " using 'gsctl create kubeconfig'"
 	}
 
 	addKeyPairBody := gsclientgen.AddKeyPairBody{Description: cmdDescription, TtlHours: ttlHours}


### PR DESCRIPTION
- Replaces `g8m` with `gsctl` in a generated description for `gsctl create kubeconfig`
- Adds a default description for the `gsctl create keypair` command