### PR TITLE
do not print empty new line in case no cluster can be listed

### DIFF
--- a/commands/list_clusters.go
+++ b/commands/list_clusters.go
@@ -53,7 +53,9 @@ func listClusters(cmd *cobra.Command, args []string) {
 		}
 		os.Exit(1)
 	}
-	fmt.Println(output)
+	if output != "" {
+		fmt.Println(output)
+	}
 }
 
 // clustersTable returns a table of clusters the user has access to


### PR DESCRIPTION
When there are no clusters to list, before it was this. 

```
xh3b4sd@osx.local lycangsctl list clusters

xh3b4sd@osx.local
```

Now it is this. 

```
xh3b4sd@osx.local lycangsctl list clusters
xh3b4sd@osx.local
```