### PR TITLE
Adds support for english spelling of organisations

### DIFF
--- a/commands/list.go
+++ b/commands/list.go
@@ -29,6 +29,7 @@ var (
 	// ListOrgsCommand performs the "list organizations" function
 	ListOrgsCommand = &cobra.Command{
 		Use:     "organizations",
+		Aliases: []string{"organisations"},
 		Short:   "List organizations",
 		Long:    `Prints a list of the organizations you are a member of`,
 		PreRunE: checkListOrgs,

--- a/commands/list.go
+++ b/commands/list.go
@@ -29,7 +29,7 @@ var (
 	// ListOrgsCommand performs the "list organizations" function
 	ListOrgsCommand = &cobra.Command{
 		Use:     "organizations",
-		Aliases: []string{"organisations"},
+		Aliases: []string{"orgs", "organisations"},
 		Short:   "List organizations",
 		Long:    `Prints a list of the organizations you are a member of`,
 		PreRunE: checkListOrgs,


### PR DESCRIPTION
Having to type 'organizations' keeps tripping me up, and I really hate it.

This adds support for using a spelling I actually know

e.g:
```
09:47:16 ~/go/src/github.com/giantswarm/gsctl (english-please)
$ ./gsctl --api-endpoint=https://api-aws.giantswarm.io list organisations
ORGANIZATION
giantswarm
joseph
```

the usage is hidden, so I don't think we need to worry about people getting confused - american is still the standard:
```
09:47:55 ~/go/src/github.com/giantswarm/gsctl (english-please)
$ ./gsctl --api-endpoint=https://api-aws.giantswarm.io list --help
Prints a list of the things you have access to

Usage:
  gsctl list [command]

Available Commands:
  clusters      List clusters
  keypairs      List key-pairs for a cluster
  organizations List organizations

Global Flags:
      --api-endpoint string   The URL base path, to access the API (default "https://api.giantswarm.io")
      --auth-token string     Authorization token to use for one command execution
  -v, --verbose               Print more information

Use "gsctl list [command] --help" for more information about a command.
```