### PR TITLE
gsctl create kubeconfig: adding --context flag

### DIFF
--- a/commands/create_kubeconfig.go
+++ b/commands/create_kubeconfig.go
@@ -374,8 +374,8 @@ func createKubeconfig(args createKubeconfigArguments) (createKubeconfigResult, e
 	addKeyPairBody := gsclientgen.V4AddKeyPairBody{
 		Description:              args.description,
 		TtlHours:                 args.ttlHours,
-		CnPrefix:                 cmdCNPrefix,
-		CertificateOrganizations: cmdCertificateOrganizations,
+		CnPrefix:                 args.cnPrefix,
+		CertificateOrganizations: args.certOrgs,
 	}
 
 	clientConfig.Timeout = 60 * time.Second

--- a/commands/create_kubeconfig_test.go
+++ b/commands/create_kubeconfig_test.go
@@ -59,6 +59,7 @@ func Test_CreateKubeconfig(t *testing.T) {
 		t.Error(err)
 	}
 	os.Setenv("KUBECONFIG", kubeConfigPath)
+	defer os.Unsetenv("KUBECONFIG")
 
 	configDir, err := tempConfig("")
 	if err != nil {
@@ -66,13 +67,18 @@ func Test_CreateKubeconfig(t *testing.T) {
 	}
 	defer os.RemoveAll(configDir)
 
-	cmdAPIEndpoint = mockServer.URL
-	cmdClusterID = "test-cluster-id"
+	args := createKubeconfigArguments{
+		authToken:   "auth-token",
+		apiEndpoint: mockServer.URL,
+		clusterID:   "test-cluster-id",
+		contextName: "giantswarm-test-cluster-id",
+	}
 
-	args := defaultCreateKubeconfigArguments()
-	// no additional command line args
-	extraArgs := []string{}
-	verifyCreateKubeconfigPreconditions(args, extraArgs)
+	err = verifyCreateKubeconfigPreconditions(args, []string{})
+	if err != nil {
+		t.Error(err)
+	}
+
 	result, err := createKubeconfig(args)
 	if err != nil {
 		t.Error(err)
@@ -129,15 +135,19 @@ func Test_CreateKubeconfigSelfContained(t *testing.T) {
 	tmpdir := tempDir()
 	defer os.RemoveAll(tmpdir)
 
-	cmdAPIEndpoint = mockServer.URL
-	cmdClusterID = "test-cluster-id"
-	cmdKubeconfigSelfContained = tmpdir + string(os.PathSeparator) + "kubeconfig"
+	args := createKubeconfigArguments{
+		apiEndpoint:       mockServer.URL,
+		authToken:         "auth-token",
+		clusterID:         "test-cluster-id",
+		contextName:       "giantswarm-test-cluster-id",
+		selfContainedPath: tmpdir + string(os.PathSeparator) + "kubeconfig",
+	}
 
-	args := defaultCreateKubeconfigArguments()
+	err = verifyCreateKubeconfigPreconditions(args, []string{})
+	if err != nil {
+		t.Error(err)
+	}
 
-	// no additional command line args
-	extraArgs := []string{}
-	verifyCreateKubeconfigPreconditions(args, extraArgs)
 	result, err := createKubeconfig(args)
 	if err != nil {
 		t.Error(err)

--- a/commands/create_kubeconfig_test.go
+++ b/commands/create_kubeconfig_test.go
@@ -189,3 +189,57 @@ func Test_CreateKubeconfigSelfContained(t *testing.T) {
 		t.Error("Kubeconfig doesn't contain the key certificate-authority-data")
 	}
 }
+
+// Test_CreateKubeconfigCustomContext tests creation of a kubeconfig
+// with custom context name
+func Test_CreateKubeconfigCustomContext(t *testing.T) {
+	mockServer := makeMockServer()
+	defer mockServer.Close()
+
+	// temporary kubeconfig file
+	kubeConfigPath, err := tempKubeconfig()
+	if err != nil {
+		t.Error(err)
+	}
+	os.Setenv("KUBECONFIG", kubeConfigPath)
+	defer os.Unsetenv("KUBECONFIG")
+
+	// temporary config
+	configDir, err := tempConfig("")
+	if err != nil {
+		t.Error(err)
+	}
+	defer os.RemoveAll(configDir)
+
+	args := createKubeconfigArguments{
+		apiEndpoint: mockServer.URL,
+		authToken:   "auth-token",
+		clusterID:   "test-cluster-id",
+		contextName: "test-context",
+	}
+
+	err = verifyCreateKubeconfigPreconditions(args, []string{})
+	if err != nil {
+		t.Error(err)
+	}
+
+	result, err := createKubeconfig(args)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// check result object
+	if result.contextName == "" {
+		t.Error("Expected non-empty result.contextName, got empty string")
+	}
+
+	// check kubeconfig content
+	content, err := ioutil.ReadFile(kubeConfigPath)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !strings.Contains(string(content), "current-context: "+args.contextName) {
+		t.Error("Kubeconfig doesn't contain the expected context name")
+	}
+}

--- a/util/error.go
+++ b/util/error.go
@@ -16,7 +16,7 @@ func IsCouldNotSetKubectlCredentialsError(err error) bool {
 	return errgo.Cause(err) == CouldNotSetKubectlCredentialsError
 }
 
-var CouldNotSetKubectlContextError = errgo.New("could not set context using 'kubectl config sez-context''")
+var CouldNotSetKubectlContextError = errgo.New("could not set context using 'kubectl config set-context''")
 
 // IsCouldNotSetKubectlContextError asserts CouldNotSetKubectlContextError.
 func IsCouldNotSetKubectlContextError(err error) bool {

--- a/util/kubectl.go
+++ b/util/kubectl.go
@@ -60,8 +60,7 @@ func KubectlSetCredentials(clusterID, keyPath, certificatePath string) error {
 }
 
 // KubectlSetContext is a wrapper for the `kubectl config set-context` command
-func KubectlSetContext(clusterID string) error {
-	contextName := "giantswarm-" + clusterID
+func KubectlSetContext(contextName, clusterID string) error {
 	clusterArgument := "--cluster=giantswarm-" + clusterID
 	userArgument := "--user=giantswarm-" + clusterID + "-user"
 	cmd := exec.Command(binaryName,
@@ -74,8 +73,7 @@ func KubectlSetContext(clusterID string) error {
 }
 
 // KubectlUseContext applies the context for the given cluster ID
-func KubectlUseContext(clusterID string) error {
-	contextName := "giantswarm-" + clusterID
+func KubectlUseContext(contextName string) error {
 	cmd := exec.Command(binaryName, "config", "use-context", contextName)
 	err := cmd.Run()
 	return err


### PR DESCRIPTION
For https://github.com/giantswarm/gsctl/issues/114, based on #162 

The actual purpose of this PR is to add a flag `--context` to let the user set a custom context name when desired.

As a side effect, I had to fix a few old mistakes made in the tests.