### PR TITLE
gsctl: Ensure that certificate paths get updated with config dir migration

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -289,14 +289,15 @@ func migrateConfigDir() error {
 	// adapt certificate paths in kubeconfig
 	if len(KubeConfigPaths) > 0 {
 		// we only adapt the first file found (on purpose)
-		if stat, err := os.Stat(KubeConfigPaths[0]); err == nil {
-			oldConfig, configErr := ioutil.ReadFile(KubeConfigPaths[0])
+		theKubeConfigPath := KubeConfigPaths[0]
+		if stat, err := os.Stat(theKubeConfigPath); err == nil {
+			oldConfig, configErr := ioutil.ReadFile(theKubeConfigPath)
 			if configErr != nil {
 				return configErr
 			}
 			newConfig := strings.Replace(string(oldConfig), LegacyConfigDirPath, DefaultConfigDirPath, -1)
 			// write back
-			writeErr := ioutil.WriteFile(KubeConfigPaths[0], []byte(newConfig), stat.Mode())
+			writeErr := ioutil.WriteFile(theKubeConfigPath, []byte(newConfig), stat.Mode())
 			if writeErr != nil {
 				return fmt.Errorf("Could not overwrite kubectl config file. %s", writeErr.Error())
 			}

--- a/config/config.go
+++ b/config/config.go
@@ -299,7 +299,7 @@ func migrateConfigDir() error {
 			// write back
 			writeErr := ioutil.WriteFile(theKubeConfigPath, []byte(newConfig), stat.Mode())
 			if writeErr != nil {
-				return fmt.Errorf("Could not overwrite kubectl config file. %s", writeErr.Error())
+				return errors.New("could not overwrite kubectl config file")
 			}
 		}
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -81,6 +81,9 @@ func Test_Initialize_NonEmpty(t *testing.T) {
 	}
 }
 
+// Test_Kubeconfig_Env_Nonexisting tests what happens
+// when the KUBECONFIG env variable points to the
+// same dir as we use for config, and it's empty
 func Test_Kubeconfig_Env_Nonexisting(t *testing.T) {
 	defer viper.Reset()
 	dir := tempDir()
@@ -90,6 +93,72 @@ func Test_Kubeconfig_Env_Nonexisting(t *testing.T) {
 	if err != nil {
 		t.Error("Error in Initialize:", err)
 	}
+}
+
+// Test_Config_Migration tests the config dir migration from the old
+// to the new default location, including updating certificate paths
+// in the kubectl config file.
+func Test_Config_Migration(t *testing.T) {
+	defer viper.Reset()
+
+	// override standard paths for testing
+	dir := tempDir()
+	HomeDirPath = dir
+	DefaultConfigDirPath = path.Join(HomeDirPath, ".config", ProgramName)
+	LegacyConfigDirPath = path.Join(HomeDirPath, "."+ProgramName)
+
+	// create fake certs file
+	certsPath := path.Join(HomeDirPath, "."+ProgramName, "certs")
+	err := os.MkdirAll(certsPath, 0700)
+	if err != nil {
+		t.Error(err)
+	}
+	certFile, _ := os.Create(path.Join(certsPath, "test-ca.crt"))
+	certFile.Close()
+	certFile, _ = os.Create(path.Join(certsPath, "test-12345-client.crt"))
+	certFile.Close()
+	certFile, _ = os.Create(path.Join(certsPath, "test-12345-client.key"))
+	certFile.Close()
+
+	// add a test kubectl config file
+	kubeconfigpath := path.Join(dir, "tempkubeconfig")
+	KubeConfigPaths = []string{kubeconfigpath}
+	kubeConfig := []byte(`apiVersion: v1
+kind: Config
+preferences: {}
+current-context: g8s-system
+clusters:
+- cluster:
+    certificate-authority: ` + LegacyConfigDirPath + `/certs/test-ca.crt
+    server: https://api.n41en.g8s.fra-1.giantswarm.io
+  name: giantswarm-test
+users:
+- name: testuser
+  user:
+    client-certificate: ` + LegacyConfigDirPath + `/certs/test-12345-client.crt
+    client-key: ` + LegacyConfigDirPath + `/certs/test-12345-client.key
+contexts:
+- context:
+    cluster: giantswarm-test
+    user: testuser
+  name: giantswarm-test
+`)
+	fileErr := ioutil.WriteFile(kubeconfigpath, kubeConfig, 0700)
+	if fileErr != nil {
+		t.Error(fileErr)
+	}
+
+	t.Log("DefaultConfigDirPath:", DefaultConfigDirPath)
+	t.Log("LegacyConfigDirPath:", LegacyConfigDirPath)
+
+	migrateConfigDir()
+
+	// spit out config
+	newConf, confReadErr := ioutil.ReadFile(kubeconfigpath)
+	if confReadErr != nil {
+		t.Error(confReadErr)
+	}
+	t.Log(string(newConf))
 }
 
 func Test_UserAgent(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/giantswarm/gsctl/issues/59

In #55 a migration of the configuration directory has been introduced. Unfortunately I forgot to take care of a user's kubectl config file.

This PR here makes the migration also maintain the paths. It does it simply by replacing occurrences of the old path with the new path in the config, not trying to be any more clever than that.