### PR TITLE
Add CN and O to "list keypairs" output table

### DIFF
--- a/commands/list_keypairs.go
+++ b/commands/list_keypairs.go
@@ -171,6 +171,8 @@ func listKeypairsOutput(cmd *cobra.Command, extraArgs []string) {
 			color.CyanString("EXPIRES"),
 			color.CyanString("ID"),
 			color.CyanString("DESCRIPTION"),
+			color.CyanString("CN"),
+			color.CyanString("O"),
 		}
 		output = append(output, strings.Join(headers, "|"))
 
@@ -184,6 +186,8 @@ func listKeypairsOutput(cmd *cobra.Command, extraArgs []string) {
 				util.ShortDate(expires),
 				util.Truncate(util.CleanKeypairID(keypair.Id), 10),
 				keypair.Description,
+				util.Truncate(keypair.CommonName, 24),
+				keypair.CertificateOrganizations,
 			}
 			output = append(output, strings.Join(row, "|"))
 		}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/2084

The CN is truncated to 24 characters, as it's usually pretty long and totally reaks any layout by wrapping lines.