### PR TITLE
On keypair creation, print resulting TTL instead of requested TTL

### DIFF
--- a/commands/create_keypair.go
+++ b/commands/create_keypair.go
@@ -78,7 +78,7 @@ func addKeypair(cmd *cobra.Command, args []string) {
 
 	if apiResponse.StatusCode == 200 {
 		cleanID := util.CleanKeypairID(keypairResponse.Id)
-		msg := fmt.Sprintf("New key-pair created with ID %s", cleanID)
+		msg := fmt.Sprintf("New key-pair created with ID %s and expiry of %v hours", cleanID, keypairResponse.TtlHours)
 		fmt.Println(color.GreenString(msg))
 
 		// store credentials to file

--- a/commands/create_kubeconfig.go
+++ b/commands/create_kubeconfig.go
@@ -113,7 +113,7 @@ func createKubeconfig(cmd *cobra.Command, args []string) {
 	if apiResponse.StatusCode == 200 || apiResponse.StatusCode == 201 {
 		msg := fmt.Sprintf("New key-pair created with ID %s and expiry of %v hours",
 			util.Truncate(util.CleanKeypairID(keypairResponse.Id), 10),
-			ttlHours)
+			keypairResponse.TtlHours)
 		fmt.Println(msg)
 
 		// store credentials to file


### PR DESCRIPTION
Tiny change that lets us see the keypair TTL as received from the backend, as opposed to printing the requested TTL.