### PR TITLE
Some fixes to the gsctl release automation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ endif
 # binary to test with
 TESTBIN := build/bin/${BIN}-${GOOS}-${GOARCH}
 
-.PHONY: clean build test crosscompile assert-tagged-version
+.PHONY: clean build test crosscompile
 
 all: build
 
@@ -86,9 +86,8 @@ test:
 
 # Create binary files for releases
 bin-dist: crosscompile
-	rm -rf build
 
-	mkdir bin-dist
+	mkdir -p bin-dist
 
 	for OS in darwin-amd64 linux-amd64; do \
 		mkdir -p build/$(BIN)-$(VERSION)-$$OS; \
@@ -113,15 +112,9 @@ bin-dist: crosscompile
 		cd .. ; \
 	done
 
-assert-tagged-version:
-ifeq ($(shell cat VERSION|grep git),)
-	@echo "You are not on a tagged version."
-	@echo "Perform a 'git checkout <release-tag>' first."
-	@exit 1
-endif
 
 # This automates a release (except for a GitHub release)
-release: assert-tagged-version bin-dist
+release: bin-dist
 	# file uploads to S3
 	aws s3 cp bin-dist s3://downloads.giantswarm.io/gsctl/$(VERSION)/ --recursive --exclude="*" --include="*.tar.gz" --acl=public-read
 	aws s3 cp bin-dist s3://downloads.giantswarm.io/gsctl/$(VERSION)/ --recursive --exclude="*" --include="*.zip" --acl=public-read
@@ -131,15 +124,15 @@ release: assert-tagged-version bin-dist
 	./update-homebrew.sh
 
 	# Update version number occurrences in README.md
-	perl -pi -e "s:gsctl\/[0-9]+\.[0-9]+\.[0-9]+\/:gsctl\/${VERSION}\/:g" README.md
-	perl -pi -e "s:gsctl\-[0-9]+\.[0-9]+\.[0-9]+\-:gsctl\-${VERSION}\-:g" README.md
+	#perl -pi -e "s:gsctl\/[0-9]+\.[0-9]+\.[0-9]+\/:gsctl\/${VERSION}\/:g" README.md
+	#perl -pi -e "s:gsctl\-[0-9]+\.[0-9]+\.[0-9]+\-:gsctl\-${VERSION}\-:g" README.md
 
-	@echo ""
-	@echo "README.md has changed. Please commit and push this change using these commands:"
-	@echo ""
-	@echo "  git commit -m \"Updated version number in README.md to ${VERSION}\" README.md"
-	@echo "git push origin master"
-	@echo ""
+	#@echo ""
+	#@echo "README.md has changed. Please commit and push this change using these commands:"
+	#@echo ""
+	#@echo "  git commit -m \"Updated version number in README.md to ${VERSION}\" README.md"
+	#@echo "git push origin master"
+	#@echo ""
 
 # remove generated stuff
 clean:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,22 +5,44 @@
 - GNU Make
 - Docker environment
 - `builder` (see https://github.com/giantswarm/builder)
-- AWS CLI (`aws` command line utility)
+- AWS CLI (`aws` command line utility, see http://docs.aws.amazon.com/cli/latest/userguide/installing.html)
 - AWS S3 create/upload permissions for `downloads.giantswarm.io`
-- `git`
+- env variable `AWS_ACCESS_KEY_ID` set
+- env variable `AWS_SECRET_ACCESS_KEY` set
+- `git` command line utility
+- Push permissions for https://github.com/giantswarm/gsctl
 - Push permissions for https://github.com/giantswarm/homebrew-giantswarm
+- env variable `BUILDER_GITHUB_TOKEN` set to a valid Github token
 
 ## Instructions
+
+We first build a binary for the current platform and test it.
 
 ```nohighlight
 make
 make test
-
-builder release patch|minor|major
-
-git checkout <version-tag>
-
-make bin-dist
-make release
-
+make clean
 ```
+
+Now we create a release draft on Github using `builder`. This will add some broken binaries to that release. We take care of that later.
+
+```nohighlight
+builder release patch|minor|major
+```
+
+Now check out the release tag:
+
+```nohighlight
+make clean
+git checkout <version-tag>
+```
+
+Open the [release draft](https://github.com/giantswarm/gsctl/releases/) on Github. Edit the description to inform about what has changed since the last release. Save and publish the release.
+
+To also upload the binaries to AWS S3 and provide an update for homebrew users, execute this:
+
+```nohighlight
+make release
+```
+
+Finally, when everything went fine, do another `make clean`.

--- a/update-homebrew.sh
+++ b/update-homebrew.sh
@@ -32,7 +32,7 @@ EOF
 
 # commit and push formula to our Homebrew tap
 cd bin-dist
-git clone git@github.com:giantswarm/homebrew-giantswarm.git
+git clone https://github.com/giantswarm/homebrew-giantswarm.git
 mv ../gsctl.rb homebrew-giantswarm/Formula/
 cd homebrew-giantswarm
 git add Formula/gsctl.rb && git commit -m "Updated gsctl to ${VERSION}" && git push origin master


### PR DESCRIPTION
- `assert-tagged-version` just didn't work
- Removed some `rm -rf build` which deleted the stuff we wanted to
distribute
- Deactivated updating of the README, since we are in a detached branch
- Updated RELEASE.md documentation

[skip ci]