### PR TITLE
Ensure line break after clusters table

### DIFF
--- a/commands/list_clusters.go
+++ b/commands/list_clusters.go
@@ -53,7 +53,7 @@ func listClusters(cmd *cobra.Command, args []string) {
 		}
 		os.Exit(1)
 	}
-	fmt.Print(output)
+	fmt.Println(output)
 }
 
 // clustersTable returns a table of clusters the user has access to


### PR DESCRIPTION
There was a line break missing at the end of the `gsctl list clusters` output.