### PR TITLE
Ensure config file mode of 0600

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,9 @@ const (
 	// ConfigFileName is the name of the configuration file, without ending
 	ConfigFileName = "config"
 
+	// ConfigFilePermission is the rights mask for the config file
+	ConfigFilePermission = 0600
+
 	// ProgramName is the name of this program
 	ProgramName = "gsctl"
 
@@ -252,6 +255,11 @@ func Initialize(configDirPath string) error {
 			return fileErr
 		}
 		file.Close()
+
+		err = os.Chmod(ConfigFilePath, ConfigFilePermission)
+		if err != nil {
+			return microerror.Mask(err)
+		}
 	}
 
 	myConfig, err := readFromFile(ConfigFilePath)

--- a/config/config.go
+++ b/config/config.go
@@ -247,12 +247,12 @@ func Initialize(configDirPath string) error {
 		// ensure directory exists
 		dirErr := os.MkdirAll(ConfigDirPath, 0700)
 		if dirErr != nil {
-			return dirErr
+			return microerror.Mask(dirErr)
 		}
 		// ensure file exists
 		file, fileErr := os.Create(ConfigFilePath)
 		if fileErr != nil {
-			return fileErr
+			return microerror.Mask(fileErr)
 		}
 		file.Close()
 
@@ -338,7 +338,7 @@ func WriteToFile() error {
 		return microerror.Mask(err)
 	}
 
-	err = ioutil.WriteFile(ConfigFilePath, yamlBytes, 0600)
+	err = ioutil.WriteFile(ConfigFilePath, yamlBytes, ConfigFilePermission)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -343,6 +343,12 @@ func WriteToFile() error {
 		return microerror.Mask(err)
 	}
 
+	// finally update permissions, in case they weren't right before
+	err = os.Chmod(ConfigFilePath, ConfigFilePermission)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Fixes https://github.com/giantswarm/gsctl/issues/87

The problem was that the creation using `file, fileErr := os.Create(ConfigFilePath)` simply did not set any permission.

Since users will now have config files with permission 0644 from current gsctl versions, an additional permission udpdate after each write access to the config file should ensure the correct mode.