### PR TITLE
Sort cluster list by ID, then organization

### DIFF
--- a/commands/list_clusters.go
+++ b/commands/list_clusters.go
@@ -81,21 +81,18 @@ func clustersTable() (string, error) {
 		return "", nil
 	}
 	// table headers
-	output := []string{color.CyanString("ORGANIZATION") + "|" + color.CyanString("ID") + "|" + color.CyanString("NAME") + "|" + color.CyanString("CREATED")}
+	output := []string{color.CyanString("ID") + "|" + color.CyanString("ORGANIZATION") + "|" + color.CyanString("NAME") + "|" + color.CyanString("CREATED")}
 
-	// sort clusters by organization
+	// sort clusters by ID
 	slice.Sort(clusters[:], func(i, j int) bool {
-		if clusters[i].Owner == clusters[j].Owner {
-			return clusters[i].Id < clusters[j].Id
-		}
-		return clusters[i].Owner < clusters[j].Owner
+		return clusters[i].Id < clusters[j].Id
 	})
 
 	for _, cluster := range clusters {
 		created := util.ShortDate(util.ParseDate(cluster.CreateDate))
 		output = append(output,
-			cluster.Owner+"|"+
-				cluster.Id+"|"+
+			cluster.Id+"|"+
+				cluster.Owner+"|"+
 				cluster.Name+"|"+
 				created)
 	}

--- a/commands/list_clusters.go
+++ b/commands/list_clusters.go
@@ -81,20 +81,23 @@ func clustersTable() (string, error) {
 		return "", nil
 	}
 	// table headers
-	output := []string{color.CyanString("ID") + "|" + color.CyanString("NAME") + "|" + color.CyanString("CREATED") + "|" + color.CyanString("ORGANIZATION")}
+	output := []string{color.CyanString("ORGANIZATION") + "|" + color.CyanString("ID") + "|" + color.CyanString("NAME") + "|" + color.CyanString("CREATED")}
 
 	// sort clusters by organization
 	slice.Sort(clusters[:], func(i, j int) bool {
-		return clusters[i].Owner < clusters[j].Id
+		if clusters[i].Owner == clusters[j].Owner {
+			return clusters[i].Id < clusters[j].Id
+		}
+		return clusters[i].Owner < clusters[j].Owner
 	})
 
 	for _, cluster := range clusters {
 		created := util.ShortDate(util.ParseDate(cluster.CreateDate))
 		output = append(output,
-			cluster.Id+"|"+
+			cluster.Owner+"|"+
+				cluster.Id+"|"+
 				cluster.Name+"|"+
-				created+"|"+
-				cluster.Owner)
+				created)
 	}
 
 	return columnize.SimpleFormat(output), nil

--- a/commands/list_clusters_test.go
+++ b/commands/list_clusters_test.go
@@ -38,6 +38,12 @@ func Test_ListClusters(t *testing.T) {
         "id": "` + randomClusterID() + `",
         "name": "Some random test cluster",
 				"owner": "acme"
+      },
+			{
+        "create_date": "2017-10-06T02:24:55.192170835Z",
+        "id": "` + randomClusterID() + `",
+        "name": "Another random test cluster",
+				"owner": "acme"
       }
     ]`))
 	}))

--- a/commands/list_clusters_test.go
+++ b/commands/list_clusters_test.go
@@ -30,20 +30,26 @@ func Test_ListClusters(t *testing.T) {
 			{
         "create_date": "2017-05-16T09:30:31.192170835Z",
         "id": "` + randomClusterID() + `",
-        "name": "Some random test cluster",
-				"owner": "some_org"
+        "name": "My dearest production cluster",
+				"owner": "acme"
       },
 			{
         "create_date": "2017-04-16T09:30:31.192170835Z",
         "id": "` + randomClusterID() + `",
-        "name": "Some random test cluster",
-				"owner": "acme"
+        "name": "Abandoned cluster from the early days",
+				"owner": "some_org"
       },
 			{
         "create_date": "2017-10-06T02:24:55.192170835Z",
         "id": "` + randomClusterID() + `",
-        "name": "Another random test cluster",
+        "name": "A fairly recent test cluster",
 				"owner": "acme"
+      },
+			{
+        "create_date": "2017-10-10T07:24:55.192170835Z",
+        "id": "` + randomClusterID() + `",
+        "name": "That brand new development cluster",
+				"owner": "acme_dev"
       }
     ]`))
 	}))


### PR DESCRIPTION
Fixes #124

The cluster table is now sorted by ID, then organization. The organization column is moved to the seccond position accordingly, as the expectation seems to be that sort order and position correlate.

Example:

```
ID       ORGANIZATION  NAME                                   CREATED
35e3vfw  acme_dev      That brand new development cluster     2017 Oct 10, 07:24 UTC
h9mqa6z  acme          My dearest production cluster          2017 May 16, 09:30 UTC
jjasn0x  some_org      Abandoned cluster from the early days  2017 Apr 16, 09:30 UTC
xs4sew7  acme          A fairly recent test cluster           2017 Oct 06, 02:24 UTC
```

Before, the ORGANIZATION column has been printed last.