### PR TITLE
Fixes panic due to missing check

### DIFF
--- a/commands/logout.go
+++ b/commands/logout.go
@@ -112,7 +112,7 @@ func logout(args logoutArguments) error {
 	if err != nil {
 		// special treatment for HTTP 401 (unauthorized) error,
 		// in which case no JSON body is returned.
-		if apiResponse.Response.StatusCode == http.StatusUnauthorized {
+		if apiResponse.Response != nil && apiResponse.Response.StatusCode == http.StatusUnauthorized {
 			return microerror.Mask(notAuthorizedError)
 		}
 


### PR DESCRIPTION
```
$ /opt/bin/gsctl login joseph@giantswarm.io -e [REDACTED]
Password for joseph@giantswarm.io on [REDACTED]: 
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x7791a4]

goroutine 1 [running]:
github.com/giantswarm/gsctl/commands.logout(0xc42011c280, 0x31, 0xc420080210, 0x24, 0xc4200762a0, 0x58)
        /go/src/github.com/giantswarm/gsctl/commands/logout.go:115 +0x1f4
github.com/giantswarm/gsctl/commands.login(0xc42011c280, 0x31, 0x7ffedc7366dc, 0x14, 0xc42011c240, 0x40, 0x0, 0x0, 0x0, 0x0, ...)
        /go/src/github.com/giantswarm/gsctl/commands/login.go:213 +0x88b
github.com/giantswarm/gsctl/commands.loginOutput(0xa9ed00, 0xc42007d8c0, 0x1, 0x3)
        /go/src/github.com/giantswarm/gsctl/commands/login.go:151 +0xcd
github.com/giantswarm/gsctl/vendor/github.com/spf13/cobra.(*Command).execute(0xa9ed00, 0xc42007d830, 0x3, 0x3, 0xa9ed00, 0xc42007d830)
        /go/src/github.com/giantswarm/gsctl/vendor/github.com/spf13/cobra/command.go:746 +0x2e7
github.com/giantswarm/gsctl/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xa9cb40, 0x8555d7, 0x3, 0x0)
        /go/src/github.com/giantswarm/gsctl/vendor/github.com/spf13/cobra/command.go:827 +0x30e
github.com/giantswarm/gsctl/vendor/github.com/spf13/cobra.(*Command).Execute(0xa9cb40, 0xc42004ff70, 0x7844ad)
        /go/src/github.com/giantswarm/gsctl/vendor/github.com/spf13/cobra/command.go:780 +0x2b
main.main()
        /go/src/github.com/giantswarm/gsctl/main.go:24 +0x2d
```

becomes

```
$ ./gsctl login joseph@giantswarm.io -e [REDACTED]
Password for joseph@giantswarm.io on [REDACTED]: 
Post [REDACTED]/v1/user/joseph@giantswarm.io/login: dial tcp 10.0.2.71:443: getsockopt: no route to host
```

In cases where no api response can be returned, due to network errors, the status code isn't populated, so we get a panic.