### PR TITLE
Use Go 1.8 for builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: go
 
 go:
     - 1.7
+    - 1.8
 
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ services:
 language: go
 
 go:
-    - 1.7
     - 1.8
 
 notifications:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PROJECT=gsctl
 ORGANISATION=giantswarm
 BIN=$(PROJECT)
-GOVERSION := 1.7.4
+GOVERSION := 1.8-alpine
 BUILDDATE := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 VERSION := $(shell cat VERSION)
 COMMIT := $(shell git rev-parse HEAD | cut -c1-10)


### PR DESCRIPTION
This PR switches our build (and Travis tests) to Golang 1.8. For builds, the smaller `golang:1.8-alpine` image is now used instead of the standard one.