### PR TITLE
Fixes for the "show cluster" command

### DIFF
--- a/commands/show_cluster.go
+++ b/commands/show_cluster.go
@@ -189,6 +189,12 @@ func showClusterRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 	created := util.ParseDate(clusterDetails.CreateDate)
 
 	output = append(output, color.YellowString("ID:")+"|"+clusterDetails.Id)
+
+	if clusterDetails.Name != "" {
+		output = append(output, color.YellowString("Name:")+"|"+clusterDetails.Name)
+	} else {
+		output = append(output, color.YellowString("Name:")+"|n/a")
+	}
 	output = append(output, color.YellowString("Created:")+"|"+util.ShortDate(created))
 	output = append(output, color.YellowString("Organization:")+"|"+clusterDetails.Owner)
 	output = append(output, color.YellowString("Kubernetes API endpoint:")+"|"+clusterDetails.ApiEndpoint)

--- a/commands/show_cluster.go
+++ b/commands/show_cluster.go
@@ -96,7 +96,7 @@ func verifyShowClusterPreconditions(args showClusterArguments, cmdLineArgs []str
 	if config.Config.Token == "" && args.authToken == "" {
 		return microerror.Mask(notLoggedInError)
 	}
-	if len(cmdLineArgs) == 0 || args.clusterID == "" {
+	if len(cmdLineArgs) == 0 {
 		return microerror.Mask(clusterIDMissingError)
 	}
 	return nil

--- a/commands/show_cluster_test.go
+++ b/commands/show_cluster_test.go
@@ -91,7 +91,7 @@ func TestShowClusterMissingID(t *testing.T) {
 		authToken:   "auth-token",
 	}
 
-	err := verifyShowClusterPreconditions(testArgs, []string{testArgs.clusterID})
+	err := verifyShowClusterPreconditions(testArgs, []string{})
 	if !IsClusterIDMissingError(err) {
 		t.Errorf("Expected clusterIdMissingError, got '%s'", err.Error())
 	}


### PR DESCRIPTION
Two fixes for the implementation of https://github.com/giantswarm/gsctl/issues/105

- Reverted a late change to  `verifyShowClusterPreconditions` that broke the command line execution
- Added the cluster name field to the details output