### PR TITLE
Setting "-" as the word separator for flags

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -30,13 +30,13 @@ var (
 	// verbose flag
 	cmdVerbose bool
 
-	// certificate_organizations flag
+	// certificate-organizations flag
 	cmdCertificateOrganizations string
 
 	// cluster ID flag
 	cmdClusterID string
 
-	// cn_prefox flag
+	// cn-prefix flag
 	cmdCNPrefix string
 
 	// description flag

--- a/commands/create_keypair.go
+++ b/commands/create_keypair.go
@@ -32,8 +32,8 @@ const (
 func init() {
 	CreateKeypairCommand.Flags().StringVarP(&cmdClusterID, "cluster", "c", "", "ID of the cluster to create a key pair for")
 	CreateKeypairCommand.Flags().StringVarP(&cmdDescription, "description", "d", "", "Description for the key pair")
-	CreateKeypairCommand.Flags().StringVarP(&cmdCNPrefix, "cn_prefix", "", "", "The common name prefix for the issued certificates 'CN' field.")
-	CreateKeypairCommand.Flags().StringVarP(&cmdCertificateOrganizations, "certificate_organizations", "", "", "A comma separated list of organizations for the issued certificates 'O' fields.")
+	CreateKeypairCommand.Flags().StringVarP(&cmdCNPrefix, "cn-prefix", "", "", "The common name prefix for the issued certificates 'CN' field.")
+	CreateKeypairCommand.Flags().StringVarP(&cmdCertificateOrganizations, "certificate-organizations", "", "", "A comma separated list of organizations for the issued certificates 'O' fields.")
 	CreateKeypairCommand.Flags().IntVarP(&cmdTTLDays, "ttl", "", 30, "Duration until expiry of the created key pair in days")
 
 	CreateCommand.AddCommand(CreateKeypairCommand)

--- a/commands/create_kubeconfig.go
+++ b/commands/create_kubeconfig.go
@@ -34,8 +34,8 @@ const (
 func init() {
 	CreateKubeconfigCommand.Flags().StringVarP(&cmdClusterID, "cluster", "c", "", "ID of the cluster")
 	CreateKubeconfigCommand.Flags().StringVarP(&cmdDescription, "description", "d", "", "Description for the key pair")
-	CreateKubeconfigCommand.Flags().StringVarP(&cmdCNPrefix, "cn_prefix", "", "", "The common name prefix for the issued certificates 'CN' field.")
-	CreateKubeconfigCommand.Flags().StringVarP(&cmdCertificateOrganizations, "certificate_organizations", "", "", "A comma separated list of organizations for the issued certificates 'O' fields.")
+	CreateKubeconfigCommand.Flags().StringVarP(&cmdCNPrefix, "cn-prefix", "", "", "The common name prefix for the issued certificates 'CN' field.")
+	CreateKubeconfigCommand.Flags().StringVarP(&cmdCertificateOrganizations, "certificate-organizations", "", "", "A comma separated list of organizations for the issued certificates 'O' fields.")
 	CreateKubeconfigCommand.Flags().IntVarP(&cmdTTLDays, "ttl", "", 30, "Duration until expiry of the created key pair in days")
 
 	CreateCommand.AddCommand(CreateKubeconfigCommand)


### PR DESCRIPTION
To conform to conventions and to be consistent, this PR changes two new command line flags to use the dash/minus as a word seperator, instead of the underscore.