### PR TITLE
Ping refactoring, testing, sending user-agent header

### DIFF
--- a/commands/ping.go
+++ b/commands/ping.go
@@ -32,7 +32,7 @@ func init() {
 func runPingCommand(cmd *cobra.Command, args []string) {
 	duration, err := ping(cmdAPIEndpoint)
 	if err != nil {
-		fmt.Println(color.RedString("API connection is bad"))
+		fmt.Println(color.RedString("Could not reach API"))
 		fmt.Println(err)
 		os.Exit(1)
 	}

--- a/commands/ping.go
+++ b/commands/ping.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/gsctl/config"
 )
 
 var (
@@ -17,7 +19,7 @@ var (
 		Use:   "ping",
 		Short: "Check API connection",
 		Long:  `Tests the connection to the API`,
-		Run:   ping,
+		Run:   runPingCommand,
 	}
 )
 
@@ -25,33 +27,57 @@ func init() {
 	RootCommand.AddCommand(PingCommand)
 }
 
-// ping checks the API connections
-func ping(cmd *cobra.Command, args []string) {
-	u, err := url.Parse(cmdAPIEndpoint)
+// runPingCommand executes the ping() function
+// and prints output in a user-friendly way
+func runPingCommand(cmd *cobra.Command, args []string) {
+	duration, err := ping(cmdAPIEndpoint)
 	if err != nil {
-		fmt.Println(err.Error())
+		fmt.Println(color.RedString("API connection is bad"))
+		fmt.Println(err)
 		os.Exit(1)
+	}
+	fmt.Println(color.GreenString("API connection is fine"))
+	fmt.Printf("Ping took %v\n", duration)
+}
+
+// ping checks the API connection and returns
+// duration (in case of success) and error (in case of failure)
+func ping(endpointURL string) (time.Duration, error) {
+	var duration time.Duration
+
+	// create URI
+	u, err := url.Parse(endpointURL)
+	if err != nil {
+		return duration, err
 	}
 	u, err = u.Parse("/v1/ping")
 	if err != nil {
-		fmt.Println(err.Error())
-		os.Exit(1)
+		return duration, err
+	}
+
+	// create client and request
+	request, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return duration, err
+	}
+	request.Header.Set("User-Agent", config.UserAgent())
+
+	// create client
+	pingClient := &http.Client{
+		Timeout: 5 * time.Second,
 	}
 
 	start := time.Now()
-	resp, err := http.Get(u.String())
+	resp, err := pingClient.Do(request)
 	if err != nil {
-		fmt.Println(color.RedString("API cannot be reached"))
-		fmt.Println(err.Error())
-		os.Exit(1)
+		return duration, err
 	}
 	defer resp.Body.Close()
-	elapsed := time.Since(start)
-	if resp.StatusCode == 200 {
-		fmt.Println(color.GreenString("API connection is fine"))
-		fmt.Printf("Ping took %v\n", elapsed)
-	} else {
-		fmt.Println(color.RedString("API returned unexpected response status %v", resp.StatusCode))
-		os.Exit(2)
+
+	duration = time.Since(start)
+	if resp.StatusCode != http.StatusOK {
+		return duration, fmt.Errorf("bad status code %d", resp.StatusCode)
 	}
+
+	return duration, nil
 }

--- a/commands/ping_test.go
+++ b/commands/ping_test.go
@@ -38,8 +38,7 @@ func Test_Ping_InternalServerError(t *testing.T) {
 
 func Test_Ping_NonexistingEndpoint(t *testing.T) {
 	_, err := ping("http://not.existing")
-	expectedErrorString := "Get http://not.existing/v1/ping: dial tcp: lookup not.existing: no such host"
-	if err.Error() != expectedErrorString {
-		t.Errorf("Expected error '%s', got '%s'", expectedErrorString, err.Error())
+	if err == nil {
+		t.Error("Expected 'no such host' error, got nil")
 	}
 }

--- a/commands/ping_test.go
+++ b/commands/ping_test.go
@@ -1,0 +1,45 @@
+package commands
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func Test_Ping(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`OK`))
+	}))
+	defer mockServer.Close()
+
+	duration, err := ping(mockServer.URL)
+	if err != nil {
+		t.Error("Unexpected error:", err)
+	}
+	if duration == 0 {
+		t.Error("Expected duration > 0, was 0")
+	}
+}
+
+func Test_Ping_InternalServerError(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer mockServer.Close()
+
+	_, err := ping(mockServer.URL)
+	if err == nil {
+		t.Error("Expected error, got nil")
+	}
+}
+
+func Test_Ping_NonexistingEndpoint(t *testing.T) {
+	_, err := ping("http://not.existing")
+	expectedErrorString := "Get http://not.existing/v1/ping: dial tcp: lookup not.existing: no such host"
+	if err.Error() != expectedErrorString {
+		t.Errorf("Expected error '%s', got '%s'", expectedErrorString, err.Error())
+	}
+}


### PR DESCRIPTION
This PR

- ensures that ping requests send the user-agent header
- makes the ping function better testable by separating logic from output handling
- adds a unit test