### PR TITLE
Automatically sign binaries during release process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ release
 /gsctl.exe
 
 /coverage.txt
+
+/certs

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,16 @@ test:
 # Create binary files for releases
 bin-dist: crosscompile
 
-	mkdir -p bin-dist
+	@mkdir -p bin-dist
+
+	@# test if code signing certificate is available in ./certs/code-signing.p12
+	test -f ./certs/code-signing.p12
+
+	@# test if code signing bundle password is in $CODE_SIGNING_CERT_BUNDLE_PASSWORD
+	@ if [ "${CODE_SIGNING_CERT_BUNDLE_PASSWORD}" = "" ]; then \
+	  echo 'Environment variable $$CODE_SIGNING_CERT_BUNDLE_PASSWORD not set'; \
+	  exit 1; \
+  fi
 
 	for OS in darwin-amd64 linux-amd64; do \
 		mkdir -p build/$(BIN)-$(VERSION)-$$OS; \
@@ -105,12 +114,23 @@ bin-dist: crosscompile
 		cd ..; \
 	done
 
-	# little different treatment for windows
+	@# little different treatment for windows,
+	@# becaue of .exe suffix and code signing
 	for OS in windows-386 windows-amd64; do \
 		mkdir -p build/$(BIN)-$(VERSION)-$$OS; \
 		cp README.md build/$(BIN)-$(VERSION)-$$OS/; \
 		cp LICENSE build/$(BIN)-$(VERSION)-$$OS/; \
-		cp build/bin/$(BIN)-$$OS build/$(BIN)-$(VERSION)-$$OS/$(BIN).exe; \
+		docker run --rm -ti \
+		  -v $(shell pwd)/certs:/mnt/certs \
+		  -v $(shell pwd)/build:/mnt/binaries \
+		  quay.io/giantswarm/signcode-util:latest \
+		  sign \
+		  -pkcs12 /mnt/certs/code-signing.p12 \
+		  -n "gsctl" \
+		  -i https://github.com/giantswarm/gsctl \
+		  -in /mnt/binaries/bin/$(BIN)-$$OS \
+		  -out /mnt/binaries/$(BIN)-$(VERSION)-$$OS/$(BIN).exe \
+		  -pass $(CODE_SIGNING_CERT_BUNDLE_PASSWORD); \
 		cd build; \
 		zip $(BIN)-$(VERSION)-$$OS.zip $(BIN)-$(VERSION)-$$OS/*; \
 		mv ./$(BIN)-$(VERSION)-$$OS.zip ../bin-dist/; \

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,6 +13,7 @@
 - Push permissions for https://github.com/giantswarm/gsctl
 - Push permissions for https://github.com/giantswarm/homebrew-giantswarm
 - env variable `BUILDER_GITHUB_TOKEN` set to a valid Github token
+- Code signing certificate from keePass
 
 ## Instructions
 
@@ -37,12 +38,23 @@ make clean
 git checkout <version-tag>
 ```
 
-Open the [release draft](https://github.com/giantswarm/gsctl/releases/) on Github. Edit the description to inform about what has changed since the last release. Save and publish the release.
+Create the folder `certs` inside the repo, if not there, and place the file `code-signing.p12` from keePass (code signing certificate) there.
 
-To also upload the binaries to AWS S3 and provide an update for homebrew users, execute this:
+Set the environment variable `$CODE_SIGNING_CERT_BUNDLE_PASSWORD` to the PKCS#12 encryption password you find in keePass.
+
+Then run this:
 
 ```nohighlight
 make release
 ```
+
+Open the [release draft](https://github.com/giantswarm/gsctl/releases/) on Github.
+
+Upload the windows binaries to the release.
+
+Edit the description to inform about what has changed since the last release. Save and publish the release.
+
+To also upload the binaries to AWS S3 and provide an update for homebrew users, execute this:
+
 
 Finally, when everything went fine, do another `make clean`.


### PR DESCRIPTION
Solves https://github.com/giantswarm/giantswarm/issues/1598, partly solves https://github.com/giantswarm/gsctl/issues/98

Changes:

- Update to documentation (RELEASE.md)
- Update to Makefile