### PR TITLE
gsctl: Don't overwrite the user's kubectl config when running tests

### DIFF
--- a/commands/create_kubeconfig_test.go
+++ b/commands/create_kubeconfig_test.go
@@ -78,4 +78,26 @@ func Test_CreateKubeconfig(t *testing.T) {
 	cmdClusterID = "test-cluster-id"
 	checkCreateKubeconfig(CreateKeypairCommand, []string{})
 	createKubeconfig(CreateKeypairCommand, []string{})
+
+	// check kubeconfig content
+	content, err := ioutil.ReadFile(kubeConfigPath)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// for reference in case of error
+	t.Log(string(content))
+
+	if !strings.Contains(string(content), "current-context: giantswarm-"+cmdClusterID) {
+		t.Error("Kubeconfig doesn't contain the expected current-context value")
+	}
+	if !strings.Contains(string(content), "client-certificate: "+configDir) {
+		t.Error("Kubeconfig doesn't contain the expected client-certificate value")
+	}
+	if !strings.Contains(string(content), "client-key: "+configDir) {
+		t.Error("Kubeconfig doesn't contain the expected client-key value")
+	}
+	if !strings.Contains(string(content), "certificate-authority: "+configDir) {
+		t.Error("Kubeconfig doesn't contain the expected certificate-authority value")
+	}
 }

--- a/commands/create_kubeconfig_test.go
+++ b/commands/create_kubeconfig_test.go
@@ -29,8 +29,8 @@ func tempKubeconfig() (string, error) {
 	config.LegacyConfigDirPath = path.Join(config.HomeDirPath, "."+config.ProgramName)
 
 	// add a test kubectl config file
-	kubeconfigpath := path.Join(dir, "tempkubeconfig")
-	config.KubeConfigPaths = []string{kubeconfigpath}
+	kubeConfigPath := path.Join(dir, "tempkubeconfig")
+	config.KubeConfigPaths = []string{kubeConfigPath}
 	kubeConfig := []byte(`apiVersion: v1
 kind: Config
 preferences: {}
@@ -39,12 +39,12 @@ clusters:
 users:
 contexts:
 `)
-	fileErr := ioutil.WriteFile(kubeconfigpath, kubeConfig, 0700)
+	fileErr := ioutil.WriteFile(kubeConfigPath, kubeConfig, 0700)
 	if fileErr != nil {
 		return "", fileErr
 	}
 
-	return kubeconfigpath, nil
+	return kubeConfigPath, nil
 }
 
 func Test_CreateKubeconfig(t *testing.T) {


### PR DESCRIPTION
Solves https://github.com/giantswarm/gsctl/issues/56

This PR ensures that a temporary kubectl config file is used for test purposes.

Additionally, the output written to the kubectl config file is now verified.