### PR TITLE
Adding API endpoint output to "gsctl info"

### DIFF
--- a/commands/info.go
+++ b/commands/info.go
@@ -21,6 +21,34 @@ var (
 	}
 )
 
+// infoArguments represents the arguments we can make use of in this command
+type infoArguments struct {
+	token       string
+	verbose     bool
+	apiEndpoint string
+}
+
+// defaultInfoArguments returns an infoArguments object populated by the user's
+// command line arguments
+func defaultInfoArguments() infoArguments {
+	return infoArguments{
+		token:       cmdToken,
+		verbose:     cmdVerbose,
+		apiEndpoint: cmdAPIEndpoint,
+	}
+}
+
+// infoResult is the struct used to return all the info we might want to print
+type infoResult struct {
+	apiEndpoint     string
+	email           string
+	token           string
+	version         string
+	buildDate       string
+	configFilePath  string
+	kubeConfigPaths []string
+}
+
 func init() {
 	RootCommand.AddCommand(InfoCommand)
 }
@@ -28,40 +56,66 @@ func init() {
 // printInfo prints some information on the current user and configuration
 func printInfo(cmd *cobra.Command, args []string) {
 
+	infoArgs := defaultInfoArguments()
+	result := info(infoArgs)
+
 	output := []string{}
 
-	if config.Config.Email == "" {
+	output = append(output, color.YellowString("API endpoint:")+"|"+color.CyanString(result.apiEndpoint))
+
+	if result.email == "" {
 		output = append(output, color.YellowString("Email:")+"|"+"n/a")
 	} else {
 		output = append(output, color.YellowString("Email:")+"|"+color.CyanString(config.Config.Email))
 	}
 
-	if cmdVerbose {
-		if cmdToken != "" {
-			output = append(output, color.YellowString("Auth token:")+"|"+color.CyanString(cmdToken))
-		} else if config.Config.Token != "" {
-			output = append(output, color.YellowString("Auth token:")+"|"+color.CyanString(config.Config.Token))
+	if infoArgs.verbose {
+		if result.token != "" {
+			output = append(output, color.YellowString("Auth token:")+"|"+color.CyanString(result.token))
 		} else {
 			output = append(output, color.YellowString("Auth token:")+"|n/a")
 		}
 	}
 
-	output = append(output, color.YellowString("%s version:", config.ProgramName)+"|"+color.CyanString(config.Version))
-	output = append(output, color.YellowString("%s build:", config.ProgramName)+"|"+color.CyanString(config.BuildDate))
-
-	output = append(output, color.YellowString("Config path:")+"|"+color.CyanString(config.ConfigFilePath))
+	output = append(output, color.YellowString("%s version:", config.ProgramName)+"|"+color.CyanString(result.version))
+	output = append(output, color.YellowString("%s build:", config.ProgramName)+"|"+color.CyanString(result.buildDate))
+	output = append(output, color.YellowString("Config path:")+"|"+color.CyanString(result.configFilePath))
 
 	// kubectl configuration paths
-	if len(config.KubeConfigPaths) == 0 {
-		output = append(output, color.YellowString("kubectl config path:")+"|n/a")
-	} else {
-		paths := []string{}
-		for _, myPath := range config.KubeConfigPaths {
-			paths = append(paths, color.CyanString(myPath))
-		}
-		output = append(output, color.YellowString("kubectl config path:")+"|"+strings.Join(paths, ", "))
-	}
+	output = append(output, color.YellowString("kubectl config path:")+"|"+color.CyanString(strings.Join(result.kubeConfigPaths, ", ")))
 
 	fmt.Println(columnize.SimpleFormat(output))
+}
 
+// info gets all the information we'd like to show with the "info" command
+// and returns it as a struct
+func info(args infoArguments) infoResult {
+	result := infoResult{}
+
+	result.apiEndpoint = config.DefaultAPIEndpoint
+	if args.apiEndpoint != "" {
+		result.apiEndpoint = args.apiEndpoint
+	}
+
+	result.email = config.Config.Email
+
+	if args.token != "" {
+		result.token = args.token
+	} else if config.Config.Token != "" {
+		result.token = config.Config.Token
+	}
+
+	result.version = config.Version
+	result.buildDate = config.BuildDate
+
+	result.configFilePath = config.ConfigFilePath
+
+	// kubectl configuration paths
+	if len(config.KubeConfigPaths) > 0 {
+		for _, myPath := range config.KubeConfigPaths {
+			result.kubeConfigPaths = append(result.kubeConfigPaths, myPath)
+		}
+	}
+
+	return result
 }

--- a/commands/info_test.go
+++ b/commands/info_test.go
@@ -1,12 +1,24 @@
 package commands
 
-import "testing"
+import (
+	"io/ioutil"
+	"testing"
 
-func Test_Info(t *testing.T) {
+	"github.com/giantswarm/gsctl/config"
+)
+
+func Test_PrintInfo(t *testing.T) {
 	printInfo(InfoCommand, []string{})
 }
 
-func Test_Info_Verbose(t *testing.T) {
+func Test_PrintInfoVerbose(t *testing.T) {
 	cmdVerbose = true
+	printInfo(InfoCommand, []string{})
+}
+
+func Test_PrintInfoWithTempDirAndToken(t *testing.T) {
+	dir, _ := ioutil.TempDir("", config.ProgramName)
+	cmdConfigDirPath = dir
+	cmdToken = "fake token"
 	printInfo(InfoCommand, []string{})
 }

--- a/commands/info_test.go
+++ b/commands/info_test.go
@@ -32,8 +32,8 @@ func Test_InfoWithTempDirAndToken(t *testing.T) {
 	// Normally cobra does this for us, but here we don't use cobra.
 	config.Initialize(dir)
 
-	cmdToken = "fake token"
 	args := defaultInfoArguments()
+	args.token = "fake token"
 
 	infoResult := info(args)
 
@@ -41,7 +41,7 @@ func Test_InfoWithTempDirAndToken(t *testing.T) {
 		t.Errorf("Config file path not as expected: Got %s, expected %s",
 			infoResult.configFilePath, dir)
 	}
-	if infoResult.token != cmdToken {
+	if infoResult.token != args.token {
 		t.Errorf("Expected token '%s', got '%s'", cmdToken, infoResult.token)
 	}
 	if infoResult.email != "" {

--- a/commands/info_test.go
+++ b/commands/info_test.go
@@ -2,23 +2,49 @@ package commands
 
 import (
 	"io/ioutil"
+	"os"
+	"strings"
 	"testing"
+
+	"github.com/spf13/viper"
 
 	"github.com/giantswarm/gsctl/config"
 )
 
 func Test_PrintInfo(t *testing.T) {
+	defer viper.Reset()
 	printInfo(InfoCommand, []string{})
 }
 
 func Test_PrintInfoVerbose(t *testing.T) {
+	defer viper.Reset()
 	cmdVerbose = true
 	printInfo(InfoCommand, []string{})
 }
 
-func Test_PrintInfoWithTempDirAndToken(t *testing.T) {
+// Test_InfoWithTempDirAndToken tests the info() function with a custom
+// configuration path and an auth-token
+func Test_InfoWithTempDirAndToken(t *testing.T) {
+	defer viper.Reset()
 	dir, _ := ioutil.TempDir("", config.ProgramName)
-	cmdConfigDirPath = dir
+	defer os.RemoveAll(dir)
+
+	// Normally cobra does this for us, but here we don't use cobra.
+	config.Initialize(dir)
+
 	cmdToken = "fake token"
-	printInfo(InfoCommand, []string{})
+	args := defaultInfoArguments()
+
+	infoResult := info(args)
+
+	if !strings.Contains(infoResult.configFilePath, dir) {
+		t.Errorf("Config file path not as expected: Got %s, expected %s",
+			infoResult.configFilePath, dir)
+	}
+	if infoResult.token != cmdToken {
+		t.Errorf("Expected token '%s', got '%s'", cmdToken, infoResult.token)
+	}
+	if infoResult.email != "" {
+		t.Error("Expected empty email, got ", infoResult.email)
+	}
 }


### PR DESCRIPTION
See #79 

Also refactored functions to separate info acquisition from info printing. That should help keep the code more readable and testable in the longer run.