### PR TITLE
Configure client to use proxy if environment variables present

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -53,7 +53,10 @@ func NewClient(clientConfig Configuration) (*gsclientgen.DefaultApi, error) {
 	if rootCertsErr != nil {
 		return nil, microerror.MaskAny(rootCertsErr)
 	}
-	configuration.Transport = &http.Transport{TLSClientConfig: tlsConfig}
+	configuration.Transport = &http.Transport{
+		Proxy:           http.ProxyFromEnvironment,
+		TLSClientConfig: tlsConfig,
+	}
 
 	return &gsclientgen.DefaultApi{
 		Configuration: configuration,

--- a/commands/ping.go
+++ b/commands/ping.go
@@ -74,8 +74,10 @@ func ping(endpointURL string) (time.Duration, error) {
 	if rootCertsErr != nil {
 		return duration, microerror.MaskAny(rootCertsErr)
 	}
-	t := &http.Transport{}
-	t.TLSClientConfig = tlsConfig
+	t := &http.Transport{
+		Proxy:           http.ProxyFromEnvironment,
+		TLSClientConfig: tlsConfig,
+	}
 	pingClient := &http.Client{
 		Timeout:   5 * time.Second,
 		Transport: t,


### PR DESCRIPTION
Fixes #99 in parts.

This change enables the use of a proxy server if the environment variables `HTTP_PROXY` or `HTTPS_PROXY` are set to a proxy server URL.

I used `mitmdump` (https://mitmproxy.org/) as proxy.

```
mitmdump -b 127.0.0.1 -p 8080 -v
```

gsctl call:

```
HTTPS_PROXY=http://127.0.0.1:8080 GSCTL_CAFILE=~/.mitmproxy/mitmproxy-ca.pem ./gsctl ping
```

mitmdump log:

```
Proxy server listening at http://127.0.0.1:8080
127.0.0.1:61909: clientconnect
127.0.0.1:61909: GET https://api.giantswarm.io/v1/ping
              << 200 OK 5b
127.0.0.1:61909: clientdisconnect
```