### PR TITLE
Fixing branch name

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -8,7 +8,7 @@ import:
 - package: github.com/giantswarm/columnize
   version: =2.0.2
 - package: github.com/giantswarm/gsclientgen
-  version: cluster-details
+  version: master
 - package: github.com/howeyc/gopass
 - package: github.com/spf13/cobra
 - package: gopkg.in/yaml.v2


### PR DESCRIPTION
Now that https://github.com/giantswarm/gsclientgen/pull/20 is merged, this has to be fixed back to master.