### PR TITLE
Human-friendly duration output for key pair expiry

### DIFF
--- a/commands/create_keypair.go
+++ b/commands/create_keypair.go
@@ -98,8 +98,9 @@ func addKeypair(cmd *cobra.Command, args []string) {
 	}
 
 	if apiResponse.StatusCode == 200 {
-		cleanID := util.CleanKeypairID(keypairResponse.Id)
-		msg := fmt.Sprintf("New key pair created with ID %s and expiry of %v hours", cleanID, keypairResponse.TtlHours)
+		msg := fmt.Sprintf("New key pair created with ID %s and expiry of %v",
+			util.CleanKeypairID(keypairResponse.Id),
+			util.DurationPhrase(int(keypairResponse.TtlHours)))
 		fmt.Println(color.GreenString(msg))
 
 		// store credentials to file

--- a/commands/create_keypair.go
+++ b/commands/create_keypair.go
@@ -99,7 +99,7 @@ func addKeypair(cmd *cobra.Command, args []string) {
 
 	if apiResponse.StatusCode == 200 {
 		msg := fmt.Sprintf("New key pair created with ID %s and expiry of %v",
-			util.CleanKeypairID(keypairResponse.Id),
+			util.Truncate(util.CleanKeypairID(keypairResponse.Id), 10),
 			util.DurationPhrase(int(keypairResponse.TtlHours)))
 		fmt.Println(color.GreenString(msg))
 

--- a/commands/create_kubeconfig.go
+++ b/commands/create_kubeconfig.go
@@ -200,9 +200,9 @@ func createKubeconfigRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 
 	fmt.Println("Creating new key pair…")
 
-	fmt.Printf("New key pair created with ID %s and expiry of %v hours\n",
+	fmt.Printf("New key pair created with ID %s and expiry of %s\n",
 		util.Truncate(util.CleanKeypairID(result.keypairResponse.Id), 10),
-		result.keypairResponse.TtlHours)
+		util.DurationPhrase(int(result.keypairResponse.TtlHours)))
 
 	fmt.Println("Certificate and key files written to:")
 	fmt.Println(result.caCertPath)

--- a/commands/create_kubeconfig.go
+++ b/commands/create_kubeconfig.go
@@ -198,11 +198,10 @@ func createKubeconfigRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 
 	// Success output
 
-	fmt.Println("Creating new key pair…")
-
-	fmt.Printf("New key pair created with ID %s and expiry of %s\n",
+	msg := fmt.Sprintf("New key pair created with ID %s and expiry of %v",
 		util.Truncate(util.CleanKeypairID(result.keypairResponse.Id), 10),
 		util.DurationPhrase(int(result.keypairResponse.TtlHours)))
+	fmt.Println(color.GreenString(msg))
 
 	fmt.Println("Certificate and key files written to:")
 	fmt.Println(result.caCertPath)

--- a/util/duration.go
+++ b/util/duration.go
@@ -1,0 +1,67 @@
+package util
+
+import (
+	"fmt"
+	"strings"
+)
+
+// DurationPhrase creates a human-friendly phrase from a number of hours
+// expressing a duration, like "3 days, 2 hours". Precision of output
+// is limited in favour of readability.
+func DurationPhrase(hours int) string {
+
+	hoursInYear := 365 * 24
+	hoursInMonth := 30 * 24
+	hoursInWeek := 7 * 24
+	hoursInDay := 24
+
+	years := hours / hoursInYear
+	months := (hours - years*hoursInYear) / hoursInMonth
+	weeks := (hours - years*hoursInYear - months*hoursInMonth) / hoursInWeek
+	days := (hours - years*hoursInYear - months*hoursInMonth - weeks*hoursInWeek) / hoursInDay
+	hours = hours - years*hoursInYear - months*hoursInMonth - weeks*hoursInWeek - days*hoursInDay
+
+	phraseParts := []string{}
+
+	if years > 0 {
+		plural := ""
+		if years > 1 {
+			plural = "s"
+		}
+		phraseParts = append(phraseParts, fmt.Sprintf("%d year%s", years, plural))
+	}
+
+	if months > 0 {
+		plural := ""
+		if months > 1 {
+			plural = "s"
+		}
+		phraseParts = append(phraseParts, fmt.Sprintf("%d month%s", months, plural))
+	}
+
+	if weeks > 0 && len(phraseParts) < 2 {
+		plural := ""
+		if weeks > 1 {
+			plural = "s"
+		}
+		phraseParts = append(phraseParts, fmt.Sprintf("%d week%s", weeks, plural))
+	}
+
+	if days > 0 && len(phraseParts) < 2 {
+		plural := ""
+		if days > 1 {
+			plural = "s"
+		}
+		phraseParts = append(phraseParts, fmt.Sprintf("%d day%s", days, plural))
+	}
+
+	if hours > 0 && len(phraseParts) < 2 {
+		plural := ""
+		if hours > 1 {
+			plural = "s"
+		}
+		phraseParts = append(phraseParts, fmt.Sprintf("%d hour%s", hours, plural))
+	}
+
+	return strings.Join(phraseParts, ", ")
+}

--- a/util/duration_test.go
+++ b/util/duration_test.go
@@ -1,0 +1,35 @@
+package util
+
+import "testing"
+
+var durationTest = []struct {
+	in  int
+	out string
+}{
+	{1, "1 hour"},
+	{12, "12 hours"},
+	{24, "1 day"},
+	{25, "1 day, 1 hour"},
+	{26, "1 day, 2 hours"},
+	{48, "2 days"},
+	{49, "2 days, 1 hour"},
+	{75, "3 days, 3 hours"},
+	{24 * 7, "1 week"},
+	{24*7*2 - 5, "1 week, 6 days"},
+	{24 * 7 * 2, "2 weeks"},
+	{24*7*2 + 5, "2 weeks, 5 hours"},
+	{11 * 24 * 30, "11 months"},
+	{365 * 24, "1 year"},
+	{365*24 + 4, "1 year, 4 hours"},
+	{365*24 + 30, "1 year, 1 day"},
+	{365*24*2 + 30, "2 years, 1 day"},
+}
+
+func TestFriendlyDuration(t *testing.T) {
+	for _, tt := range durationTest {
+		phrase := DurationPhrase(tt.in)
+		if phrase != tt.out {
+			t.Errorf("Value '%d', got '%s', wanted '%s'", tt.in, phrase, tt.out)
+		}
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/giantswarm/gsctl/issues/24, based on https://github.com/giantswarm/gsctl/pull/161

Also 
- aligns the output of `create kubeconfig` and `create keypair`.
- removes the output of line `Creating new key pair…`