### PR TITLE
Fix panic if api response is nil

### DIFF
--- a/commands/create_kubeconfig.go
+++ b/commands/create_kubeconfig.go
@@ -364,7 +364,13 @@ func createKubeconfig(args createKubeconfigArguments) (createKubeconfigResult, e
 		createKubeconfigActivityName,
 		cmdLine)
 	if err != nil {
-		return result, microerror.Maskf(err, fmt.Sprintf("HTTP status: %d", apiResponse.StatusCode))
+		var errorMessage string
+		if apiResponse != nil {
+			errorMessage = fmt.Sprintf("HTTP status: %d", apiResponse.StatusCode)
+		} else {
+			errorMessage = "No response received from the API"
+		}
+		return result, microerror.Maskf(err, errorMessage)
 	}
 
 	result.apiEndpoint = clusterDetailsResponse.ApiEndpoint


### PR DESCRIPTION
```
gsctl create kubeconfig --cn-prefix="system:masters" -c 5qufg
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x136b248]

goroutine 1 [running]:
github.com/giantswarm/gsctl/commands.createKubeconfig(0xc420012900, 0x33, 0xc42001c3f0, 0x24, 0x7ffeefbff85e, 0x5, 0xc420012c00, 0x40, 0x7ffeefbff84c, 0xe, ...)
    /go/src/github.com/giantswarm/gsctl/commands/create_kubeconfig.go:367 +0x1448
github.com/giantswarm/gsctl/commands.createKubeconfigRunOutput(0x1699380, 0xc420075950, 0x0, 0x3)
    /go/src/github.com/giantswarm/gsctl/commands/create_kubeconfig.go:272 +0xa2
github.com/giantswarm/gsctl/vendor/github.com/spf13/cobra.(*Command).execute(0x1699380, 0xc4200758c0, 0x3, 0x3, 0x1699380, 0xc4200758c0)
    /go/src/github.com/giantswarm/gsctl/vendor/github.com/spf13/cobra/command.go:702 +0x2c6
github.com/giantswarm/gsctl/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0x16988e0, 0x1453cb9, 0x3, 0x0)
    /go/src/github.com/giantswarm/gsctl/vendor/github.com/spf13/cobra/command.go:783 +0x30e
github.com/giantswarm/gsctl/vendor/github.com/spf13/cobra.(*Command).Execute(0x16988e0, 0xc420043f70, 0x13843ad)
    /go/src/github.com/giantswarm/gsctl/vendor/github.com/spf13/cobra/command.go:736 +0x2b
main.main()
    /go/src/github.com/giantswarm/gsctl/main.go:24 +0x2d
```

In the case that the api response is nil (most likely due to some network error), the error handling itself would cause a panic. This handles that nicer.

See https://gigantic.slack.com/archives/C02MS174K/p1517316517000239