### PR TITLE
Login switch account

### DIFF
--- a/commands/login.go
+++ b/commands/login.go
@@ -18,96 +18,219 @@ import (
 )
 
 const (
-	loginActivityName string = "login"
+	loginActivityName = "login"
+
+	// errors
+	errTokenArgumentNotApplicable = "token argument cannot be used here"
+	errNoEmailArgumentGiven       = "no email argument given"
+	errInvalidCredentials         = "invalid credentials submitted"
+	errEmptyPassword              = "password must not be empty"
 )
 
 var (
-	// password given via command line flag
-	password string
+	// cmdPassword is the password given via command line flag
+	cmdPassword string
+
+	// email address passed as a positional argument
+	cmdEmail string
 
 	// LoginCommand is the "login" CLI command
 	LoginCommand = &cobra.Command{
-		Use:     "login <email>",
-		Short:   "Sign in as a user",
-		Long:    `Sign in with email address and password. Password has to be entered interactively or given as -p flag.`,
-		PreRunE: checkLogin,
-		Run:     login,
+		Use:    "login <email>",
+		Short:  "Sign in as a user",
+		Long:   `Sign in with email address and password. Password has to be entered interactively or given as -p flag.`,
+		PreRun: loginValidationOutput,
+		Run:    loginOutput,
 	}
 )
 
+type loginResult struct {
+	// apiEndpoint is the API endpoint the user has been logged in to
+	apiEndpoint string
+	// loggedOutBefore is true if the user has been logged out from a previous session
+	loggedOutBefore bool
+	// email is the email address we are signed in with
+	email string
+	// token is the new session token received
+	token string
+}
+
+type loginArguments struct {
+	apiEndpoint string
+	email       string
+	password    string
+	verbose     bool
+}
+
+func defaultLoginArguments() loginArguments {
+	return loginArguments{
+		apiEndpoint: cmdAPIEndpoint,
+		email:       cmdEmail,
+		password:    cmdPassword,
+		verbose:     cmdVerbose,
+	}
+}
+
 func init() {
-	LoginCommand.Flags().StringVarP(&password, "password", "p", "", "Password. If not given, will be prompted interactively.")
+	LoginCommand.Flags().StringVarP(&cmdPassword, "password", "p", "", "Password. If not given, will be prompted interactively.")
 	RootCommand.AddCommand(LoginCommand)
 }
 
-// checks if all arguments for the login command are given
-func checkLogin(cmd *cobra.Command, args []string) error {
-	if len(args) < 1 {
-		return errors.New(color.RedString("The email argument is required"))
+// loginValidationOutput runs our pre-checks.
+// If an error occurred, it prints the error info and exits with non-zero code.
+func loginValidationOutput(cmd *cobra.Command, positionalArgs []string) {
+	err := loginValidation(positionalArgs)
+
+	if err != nil {
+		var headline = ""
+		var subtext = ""
+		switch err.Error() {
+		case "":
+			return
+		case errNoEmailArgumentGiven:
+			headline = "The email argument is required."
+			subtext = "Please execute the command as 'gsctl login <email>'. See 'gsctl login --help' for details."
+		case errTokenArgumentNotApplicable:
+			headline = "The '--auth-token' flag cannot be used with the 'gsctl login' command."
+		case errEmptyPassword:
+			headline = "The password cannot be empty."
+			subtext = "Please call the command again and enter a non-empty password. See 'gsctl login --help' for details."
+		default:
+			headline = err.Error()
+		}
+
+		fmt.Println(color.RedString(headline))
+		if subtext != "" {
+			fmt.Println(subtext)
+		}
+		os.Exit(1)
+	}
+}
+
+// loginValidation does the pre-checks and returns an error in case something's wrong.
+func loginValidation(positionalArgs []string) error {
+	if len(positionalArgs) >= 1 {
+		// set cmdEmail for later use, as cobra doesn't do that for us
+		cmdEmail = positionalArgs[0]
+	} else {
+		return errors.New(errNoEmailArgumentGiven)
 	}
 
-	// using auth token flag?
+	// using auth token flag? The 'login' command is the only exception
+	// where we can't accept this argument.
 	if cmdToken != "" {
-		return errors.New(color.RedString("The 'login' command cannot be used with the '--auth-token' flag"))
+		return errors.New(errTokenArgumentNotApplicable)
 	}
 
-	// already logged in?
-	if config.Config.Token != "" {
-		return errors.New(color.RedString("You are already logged in"))
+	// interactive password prompt
+	if cmdPassword == "" {
+		fmt.Printf("Password for %s: ", cmdEmail)
+		password, err := gopass.GetPasswd()
+		if err != nil {
+			return err
+		}
+		if string(password) == "" {
+			return errors.New(errEmptyPassword)
+		}
+		cmdPassword = string(password)
 	}
 
 	return nil
 }
 
-// login creates a new session token
-func login(cmd *cobra.Command, args []string) {
-	var email = args[0]
+// loginOutput executes the login logic and
+// prints output and sets the exit code.
+func loginOutput(cmd *cobra.Command, args []string) {
+	loginArgs := defaultLoginArguments()
 
-	// interactive password prompt
-	if password == "" {
-		fmt.Printf("Password: ")
-		pass, err := gopass.GetPasswd()
-		if err != nil {
-			fmt.Println(color.RedString("Error: %s", err))
-			os.Exit(1)
+	result, err := login(loginArgs)
+	if err != nil {
+		var headline = ""
+		var subtext = ""
+		switch err.Error() {
+		case "":
+			return
+		case errEmptyPassword:
+			headline = "Empty password submitted"
+			subtext = "The API server complains about the password provided."
+			subtext += " Please make sure to provide a string with more than white space characters."
+		case errInvalidCredentials:
+			headline = "Bad password or email address."
+			subtext = fmt.Sprintf("Could not log you in to %s.", color.CyanString(loginArgs.apiEndpoint))
+			subtext += " The email or the password provided (or both) was incorrect."
+		default:
+			headline = err.Error()
 		}
-		password = string(pass)
+
+		fmt.Println(color.RedString(headline))
+		if subtext != "" {
+			fmt.Println(subtext)
+		}
+		os.Exit(1)
 	}
 
-	encodedPassword := base64.StdEncoding.EncodeToString([]byte(password))
+	if result.loggedOutBefore && loginArgs.verbose {
+		fmt.Println("You have been logged out from your previous session.")
+	}
+
+	fmt.Println(color.GreenString("You are logged in as %s at %s.",
+		result.email, result.apiEndpoint))
+}
+
+// login executes the authentication logic.
+// If the user was logged in before, a logout is performed first.
+func login(args loginArguments) (loginResult, error) {
+	result := loginResult{
+		apiEndpoint:     args.apiEndpoint,
+		email:           args.email,
+		loggedOutBefore: false,
+	}
+
+	encodedPassword := base64.StdEncoding.EncodeToString([]byte(args.password))
+
+	// log out if logged in
+	if config.Config.Token != "" {
+		result.loggedOutBefore = true
+		// we deliberately ignore the logout result here
+		logout(logoutArguments{
+			apiEndpoint: args.apiEndpoint,
+			token:       config.Config.Token,
+		})
+	}
 
 	clientConfig := client.Configuration{
-		Endpoint:  cmdAPIEndpoint,
+		Endpoint:  args.apiEndpoint,
 		Timeout:   10 * time.Second,
 		UserAgent: config.UserAgent(),
 	}
 	apiClient := client.NewClient(clientConfig)
 
 	requestBody := gsclientgen.LoginBodyModel{Password: string(encodedPassword)}
-	loginResponse, apiResponse, err := apiClient.UserLogin(email, requestBody, requestIDHeader, loginActivityName, cmdLine)
+	loginResponse, _, err := apiClient.UserLogin(args.email, requestBody, requestIDHeader, loginActivityName, cmdLine)
 	if err != nil {
-		fmt.Println(color.RedString("Error: %s", err))
-		dumpAPIResponse(*apiResponse)
-		os.Exit(1)
-	}
-	if loginResponse.StatusCode == apischema.STATUS_CODE_DATA {
-		// successful login
-		fmt.Println(color.GreenString("Successfully logged in"))
-		config.Config.Token = loginResponse.Data.Id
-		config.Config.Email = email
-	} else if loginResponse.StatusCode == apischema.STATUS_CODE_RESOURCE_INVALID_CREDENTIALS {
-		// bad credentials
-		fmt.Println(color.RedString("Incorrect password submitted. Please try again."))
-		os.Exit(1)
-	} else if loginResponse.StatusCode == apischema.STATUS_CODE_WRONG_INPUT {
-		// empty password
-		fmt.Println(color.RedString("The password must not be empty. Please try again."))
-		os.Exit(1)
-	} else {
-		fmt.Println(color.RedString("Unhandled response code: %v", loginResponse.StatusCode))
-		dumpAPIResponse(*apiResponse)
-		os.Exit(1)
+		return result, err
 	}
 
-	config.WriteToFile()
+	switch loginResponse.StatusCode {
+	case apischema.STATUS_CODE_DATA:
+		// successful login
+		result.token = loginResponse.Data.Id
+		result.email = args.email
+		config.Config.Token = result.token
+		config.Config.Email = args.email
+		config.WriteToFile()
+
+		return result, nil
+	case apischema.STATUS_CODE_RESOURCE_INVALID_CREDENTIALS:
+		// bad credentials
+		return result, errors.New(errInvalidCredentials)
+	case apischema.STATUS_CODE_RESOURCE_NOT_FOUND:
+		// user unknown or user/password mismatch
+		return result, errors.New(errInvalidCredentials)
+	case apischema.STATUS_CODE_WRONG_INPUT:
+		// empty password
+		return result, errors.New(errEmptyPassword)
+	default:
+		return result, fmt.Errorf("Unhandled response code: %v", loginResponse.StatusCode)
+	}
 }

--- a/commands/login_test.go
+++ b/commands/login_test.go
@@ -1,0 +1,128 @@
+package commands
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/giantswarm/gsctl/config"
+	"github.com/spf13/viper"
+)
+
+// Test_LoginValidPassword simulates a login with a valid email/password combination
+func Test_LoginValidPassword(t *testing.T) {
+	defer viper.Reset()
+	dir := tempDir()
+	defer os.RemoveAll(dir)
+	config.Initialize(dir)
+
+	// this server will respond positively in any case
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+      "status_code": 10000,
+      "status_text": "Success",
+      "data": {
+        "Id": "some-test-session-token"
+      }
+    }`))
+	}))
+	defer mockServer.Close()
+
+	args := loginArguments{}
+	args.apiEndpoint = mockServer.URL
+	args.email = "email@example.com"
+	args.password = "test password"
+
+	result, err := login(args)
+	if err != nil {
+		t.Error(err)
+	}
+	if result.email != args.email {
+		t.Errorf("Expected '%s', got '%s'", args.email, result.email)
+	}
+	if result.token != "some-test-session-token" {
+		t.Errorf("Expected 'some-test-session-token', got '%s'", result.token)
+	}
+	if result.loggedOutBefore == true {
+		t.Error("result.loggedOutBefore was true, expected false")
+	}
+}
+
+// Test_LoginInvalidPassword simulates a login with a bad email/password combination
+func Test_LoginInvalidPassword(t *testing.T) {
+	defer viper.Reset()
+	dir := tempDir()
+	defer os.RemoveAll(dir)
+	config.Initialize(dir)
+
+	// this server will respond positively in any case
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+      "status_code": 10008,
+      "status_text": "resource not found"
+    }`))
+	}))
+	defer mockServer.Close()
+
+	args := loginArguments{}
+	args.apiEndpoint = mockServer.URL
+	args.email = "email@example.com"
+	args.password = "bad password"
+
+	_, err := login(args)
+	if err.Error() != errInvalidCredentials {
+		t.Errorf("Expected error '%s', got %v", errInvalidCredentials, err)
+	}
+}
+
+// Test_LoginWhenUserLoggedInBefore simulates an okay login when the user was
+// logged in before.
+func Test_LoginWhenUserLoggedInBefore(t *testing.T) {
+	defer viper.Reset()
+	dir := tempDir()
+	defer os.RemoveAll(dir)
+	config.Initialize(dir)
+	config.Config.Token = "token-from-previous-session"
+	config.Config.Email = "email-from-previous-session@example.com"
+
+	// this server will respond positively in any case
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+      "status_code": 10000,
+      "status_text": "Success",
+      "data": {
+        "Id": "another-test-session-token"
+      }
+    }`))
+	}))
+	defer mockServer.Close()
+
+	args := loginArguments{}
+	args.apiEndpoint = mockServer.URL
+	args.email = "email@example.com"
+	args.password = "test password"
+
+	result, err := login(args)
+	if err != nil {
+		t.Error(err)
+	}
+	if result.email != args.email {
+		t.Errorf("Expected '%s', got '%s'", args.email, result.email)
+	}
+	if config.Config.Email != args.email {
+		t.Errorf("Expected config email to be '%s', got '%s'", args.email, config.Config.Email)
+	}
+	if result.token != "another-test-session-token" {
+		t.Errorf("Expected 'another-test-session-token', got '%s'", result.token)
+	}
+	if !result.loggedOutBefore {
+		t.Error("result.loggedOutBefore was false, expected true")
+	}
+}

--- a/commands/logout.go
+++ b/commands/logout.go
@@ -28,7 +28,7 @@ var (
 		Use:     "logout",
 		Short:   "Sign the current user out",
 		Long:    `This will terminate the current user's session and invalidate the authentication token.`,
-		PreRunE: checkLogout,
+		PreRunE: logoutValidationOutput,
 		Run:     logoutOutput,
 	}
 )
@@ -52,7 +52,7 @@ func init() {
 }
 
 // TODO: separate validation and validation result output
-func checkLogout(cmd *cobra.Command, args []string) error {
+func logoutValidationOutput(cmd *cobra.Command, args []string) error {
 	if config.Config.Token == "" && cmdToken == "" {
 		return errors.New("You are not logged in")
 	}
@@ -61,7 +61,7 @@ func checkLogout(cmd *cobra.Command, args []string) error {
 
 // logoutOutput performs our logout function and displays the result.
 func logoutOutput(cmd *cobra.Command, extraArgs []string) {
-	logoutArgs := logoutArguments{}
+	logoutArgs := defaultLogoutArguments()
 
 	logoutArgs.token = config.Config.Token
 	if cmdToken != "" {

--- a/commands/logout_test.go
+++ b/commands/logout_test.go
@@ -1,0 +1,63 @@
+package commands
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+// Test_LogoutValidToken tests the logout for a valid token
+func Test_LogoutValidToken(t *testing.T) {
+	defer viper.Reset()
+	dir := tempDir()
+	defer os.RemoveAll(dir)
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Printf("mockServer request: %s %s\n", r.Method, r.URL)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"status_code": 10007, "status_text": "Resource deleted"}`))
+	}))
+	defer mockServer.Close()
+
+	cmdConfigDirPath = dir
+	logoutArgs := logoutArguments{
+		apiEndpoint: mockServer.URL,
+		token:       "test-token",
+	}
+
+	err := logout(logoutArgs)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+// Test_LogoutInvalidToken tests the logout for an invalid token
+func Test_LogoutInvalidToken(t *testing.T) {
+	defer viper.Reset()
+	dir := tempDir()
+	defer os.RemoveAll(dir)
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Printf("mockServer request: %s %s\n", r.Method, r.URL)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{}`))
+	}))
+	defer mockServer.Close()
+
+	cmdConfigDirPath = dir
+	logoutArgs := logoutArguments{
+		apiEndpoint: mockServer.URL,
+		token:       "test-token",
+	}
+
+	err := logout(logoutArgs)
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/commands/logout_test.go
+++ b/commands/logout_test.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -17,7 +16,6 @@ func Test_LogoutValidToken(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Printf("mockServer request: %s %s\n", r.Method, r.URL)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{"status_code": 10007, "status_text": "Resource deleted"}`))
@@ -43,7 +41,6 @@ func Test_LogoutInvalidToken(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Printf("mockServer request: %s %s\n", r.Method, r.URL)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusUnauthorized)
 		w.Write([]byte(`{}`))
@@ -60,4 +57,25 @@ func Test_LogoutInvalidToken(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+}
+
+// Test_LogoutCommand simply calls the functions cobra would call,
+// with a temporary config path and mock server as endpoint.
+func Test_LogoutCommand(t *testing.T) {
+	defer viper.Reset()
+	dir := tempDir()
+	defer os.RemoveAll(dir)
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"status_code": 10007, "status_text": "Resource deleted"}`))
+	}))
+	defer mockServer.Close()
+
+	cmdConfigDirPath = dir
+	cmdAPIEndpoint = mockServer.URL
+	cmdToken = "some-token"
+	logoutValidationOutput(LogoutCommand, []string{})
+	logoutOutput(LogoutCommand, []string{})
 }

--- a/commands/logout_test.go
+++ b/commands/logout_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/giantswarm/gsctl/config"
 	"github.com/spf13/viper"
 )
 
@@ -14,6 +15,7 @@ func Test_LogoutValidToken(t *testing.T) {
 	defer viper.Reset()
 	dir := tempDir()
 	defer os.RemoveAll(dir)
+	config.Initialize(dir)
 
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -22,7 +24,6 @@ func Test_LogoutValidToken(t *testing.T) {
 	}))
 	defer mockServer.Close()
 
-	cmdConfigDirPath = dir
 	logoutArgs := logoutArguments{
 		apiEndpoint: mockServer.URL,
 		token:       "test-token",
@@ -39,6 +40,7 @@ func Test_LogoutInvalidToken(t *testing.T) {
 	defer viper.Reset()
 	dir := tempDir()
 	defer os.RemoveAll(dir)
+	config.Initialize(dir)
 
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -47,7 +49,6 @@ func Test_LogoutInvalidToken(t *testing.T) {
 	}))
 	defer mockServer.Close()
 
-	cmdConfigDirPath = dir
 	logoutArgs := logoutArguments{
 		apiEndpoint: mockServer.URL,
 		token:       "test-token",
@@ -65,6 +66,7 @@ func Test_LogoutCommand(t *testing.T) {
 	defer viper.Reset()
 	dir := tempDir()
 	defer os.RemoveAll(dir)
+	config.Initialize(dir)
 
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -73,7 +75,6 @@ func Test_LogoutCommand(t *testing.T) {
 	}))
 	defer mockServer.Close()
 
-	cmdConfigDirPath = dir
 	cmdAPIEndpoint = mockServer.URL
 	cmdToken = "some-token"
 	logoutValidationOutput(LogoutCommand, []string{})


### PR DESCRIPTION
This PR solves https://github.com/giantswarm/gsctl/issues/22

### Preview

```nohighlight
$ ./gsctl login marian@sendung.de
Password for marian@sendung.de:
You are logged in as marian@sendung.de at https://api.giantswarm.io.

$ ./gsctl info
Email:                marian@sendung.de
gsctl version:
gsctl build:
Config path:          /Users/marian/.config/gsctl/config.yaml
kubectl config path:  /Users/marian/.kube/config

$ ./gsctl login marian@giantswarm.io --api-endpoint=https://api-g8s.giantswarm.io
Password for marian@giantswarm.io:
You are logged in as marian@giantswarm.io at https://api-g8s.giantswarm.io.

$ ./gsctl info
Email:                marian@giantswarm.io
gsctl version:
gsctl build:
Config path:          /Users/marian/.config/gsctl/config.yaml
kubectl config path:  /Users/marian/.kube/config
```

### Description

- Refactored `commands/logout.go` to be able to call the `logout()` function from `login.go` (if the user is currently logged in). Also to allow for easier testing.
- Similar refactoring for `login.go` (separation of output/error display, actual function).
- If a user was logged in before (i. e. we still has a session token in config), the user now gets logged out before the new session token is obtained. This is what #22 is about.
- Adding unit tests for `commands/logout.go` and `commands/login.go`
- To make the login test work, I had to change `list_keypairs_test.go`, as it's test config affected the result of the login test. See https://github.com/giantswarm/gsctl/pull/84/commits/ad9eb9526f3b3c8139cf47cee9fdc4bac70d2667 for details.