### PR TITLE
Tweak to prevent timeouts in 'list clusters'

### DIFF
--- a/commands/list_clusters.go
+++ b/commands/list_clusters.go
@@ -66,7 +66,7 @@ func clustersTable() (string, error) {
 
 	clientConfig := client.Configuration{
 		Endpoint:  endpoint,
-		Timeout:   3 * time.Second,
+		Timeout:   5 * time.Second,
 		UserAgent: config.UserAgent(),
 	}
 	apiClient, clientErr := client.NewClient(clientConfig)


### PR DESCRIPTION
Fixes https://github.com/giantswarm/gsctl/issues/128

This increases the timeout for the API request issues by `gsctl list clusters`. Seems like that request can take a while when the user is a member of many organizations.