### PR TITLE
Unified naming for "key pair"

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ More in the [docs](https://docs.giantswarm.io/reference/gsctl/create-cluster/)
 
 ```nohighlight
 $ gsctl create kubeconfig -c h8d0j
-Creating new key-pair…
-New key-pair created with ID 153a93201… and expiry of 720 hours
+Creating new key pair…
+New key pair created with ID 153a93201… and expiry of 720 hours
 Certificate and key files written to:
 /Users/demo/.config/gsctl/certs/h8d0j-ca.crt
 /Users/demo/.config/gsctl/certs/h8d0j-153a932010-client.crt
 /Users/demo/.config/gsctl/certs/h8d0j-153a932010-client.key
-Switched to kubectl context 'acme-xl8t1'
+Switched to kubectl context 'giantswarm-xl8t1'
 
 kubectl is set up. Check it using this command:
 
@@ -56,7 +56,7 @@ kubectl is set up. Check it using this command:
 
 Whenever you want to switch to using this context:
 
-    kubectl config use-context acme-xl8t1
+    kubectl config use-context giantswarm-xl8t1
 ```
 
 ## Install

--- a/commands/create.go
+++ b/commands/create.go
@@ -6,8 +6,8 @@ var (
 	// CreateCommand is the command to create things
 	CreateCommand = &cobra.Command{
 		Use:   "create",
-		Short: "Create clusters, key-pairs, ...",
-		Long:  `Lets you create things like clusters, key-pairs or kubectl configuration files`,
+		Short: "Create clusters, key pairs, ...",
+		Long:  `Lets you create things like clusters, key pairs or kubectl configuration files`,
 	}
 )
 

--- a/commands/create_cluster.go
+++ b/commands/create_cluster.go
@@ -262,7 +262,7 @@ func executionOutput(cmd *cobra.Command, args []string) {
 	} else {
 		fmt.Println(color.GreenString("New cluster with ID '%s' for organization '%s' is launching.", result.id, result.definition.Owner))
 	}
-	fmt.Println("Add key-pair and settings to kubectl using")
+	fmt.Println("Add key pair and settings to kubectl using")
 	fmt.Println("")
 	fmt.Printf("    %s\n\n", color.YellowString(fmt.Sprintf("gsctl create kubeconfig --cluster=%s", result.id)))
 }

--- a/commands/create_keypair.go
+++ b/commands/create_keypair.go
@@ -17,8 +17,8 @@ var (
 	// CreateKeypairCommand performs the "create keypair" function
 	CreateKeypairCommand = &cobra.Command{
 		Use:     "keypair",
-		Short:   "Create key-pair",
-		Long:    `Creates a new key-pair for a cluster`,
+		Short:   "Create key pair",
+		Long:    `Creates a new key pair for a cluster`,
 		PreRunE: checkAddKeypair,
 		Run:     addKeypair,
 	}
@@ -29,9 +29,9 @@ const (
 )
 
 func init() {
-	CreateKeypairCommand.Flags().StringVarP(&cmdClusterID, "cluster", "c", "", "ID of the cluster to create a key-pair for")
-	CreateKeypairCommand.Flags().StringVarP(&cmdDescription, "description", "d", "", "Description for the key-pair")
-	CreateKeypairCommand.Flags().IntVarP(&cmdTTLDays, "ttl", "", 30, "Duration until expiry of the created key-pair in days")
+	CreateKeypairCommand.Flags().StringVarP(&cmdClusterID, "cluster", "c", "", "ID of the cluster to create a key pair for")
+	CreateKeypairCommand.Flags().StringVarP(&cmdDescription, "description", "d", "", "Description for the key pair")
+	CreateKeypairCommand.Flags().IntVarP(&cmdTTLDays, "ttl", "", 30, "Duration until expiry of the created key pair in days")
 
 	CreateCommand.AddCommand(CreateKeypairCommand)
 }
@@ -78,7 +78,7 @@ func addKeypair(cmd *cobra.Command, args []string) {
 
 	if apiResponse.StatusCode == 200 {
 		cleanID := util.CleanKeypairID(keypairResponse.Id)
-		msg := fmt.Sprintf("New key-pair created with ID %s and expiry of %v hours", cleanID, keypairResponse.TtlHours)
+		msg := fmt.Sprintf("New key pair created with ID %s and expiry of %v hours", cleanID, keypairResponse.TtlHours)
 		fmt.Println(color.GreenString(msg))
 
 		// store credentials to file

--- a/commands/create_kubeconfig.go
+++ b/commands/create_kubeconfig.go
@@ -32,8 +32,8 @@ const (
 
 func init() {
 	CreateKubeconfigCommand.Flags().StringVarP(&cmdClusterID, "cluster", "c", "", "ID of the cluster")
-	CreateKubeconfigCommand.Flags().StringVarP(&cmdDescription, "description", "d", "", "Description for the key-pair")
-	CreateKubeconfigCommand.Flags().IntVarP(&cmdTTLDays, "ttl", "", 30, "Duration until expiry of the created key-pair in days")
+	CreateKubeconfigCommand.Flags().StringVarP(&cmdDescription, "description", "d", "", "Description for the key pair")
+	CreateKubeconfigCommand.Flags().IntVarP(&cmdTTLDays, "ttl", "", 30, "Duration until expiry of the created key pair in days")
 
 	CreateCommand.AddCommand(CreateKubeconfigCommand)
 }
@@ -97,7 +97,7 @@ func createKubeconfig(cmd *cobra.Command, args []string) {
 
 	addKeyPairBody := gsclientgen.V4AddKeyPairBody{Description: cmdDescription, TtlHours: ttlHours}
 
-	fmt.Println("Creating new key-pair…")
+	fmt.Println("Creating new key pair…")
 
 	clientConfig.Timeout = 60 * time.Second
 	apiClient = client.NewClient(clientConfig)
@@ -111,7 +111,7 @@ func createKubeconfig(cmd *cobra.Command, args []string) {
 	}
 
 	if apiResponse.StatusCode == 200 || apiResponse.StatusCode == 201 {
-		msg := fmt.Sprintf("New key-pair created with ID %s and expiry of %v hours",
+		msg := fmt.Sprintf("New key pair created with ID %s and expiry of %v hours",
 			util.Truncate(util.CleanKeypairID(keypairResponse.Id), 10),
 			keypairResponse.TtlHours)
 		fmt.Println(msg)

--- a/commands/list.go
+++ b/commands/list.go
@@ -6,7 +6,7 @@ var (
 	// ListCommand is the command to list things
 	ListCommand = &cobra.Command{
 		Use:   "list",
-		Short: "List things, like organizations, clusters, key-pairs",
+		Short: "List things, like organizations, clusters, key pairs",
 		Long:  `Prints a list of the things you have access to`,
 	}
 )

--- a/commands/list_keypairs.go
+++ b/commands/list_keypairs.go
@@ -24,15 +24,15 @@ var (
 	// ListKeypairsCommand performs the "list keypairs" function
 	ListKeypairsCommand = &cobra.Command{
 		Use:     "keypairs",
-		Short:   "List key-pairs for a cluster",
-		Long:    `Prints a list of key-pairs for a cluster`,
+		Short:   "List key pairs for a cluster",
+		Long:    `Prints a list of key pairs for a cluster`,
 		PreRunE: checkListKeypairs,
 		Run:     listKeypairs,
 	}
 )
 
 func init() {
-	ListKeypairsCommand.Flags().StringVarP(&cmdClusterID, "cluster", "c", "", "ID of the cluster to list key-pairs for")
+	ListKeypairsCommand.Flags().StringVarP(&cmdClusterID, "cluster", "c", "", "ID of the cluster to list key pairs for")
 	ListCommand.AddCommand(ListKeypairsCommand)
 }
 

--- a/commands/list_keypairs_test.go
+++ b/commands/list_keypairs_test.go
@@ -47,7 +47,7 @@ func Test_CheckListKeypairs_NotLoggedInNoCluster(t *testing.T) {
 }
 
 func Test_ListKeyPairs(t *testing.T) {
-	// mock service returning key-pairs
+	// mock service returning key pairs
 	keyPairsMockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)

--- a/commands/list_organizations_test.go
+++ b/commands/list_organizations_test.go
@@ -29,7 +29,7 @@ func Test_ListOrganizations(t *testing.T) {
 }
 
 func Test_ListOrganizationsEmpty(t *testing.T) {
-	// mock service returning key-pairs
+	// mock service returning key pairs
 	orgsMockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
We used "key-pair" in many places in gsctl, while we use "key pair" in docs and happa. Towards a unified naming!