### PR TITLE
Improve and align error handling, including 404 Forbidden error, in many commands

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/giantswarm/columnize"
 	"github.com/giantswarm/gsclientgen"
+	"github.com/giantswarm/gsctl/client"
 
 	"github.com/fatih/color"
 )
@@ -189,4 +190,60 @@ func askForConfirmation(s string) bool {
 			return false
 		}
 	}
+}
+
+// handleCommonErrors is a common function to handle certain errors happening in
+// more than one command. If the error given is handled by the function, it
+// prints according text for the end user and exits the process.
+// If the error is not recognized, we simply return.
+func handleCommonErrors(err error) {
+
+	var headline = ""
+	var subtext = ""
+
+	switch {
+	case client.IsEndpointNotSpecifiedError(err):
+		headline = "No endpoint has been specified."
+		subtext = "Please use the '-e|--endpoint' flag."
+	case IsNotLoggedInError(err):
+		headline = "You are not logged in."
+		subtext = "Use 'gsctl login' to login or '--auth-token' to pass a valid auth token."
+	case IsAccessForbiddenError(err):
+		headline = "Access Forbidden"
+		subtext = "The client has been denied access to the API endpoint with an HTTP status of 403.\n"
+		subtext += "Please make sure that you are in the right network or VPN. Once that is verified,\n"
+		subtext += "check back with Giant Swarm support that your network is permitted access."
+	case IsEmptyPasswordError(err):
+		headline = "Empty password submitted"
+		subtext = "The API server complains about the password provided."
+		subtext += " Please make sure to provide a string with more than white space characters."
+	case IsClusterIDMissingError(err):
+		headline = "No cluster ID specified."
+		subtext = "Please specify a cluster ID. Use --help for details."
+	case IsCouldNotCreateClientError(err):
+		headline = "Failed to create API client."
+		subtext = "Details: " + err.Error()
+	case IsNotAuthorizedError(err):
+		headline = "You are not authorized for this action."
+		subtext = "Please check whether you are logged in with the right credentials using 'gsctl info'."
+	case IsInternalServerError(err):
+		headline = "An internal error occurred."
+		subtext = "Please try again in a few minutes. If that does not success, please inform the Giant Swarm support team."
+	case IsNoResponseError(err):
+		headline = "The API didn't send a response."
+		subtext = "Please check your connection using 'gsctl ping'. If your connection is fine,\n"
+		subtext += "please try again in a few moments."
+	case IsUnknownError(err):
+		headline = "An error occurred."
+		subtext = "Please notify the Giant Swarm support team, or try listing releases again in a few moments.\n"
+		subtext += fmt.Sprintf("Details: %s", err.Error())
+	default:
+		return
+	}
+
+	fmt.Println(color.RedString(headline))
+	if subtext != "" {
+		fmt.Println(subtext)
+	}
+	os.Exit(1)
 }

--- a/commands/create_cluster.go
+++ b/commands/create_cluster.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"net/http"
 	"os"
 	"strings"
 
@@ -162,12 +163,12 @@ func createClusterValidationOutput(cmd *cobra.Command, args []string) {
 
 	err := validateCreateClusterPreConditions(aca)
 	if err != nil {
+
+		handleCommonErrors(err)
+
 		switch {
 		case err.Error() == "":
 			return
-		case IsNotLoggedInError(err):
-			headline = "You are not logged in."
-			subtext = fmt.Sprintf("Use '%s login' to login or '--auth-token' to pass a valid auth token.", config.ProgramName)
 		case IsConflictingFlagsError(err):
 			headline = "Conflicting flags used"
 			subtext = "When specifying a definition via a YAML file, certain flags must not be used."
@@ -206,6 +207,8 @@ func createClusterExecutionOutput(cmd *cobra.Command, args []string) {
 
 	result, err := addCluster(aca)
 	if err != nil {
+		handleCommonErrors(err)
+
 		var headline string
 		var subtext string
 		richError, richErrorOK := err.(*errgo.Err)
@@ -482,6 +485,9 @@ func addCluster(args addClusterArguments) (addClusterResult, error) {
 		}
 		responseBody, apiResponse, err := apiClient.AddCluster(authHeader, addClusterBody, requestIDHeader, createClusterActivityName, cmdLine)
 		if err != nil {
+			if apiResponse.Response != nil && apiResponse.Response.StatusCode == http.StatusForbidden {
+				return result, microerror.Mask(accessForbiddenError)
+			}
 			// lower level connection problem
 			return result, microerror.Mask(err)
 		}

--- a/commands/create_cluster.go
+++ b/commands/create_cluster.go
@@ -163,7 +163,6 @@ func createClusterValidationOutput(cmd *cobra.Command, args []string) {
 
 	err := validateCreateClusterPreConditions(aca)
 	if err != nil {
-
 		handleCommonErrors(err)
 
 		switch {

--- a/commands/create_cluster_test.go
+++ b/commands/create_cluster_test.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -169,11 +168,11 @@ func Test_CreateClusterSuccessfully(t *testing.T) {
 	for i, testCase := range testCases {
 		validateErr = validateCreateClusterPreConditions(testCase)
 		if validateErr != nil {
-			t.Error(fmt.Sprintf("Validation error in testCase %v: %s", i, validateErr.Error()))
+			t.Errorf("Validation error in testCase %v: %s", i, validateErr.Error())
 		}
 		_, executeErr = addCluster(testCase)
 		if executeErr != nil {
-			t.Error(fmt.Sprintf("Execution error in testCase %v: %s", i, executeErr.Error()))
+			t.Errorf("Execution error in testCase %v: %s", i, executeErr.Error())
 		}
 	}
 }
@@ -224,7 +223,7 @@ func Test_CreateClusterFailures(t *testing.T) {
 		if validateErr == nil {
 			_, execErr := addCluster(testCase)
 			if execErr == nil {
-				t.Error(fmt.Sprintf("Expected errors didn't occur in testCase %v", i))
+				t.Errorf("Expected errors didn't occur in testCase %v", i)
 			}
 		}
 	}

--- a/commands/create_keypair.go
+++ b/commands/create_keypair.go
@@ -196,6 +196,9 @@ func createKeypair(args createKeypairArguments) (createKeypairResult, error) {
 		addKeyPairActivityName, cmdLine)
 
 	if err != nil {
+		if apiResponse.Response != nil && apiResponse.Response.StatusCode == http.StatusForbidden {
+			return result, microerror.Mask(accessForbiddenError)
+		}
 		return result, microerror.Mask(err)
 	}
 

--- a/commands/create_keypair.go
+++ b/commands/create_keypair.go
@@ -1,9 +1,10 @@
 package commands
 
 import (
-	"errors"
 	"fmt"
+	"net/http"
 	"os"
+	"time"
 
 	"github.com/fatih/color"
 	"github.com/giantswarm/gsclientgen"
@@ -18,17 +19,63 @@ import (
 var (
 	// CreateKeypairCommand performs the "create keypair" function
 	CreateKeypairCommand = &cobra.Command{
-		Use:     "keypair",
-		Short:   "Create key pair",
-		Long:    `Creates a new key pair for a cluster`,
-		PreRunE: checkAddKeypair,
-		Run:     addKeypair,
+		Use:    "keypair",
+		Short:  "Create key pair",
+		Long:   `Creates a new key pair for a cluster`,
+		PreRun: createKeyPairPreRunOutput,
+		Run:    createKeyPairRunOutput,
 	}
 )
 
 const (
 	addKeyPairActivityName = "add-keypair"
 )
+
+// argument struct to pass to our business function and
+// to the validation function
+type createKeypairArguments struct {
+	apiEndpoint              string
+	authToken                string
+	certificateOrganizations string
+	clusterID                string
+	commonNamePrefix         string
+	description              string
+	ttlHours                 int32
+}
+
+// function to create arguments based on command line flags and config
+func defaultCreateKeypairArguments() createKeypairArguments {
+	endpoint := config.Config.ChooseEndpoint(cmdAPIEndpoint)
+	token := config.Config.ChooseToken(endpoint, cmdToken)
+
+	description := cmdDescription
+	if description == "" {
+		description = "Added by user " + config.Config.Email + " using 'gsctl create keypair'"
+	}
+
+	return createKeypairArguments{
+		apiEndpoint:              endpoint,
+		authToken:                token,
+		certificateOrganizations: cmdCertificateOrganizations,
+		clusterID:                cmdClusterID,
+		commonNamePrefix:         cmdCNPrefix,
+		description:              description,
+		ttlHours:                 int32(cmdTTLDays) * 24,
+	}
+}
+
+type createKeypairResult struct {
+	// cluster's API endpoint
+	apiEndpoint string
+	// response body returned from a successful response
+	keypairResponse gsclientgen.V4AddKeyPairResponse
+	// path where we stored the CA file
+	caCertPath string
+	// path where we stored the client cert
+	clientCertPath string
+	// path where we stored the client's private key
+	clientKeyPath string
+}
 
 func init() {
 	CreateKeypairCommand.Flags().StringVarP(&cmdClusterID, "cluster", "c", "", "ID of the cluster to create a key pair for")
@@ -42,79 +89,135 @@ func init() {
 	CreateCommand.AddCommand(CreateKeypairCommand)
 }
 
-func checkAddKeypair(cmd *cobra.Command, args []string) error {
+func createKeyPairPreRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
+	args := defaultCreateKeypairArguments()
+	err := verifyCreateKeypairPreconditions(args)
 
-	endpoint := config.Config.ChooseEndpoint(cmdAPIEndpoint)
-	token := config.Config.ChooseToken(endpoint, cmdToken)
+	if err == nil {
+		return
+	}
 
-	if endpoint == "" {
+	handleCommonErrors(err)
+
+	headline := ""
+	subtext := ""
+
+	switch {
+	case err.Error() == "":
+		return
+	default:
+		headline = err.Error()
+	}
+
+	// print error output
+	fmt.Println(color.RedString(headline))
+	if subtext != "" {
+		fmt.Println(subtext)
+	}
+	os.Exit(1)
+}
+
+func verifyCreateKeypairPreconditions(args createKeypairArguments) error {
+	if config.Config.Token == "" && args.authToken == "" {
+		return microerror.Mask(notLoggedInError)
+	}
+	if args.apiEndpoint == "" {
 		return microerror.Mask(endpointMissingError)
 	}
-	if token == "" {
-		return errors.New("You are not logged in. Use '" + config.ProgramName + " login' to log in.")
+	if args.clusterID == "" {
+		return microerror.Mask(clusterIDMissingError)
 	}
-	if cmdClusterID == "" {
-		// use default cluster if possible
-		clusterID, _ := config.GetDefaultCluster(requestIDHeader, addKeyPairActivityName, cmdLine, cmdAPIEndpoint)
-		if clusterID != "" {
-			cmdClusterID = clusterID
-		} else {
-			return errors.New("No cluster given. Please use the -c/--cluster flag to set a cluster ID.")
-		}
-	}
-	if cmdDescription == "" {
-		return errors.New("No description given. Please use the -d/--description flag to set a description.")
-	}
+
 	return nil
 }
 
-func addKeypair(cmd *cobra.Command, args []string) {
-	if cmdDescription == "" {
-		cmdDescription = "Added by user " + config.Config.Email + " using 'gsctl create keypair'"
+func createKeyPairRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
+	args := defaultCreateKeypairArguments()
+	result, err := createKeypair(args)
+
+	if err != nil {
+		handleCommonErrors(err)
+
+		var headline string
+		var subtext string
+
+		switch {
+		default:
+			headline = err.Error()
+		}
+
+		// Print error output
+		fmt.Println(color.RedString(headline))
+		if subtext != "" {
+			fmt.Println(subtext)
+		}
+		os.Exit(1)
 	}
 
-	endpoint := config.Config.ChooseEndpoint(cmdAPIEndpoint)
-	token := config.Config.ChooseToken(endpoint, cmdToken)
+	// Success output
+	msg := fmt.Sprintf("New key pair created with ID %s and expiry of %v",
+		util.Truncate(util.CleanKeypairID(result.keypairResponse.Id), 10),
+		util.DurationPhrase(int(result.keypairResponse.TtlHours)))
+	fmt.Println(color.GreenString(msg))
+
+	fmt.Println("Certificate and key files written to:")
+	fmt.Println(result.caCertPath)
+	fmt.Println(result.clientCertPath)
+	fmt.Println(result.clientKeyPath)
+}
+
+// createKeypair is our business function talking to the API to create a keypair
+// and return result or error
+func createKeypair(args createKeypairArguments) (createKeypairResult, error) {
+	result := createKeypairResult{
+		apiEndpoint: args.apiEndpoint,
+	}
 
 	clientConfig := client.Configuration{
-		Endpoint:  endpoint,
+		Endpoint:  args.apiEndpoint,
+		Timeout:   60 * time.Second,
 		UserAgent: config.UserAgent(),
 	}
 	apiClient, clientErr := client.NewClient(clientConfig)
 	if clientErr != nil {
-		fmt.Println(color.RedString("Error: %s", clientErr))
-		os.Exit(1)
+		return result, microerror.Maskf(couldNotCreateClientError, clientErr.Error())
 	}
 
-	authHeader := "giantswarm " + token
-	ttlHours := int32(cmdTTLDays * 24)
-	addKeyPairBody := gsclientgen.V4AddKeyPairBody{Description: cmdDescription, TtlHours: ttlHours, CnPrefix: cmdCNPrefix, CertificateOrganizations: cmdCertificateOrganizations}
-	keypairResponse, apiResponse, err := apiClient.AddKeyPair(authHeader, cmdClusterID, addKeyPairBody, requestIDHeader, addKeyPairActivityName, cmdLine)
+	authHeader := "giantswarm " + args.authToken
+
+	addKeyPairBody := gsclientgen.V4AddKeyPairBody{
+		Description:              args.description,
+		TtlHours:                 args.ttlHours,
+		CnPrefix:                 args.commonNamePrefix,
+		CertificateOrganizations: args.certificateOrganizations,
+	}
+	keypairResponse, apiResponse, err := apiClient.AddKeyPair(authHeader,
+		args.clusterID, addKeyPairBody, requestIDHeader,
+		addKeyPairActivityName, cmdLine)
 
 	if err != nil {
-		fmt.Println(color.RedString("Error: %s", err))
-		dumpAPIResponse(*apiResponse)
-		os.Exit(1)
+		return result, microerror.Mask(err)
 	}
 
-	if apiResponse.StatusCode == 200 {
-		msg := fmt.Sprintf("New key pair created with ID %s and expiry of %v",
-			util.Truncate(util.CleanKeypairID(keypairResponse.Id), 10),
-			util.DurationPhrase(int(keypairResponse.TtlHours)))
-		fmt.Println(color.GreenString(msg))
-
-		// store credentials to file
-		caCertPath := util.StoreCaCertificate(config.CertsDirPath, cmdClusterID, keypairResponse.CertificateAuthorityData)
-		fmt.Println("CA certificate stored in:", caCertPath)
-
-		clientCertPath := util.StoreClientCertificate(config.CertsDirPath, cmdClusterID, keypairResponse.Id, keypairResponse.ClientCertificateData)
-		fmt.Println("Client certificate stored in:", clientCertPath)
-
-		clientKeyPath := util.StoreClientKey(config.CertsDirPath, cmdClusterID, keypairResponse.Id, keypairResponse.ClientKeyData)
-		fmt.Println("Client private key stored in:", clientKeyPath)
-
-	} else {
-		fmt.Println(color.RedString("Unhandled response code: %v", apiResponse.StatusCode))
-		dumpAPIResponse(*apiResponse)
+	if apiResponse.StatusCode == http.StatusNotFound {
+		return result, microerror.Mask(clusterNotFoundError)
+	} else if apiResponse.StatusCode == http.StatusForbidden {
+		return result, microerror.Mask(accessForbiddenError)
+	} else if apiResponse.StatusCode != http.StatusOK && apiResponse.StatusCode != 201 {
+		return result, microerror.Maskf(unknownError,
+			"Unhandled response code: %v", apiResponse.StatusCode)
 	}
+
+	// success
+	result.keypairResponse = *keypairResponse
+
+	// store credentials to file
+	result.caCertPath = util.StoreCaCertificate(config.CertsDirPath,
+		args.clusterID, keypairResponse.CertificateAuthorityData)
+	result.clientCertPath = util.StoreClientCertificate(config.CertsDirPath,
+		args.clusterID, keypairResponse.Id, keypairResponse.ClientCertificateData)
+	result.clientKeyPath = util.StoreClientKey(config.CertsDirPath,
+		args.clusterID, keypairResponse.Id, keypairResponse.ClientKeyData)
+
+	return result, nil
 }

--- a/commands/create_keypair_test.go
+++ b/commands/create_keypair_test.go
@@ -32,8 +32,19 @@ func Test_CreateKeypair(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	cmdAPIEndpoint = mockServer.URL
-	cmdClusterID = "test-cluster-id"
-	checkAddKeypair(CreateKeypairCommand, []string{})
-	addKeypair(CreateKeypairCommand, []string{})
+	args := createKeypairArguments{
+		apiEndpoint: mockServer.URL,
+		clusterID:   "test-cluster-id",
+		authToken:   "test-token",
+	}
+
+	err = verifyCreateKeypairPreconditions(args)
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, err = createKeypair(args)
+	if err != nil {
+		t.Error(err)
+	}
 }

--- a/commands/create_kubeconfig.go
+++ b/commands/create_kubeconfig.go
@@ -195,7 +195,7 @@ func createKubeconfigPreRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 	args := defaultCreateKubeconfigArguments()
 	err := verifyCreateKubeconfigPreconditions(args, cmdLineArgs)
 
-	if err != nil {
+	if err == nil {
 		return
 	}
 

--- a/commands/create_kubeconfig.go
+++ b/commands/create_kubeconfig.go
@@ -390,6 +390,9 @@ func createKubeconfig(args createKubeconfigArguments) (createKubeconfigResult, e
 		createKubeconfigActivityName, cmdLine)
 
 	if err != nil {
+		if apiResponse.Response != nil && apiResponse.Response.StatusCode == http.StatusForbidden {
+			return result, microerror.Mask(accessForbiddenError)
+		}
 		return result, microerror.Mask(err)
 	}
 

--- a/commands/create_kubeconfig.go
+++ b/commands/create_kubeconfig.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"runtime"
 	"time"
@@ -194,21 +195,20 @@ func createKubeconfigPreRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 	args := defaultCreateKubeconfigArguments()
 	err := verifyCreateKubeconfigPreconditions(args, cmdLineArgs)
 
-	if err == nil {
+	if err != nil {
 		return
 	}
 
-	headline := ""
-	subtext := ""
+	handleCommonErrors(err)
+
+	var headline string
+	var subtext string
 
 	switch {
 	case err.Error() == "":
 		return
 	case IsCommandAbortedError(err):
 		headline = "File not overwritten, no kubeconfig created."
-	case IsNotLoggedInError(err):
-		headline = "You are not logged in."
-		subtext = fmt.Sprintf("Use '%s login' to login or '--auth-token' to pass a valid auth token.", config.ProgramName)
 	case IsKubectlMissingError(err):
 		headline = "kubectl is not installed"
 		if runtime.GOOS == "darwin" {
@@ -219,9 +219,6 @@ func createKubeconfigPreRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 		} else if runtime.GOOS == "windows" {
 			subtext = fmt.Sprintf("Please visit %s to download a recent kubectl binary.", kubectlWindowsInstallURL)
 		}
-	case IsClusterIDMissingError(err):
-		headline = "No cluster specified"
-		subtext = "Please use the --cluster or -c flag to indicate a cluster ID. Use --help for details."
 	default:
 		headline = err.Error()
 	}
@@ -272,14 +269,12 @@ func createKubeconfigRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 	result, err := createKubeconfig(args)
 
 	if err != nil {
+		handleCommonErrors(err)
 
-		headline := ""
-		subtext := ""
+		var headline string
+		var subtext string
 
 		switch {
-		case IsCouldNotCreateClientError(err):
-			headline = "Failed to create API client."
-			subtext = "Details: " + err.Error()
 		case util.IsCouldNotSetKubectlClusterError(err):
 			headline = "Error: " + err.Error()
 			subtext = "API endpoint would be: " + result.apiEndpoint
@@ -341,6 +336,8 @@ func createKubeconfigRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 	}
 }
 
+// createKubeconfig is our business function talking to the API to create a keypair
+// and creating a new kubectl context
 func createKubeconfig(args createKubeconfigArguments) (createKubeconfigResult, error) {
 	result := createKubeconfigResult{}
 
@@ -396,10 +393,12 @@ func createKubeconfig(args createKubeconfigArguments) (createKubeconfigResult, e
 		return result, microerror.Mask(err)
 	}
 
-	if apiResponse.StatusCode == 404 {
+	if apiResponse.StatusCode == http.StatusNotFound {
 		// cluster not found
 		return result, microerror.Mask(clusterNotFoundError)
-	} else if apiResponse.StatusCode != 200 && apiResponse.StatusCode != 201 {
+	} else if apiResponse.StatusCode == http.StatusForbidden {
+		return result, microerror.Mask(accessForbiddenError)
+	} else if apiResponse.StatusCode != http.StatusOK && apiResponse.StatusCode != 201 {
 		return result, microerror.Maskf(unknownError,
 			fmt.Sprintf("Unhandled response code: %v", apiResponse.StatusCode))
 	}

--- a/commands/delete_cluster_test.go
+++ b/commands/delete_cluster_test.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -30,11 +29,11 @@ func TestDeleteClusterSuccess(t *testing.T) {
 	for i, testCase := range testCases {
 		validateErr := validateDeleteClusterPreConditions(testCase)
 		if validateErr != nil {
-			t.Error(fmt.Sprintf("Validation error in testCase %v: %s", i, validateErr.Error()))
+			t.Errorf("Validation error in testCase %v: %s", i, validateErr.Error())
 		} else {
 			_, execErr := deleteCluster(testCase)
 			if execErr != nil {
-				t.Error(fmt.Sprintf("Execution error in testCase %v: %s", i, execErr.Error()))
+				t.Errorf("Execution error in testCase %v: %s", i, execErr.Error())
 			}
 		}
 	}

--- a/commands/error.go
+++ b/commands/error.go
@@ -256,6 +256,15 @@ func IsNoEmailArgumentGivenError(err error) bool {
 	return errgo.Cause(err) == noEmailArgumentGivenError
 }
 
+// accessForbiddenError means the client has been denied access to the API endpoint
+// with a HTTP 403 error
+var accessForbiddenError = errgo.New("access forbidden")
+
+// IsAccessForbiddenError asserts accessForbiddenError
+func IsAccessForbiddenError(err error) bool {
+	return errgo.Cause(err) == accessForbiddenError
+}
+
 // invalidCredentialsError means the user's credentials could not be verified
 // by the API
 var invalidCredentialsError = errgo.New("invalid credentials submitted")

--- a/commands/list_clusters.go
+++ b/commands/list_clusters.go
@@ -1,8 +1,8 @@
 package commands
 
 import (
-	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -21,11 +21,11 @@ import (
 var (
 	// ListClustersCommand performs the "list clusters" function
 	ListClustersCommand = &cobra.Command{
-		Use:     "clusters",
-		Short:   "List clusters",
-		Long:    `Prints a list of all clusters you have access to`,
-		PreRunE: checkListClusters,
-		Run:     listClusters,
+		Use:    "clusters",
+		Short:  "List clusters",
+		Long:   `Prints a list of all clusters you have access to`,
+		PreRun: listClusterPreRunOutput,
+		Run:    listClusterRunOutput,
 	}
 )
 
@@ -33,39 +33,71 @@ const (
 	listClustersActivityName = "list-clusters"
 )
 
+type listClustersArguments struct {
+	apiEndpoint string
+	authToken   string
+}
+
+func defaultListClustersArguments() listClustersArguments {
+	endpoint := config.Config.ChooseEndpoint(cmdAPIEndpoint)
+	token := config.Config.ChooseToken(endpoint, cmdToken)
+
+	return listClustersArguments{
+		apiEndpoint: endpoint,
+		authToken:   token,
+	}
+}
+
 func init() {
 	ListCommand.AddCommand(ListClustersCommand)
 }
 
-func checkListClusters(cmd *cobra.Command, args []string) error {
-	if config.Config.Token == "" {
-		return errors.New("You are not logged in. Use '" + config.ProgramName + " login' to log in.")
+func listClusterPreRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
+	args := defaultListClustersArguments()
+	err := verifyListClusterPreconditions(args)
+
+	if err == nil {
+		return
 	}
+
+	handleCommonErrors(err)
+}
+
+func verifyListClusterPreconditions(args listClustersArguments) error {
+	if config.Config.Token == "" && args.authToken == "" {
+		return microerror.Mask(notLoggedInError)
+	}
+	if args.apiEndpoint == "" {
+		return microerror.Mask(endpointMissingError)
+	}
+
 	return nil
 }
 
 // listClusters prints a table with all clusters the user has access to
-func listClusters(cmd *cobra.Command, args []string) {
-	output, err := clustersTable()
+func listClusterRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
+	args := defaultListClustersArguments()
+
+	output, err := clustersTable(args)
 	if err != nil {
+		handleCommonErrors(err)
+
 		fmt.Println(color.RedString("Error: %s", err))
 		if _, ok := err.(APIError); ok {
 			dumpAPIResponse((err).(APIError).APIResponse)
 		}
 		os.Exit(1)
 	}
+
 	if output != "" {
 		fmt.Println(output)
 	}
 }
 
 // clustersTable returns a table of clusters the user has access to
-func clustersTable() (string, error) {
-	endpoint := config.Config.ChooseEndpoint(cmdAPIEndpoint)
-	token := config.Config.ChooseToken(endpoint, cmdToken)
-
+func clustersTable(args listClustersArguments) (string, error) {
 	clientConfig := client.Configuration{
-		Endpoint:  endpoint,
+		Endpoint:  args.apiEndpoint,
 		Timeout:   5 * time.Second,
 		UserAgent: config.UserAgent(),
 	}
@@ -73,11 +105,14 @@ func clustersTable() (string, error) {
 	if clientErr != nil {
 		return "", microerror.Mask(couldNotCreateClientError)
 	}
-	authHeader := "giantswarm " + token
+	authHeader := "giantswarm " + args.authToken
 
 	clusters, apiResponse, err := apiClient.GetClusters(authHeader,
 		requestIDHeader, listClustersActivityName, cmdLine)
 	if err != nil {
+		if apiResponse.Response != nil && apiResponse.Response.StatusCode == http.StatusForbidden {
+			return "", microerror.Mask(accessForbiddenError)
+		}
 		return "", APIError{err.Error(), *apiResponse}
 	}
 

--- a/commands/list_clusters_test.go
+++ b/commands/list_clusters_test.go
@@ -99,6 +99,6 @@ func Test_ListClustersEmpty(t *testing.T) {
 	}
 
 	if table != "" {
-		t.Error("Expected '', got '%s'", table)
+		t.Errorf("Expected '', got '%s'", table)
 	}
 }

--- a/commands/list_clusters_test.go
+++ b/commands/list_clusters_test.go
@@ -56,16 +56,22 @@ func Test_ListClusters(t *testing.T) {
 	}))
 	defer mockServer.Close()
 
-	cmdAPIEndpoint = mockServer.URL
-	checkListClusters(ListClustersCommand, []string{})
+	args := listClustersArguments{
+		apiEndpoint: mockServer.URL,
+		authToken:   "testtoken",
+	}
 
-	table, err := clustersTable()
+	err := verifyListClusterPreconditions(args)
+	if err != nil {
+		t.Error(err)
+	}
+
+	table, err := clustersTable(args)
 	if err != nil {
 		t.Error(err)
 	}
 
 	t.Log(table)
-	listClusters(ListClustersCommand, []string{})
 }
 
 // Test_ListClustersEmpty tests listing an empty cluster table
@@ -77,14 +83,22 @@ func Test_ListClustersEmpty(t *testing.T) {
 	}))
 	defer mockServer.Close()
 
-	cmdAPIEndpoint = mockServer.URL
-	checkListClusters(ListClustersCommand, []string{})
+	args := listClustersArguments{
+		apiEndpoint: mockServer.URL,
+		authToken:   "testtoken",
+	}
 
-	table, err := clustersTable()
+	err := verifyListClusterPreconditions(args)
 	if err != nil {
 		t.Error(err)
 	}
 
-	t.Log(table)
-	listClusters(ListClustersCommand, []string{})
+	table, err := clustersTable(args)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if table != "" {
+		t.Error("Expected '', got '%s'", table)
+	}
 }

--- a/commands/list_keypairs.go
+++ b/commands/list_keypairs.go
@@ -74,25 +74,9 @@ func listKeypairsValidationOutput(cmd *cobra.Command, extraArgs []string) {
 	args := defaultListKeypairsArguments()
 	err := listKeypairsValidate(&args)
 	if err != nil {
-		var headline string
-		var subtext string
+		handleCommonErrors(err)
 
-		switch {
-		case IsNotLoggedInError(err):
-			headline = "You are not logged in."
-			subtext = "Please log in using 'gsctl login <email>' or set an auth token as a command line argument."
-			subtext += " See `gsctl list keypairs --help` for details."
-		case IsClusterIDMissingError(err):
-			headline = "No cluster ID specified."
-			subtext = "Please specify which cluster to list key pairs for, by using the '-c' or '--cluster' argument."
-		default:
-			headline = err.Error()
-		}
-
-		fmt.Println(color.RedString(headline))
-		if subtext != "" {
-			fmt.Println(subtext)
-		}
+		fmt.Println(color.RedString(err.Error()))
 		os.Exit(1)
 	}
 }
@@ -127,29 +111,15 @@ func listKeypairsOutput(cmd *cobra.Command, extraArgs []string) {
 
 	// error output
 	if err != nil {
+		handleCommonErrors(err)
+
 		var headline string
 		var subtext string
 
 		switch {
-		case IsNotLoggedInError(err):
-			headline = "You are not logged in."
-			subtext = "Please log in using 'gsctl login <email>' or set an auth token as a command line argument."
-			subtext += " See `gsctl list keypairs --help` for details."
-		case IsClusterIDMissingError(err):
-			headline = "No cluster ID specified."
-			subtext = "Please specify which cluster to list key pairs for, by using the '-c' or '--cluster' argument."
-		case IsNotAuthorizedError(err):
-			headline = "You are not authorized for this cluster."
-			subtext = "You have no permission to access key pairs for this cluster. Please check your credentials."
 		case IsClusterNotFoundError(err):
 			headline = "The cluster does not exist."
 			subtext = fmt.Sprintf("We couldn't find a cluster with the ID '%s' via API endpoint %s.", args.clusterID, args.apiEndpoint)
-		case IsInternalServerError(err):
-			headline = "An internal error occurred."
-			subtext = "Please notify the Giant Swarm support team, or try listing key pairs again in a few moments."
-		case IsUnknownError(err):
-			headline = "An error occurred."
-			subtext = "Please notify the Giant Swarm support team, or try listing key pairs again in a few moments."
 		default:
 			headline = err.Error()
 		}

--- a/commands/list_releases.go
+++ b/commands/list_releases.go
@@ -70,22 +70,9 @@ func listReleasesValidationOutput(cmd *cobra.Command, extraArgs []string) {
 	args := defaultListReleasesArguments()
 	err := listReleasesValidate(&args)
 	if err != nil {
-		var headline string
-		var subtext string
+		handleCommonErrors(err)
 
-		switch {
-		case IsNotLoggedInError(err):
-			headline = "You are not logged in."
-			subtext = "Please log in using 'gsctl login <email>' or set an auth token as a command line argument."
-			subtext += " See `gsctl list releases --help` for details."
-		default:
-			headline = err.Error()
-		}
-
-		fmt.Println(color.RedString(headline))
-		if subtext != "" {
-			fmt.Println(subtext)
-		}
+		fmt.Println(color.RedString(err.Error()))
 		os.Exit(1)
 	}
 }
@@ -108,34 +95,11 @@ func listReleasesOutput(cmd *cobra.Command, extraArgs []string) {
 
 	// error output
 	if err != nil {
-		var headline string
-		var subtext string
+		handleCommonErrors(err)
 
-		switch {
-		case IsNotLoggedInError(err):
-			headline = "You are not logged in."
-			subtext = "Please log in using 'gsctl login <email>' or set an auth token as a command line argument."
-			subtext += " See `gsctl list releases --help` for details."
-		case IsNotAuthorizedError(err):
-			headline = "You are not authorized for this cluster."
-			subtext = "You have no permission to access releases for this cluster. Please check your credentials."
-		case IsInternalServerError(err):
-			headline = "An internal error occurred."
-			subtext = "Please notify the Giant Swarm support team, or try listing releases again in a few moments."
-		case IsNoResponseError(err):
-			headline = "The API didn't send a response."
-			subtext = "Please notify the Giant Swarm support team, or try listing releases again in a few moments."
-		case IsUnknownError(err):
-			headline = "An error occurred."
-			subtext = "Please notify the Giant Swarm support team, or try listing releases again in a few moments."
-		default:
-			headline = err.Error()
-		}
+		var headline = err.Error()
 
 		fmt.Println(color.RedString(headline))
-		if subtext != "" {
-			fmt.Println(subtext)
-		}
 		os.Exit(1)
 	}
 

--- a/commands/login.go
+++ b/commands/login.go
@@ -91,30 +91,33 @@ func init() {
 func loginPreRunOutput(cmd *cobra.Command, positionalArgs []string) {
 	err := verifyLoginPreconditions(positionalArgs)
 
-	if err != nil {
-		var headline = ""
-		var subtext = ""
-		switch {
-		case err.Error() == "":
-			return
-		case IsNoEmailArgumentGivenError(err):
-			headline = "The email argument is required."
-			subtext = "Please execute the command as 'gsctl login <email>'. See 'gsctl login --help' for details."
-		case IsTokenArgumentNotApplicableError(err):
-			headline = "The '--auth-token' flag cannot be used with the 'gsctl login' command."
-		case IsEmptyPasswordError(err):
-			headline = "The password cannot be empty."
-			subtext = "Please call the command again and enter a non-empty password. See 'gsctl login --help' for details."
-		default:
-			headline = err.Error()
-		}
-
-		fmt.Println(color.RedString(headline))
-		if subtext != "" {
-			fmt.Println(subtext)
-		}
-		os.Exit(1)
+	if err == nil {
+		return
 	}
+
+	var headline = ""
+	var subtext = ""
+
+	switch {
+	case err.Error() == "":
+		return
+	case IsNoEmailArgumentGivenError(err):
+		headline = "The email argument is required."
+		subtext = "Please execute the command as 'gsctl login <email>'. See 'gsctl login --help' for details."
+	case IsTokenArgumentNotApplicableError(err):
+		headline = "The '--auth-token' flag cannot be used with the 'gsctl login' command."
+	case IsEmptyPasswordError(err):
+		headline = "The password cannot be empty."
+		subtext = "Please call the command again and enter a non-empty password. See 'gsctl login --help' for details."
+	default:
+		headline = err.Error()
+	}
+
+	fmt.Println(color.RedString(headline))
+	if subtext != "" {
+		fmt.Println(subtext)
+	}
+	os.Exit(1)
 }
 
 // verifyLoginPreconditions does the pre-checks and returns an error in case something's wrong.

--- a/commands/scale_cluster.go
+++ b/commands/scale_cluster.go
@@ -104,27 +104,11 @@ func scaleClusterPreRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 	args := defaultScaleClusterArguments()
 	err := verifyScaleClusterPreconditions(args, cmdLineArgs)
 	if err != nil {
-		var headline = ""
-		var subtext = ""
 
-		switch {
-		case err.Error() == "":
-			return
-		case IsNotLoggedInError(err):
-			headline = "You are not logged in."
-			subtext = fmt.Sprintf("Use '%s login' to login or '--auth-token' to pass a valid auth token.", config.ProgramName)
-		case IsClusterIDMissingError(err):
-			headline = "No cluster ID specified."
-			subtext = "Please specify which cluster to scale. Use --help for details."
-		default:
-			headline = err.Error()
-		}
+		handleCommonErrors(err)
 
-		// print output
-		fmt.Println(color.RedString(headline))
-		if subtext != "" {
-			fmt.Println(subtext)
-		}
+		// print non-common error
+		fmt.Println(color.RedString(err.Error()))
 		os.Exit(1)
 	}
 }
@@ -147,6 +131,8 @@ func scaleClusterRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 
 	result, err := scaleCluster(args)
 	if err != nil {
+		handleCommonErrors(err)
+
 		var headline = ""
 		var subtext = ""
 
@@ -155,9 +141,6 @@ func scaleClusterRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 			return
 		case IsCommandAbortedError(err):
 			headline = "Scaling cancelled."
-		case IsCouldNotCreateClientError(err):
-			headline = "Failed to create API client."
-			subtext = "Details: " + err.Error()
 		case IsCannotScaleBelowMinimumWorkersError(err):
 			headline = "Desired worker node count is too low."
 			subtext = "Please set the -w|--num-workers flag to a value greater than 0."
@@ -275,6 +258,18 @@ func scaleCluster(args scaleClusterArguments) (scaleClusterResults, error) {
 	}
 	scaleResult, rawResponse, err := apiClient.ModifyCluster(authHeader, args.clusterID, reqBody, requestIDHeader, scaleClusterActivityName, cmdLine)
 	if err != nil {
+		if rawResponse == nil || rawResponse.Response == nil {
+			return results, microerror.Mask(noResponseError)
+		}
+
+		if rawResponse.StatusCode == http.StatusForbidden {
+			return results, microerror.Mask(accessForbiddenError)
+		}
+
+		if rawResponse.StatusCode == http.StatusNotFound {
+			return results, microerror.Mask(clusterNotFoundError)
+		}
+
 		return results, microerror.Mask(err)
 	}
 

--- a/commands/scale_cluster.go
+++ b/commands/scale_cluster.go
@@ -103,14 +103,16 @@ func init() {
 func scaleClusterPreRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 	args := defaultScaleClusterArguments()
 	err := verifyScaleClusterPreconditions(args, cmdLineArgs)
-	if err != nil {
 
-		handleCommonErrors(err)
-
-		// print non-common error
-		fmt.Println(color.RedString(err.Error()))
-		os.Exit(1)
+	if err == nil {
+		return
 	}
+
+	handleCommonErrors(err)
+
+	// print non-common error
+	fmt.Println(color.RedString(err.Error()))
+	os.Exit(1)
 }
 
 // verifyScaleClusterPreconditions does a few general checks and returns an error in case something is missing.

--- a/commands/select_endpoint.go
+++ b/commands/select_endpoint.go
@@ -38,27 +38,30 @@ func init() {
 // shows output and exits.
 func selectEndpointPreRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 	err := verifySelectEndpointPreconditions(cmdLineArgs)
-	if err != nil {
-		var headline string
-		var subtext string
 
-		switch {
-		case err.Error() == "":
-			headline = "Unknown error."
-		case IsEndpointMissingError(err):
-			headline = "No endpoint specified."
-			subtext = "Please give an endpoint URL to use. Use --help for details."
-		default:
-			headline = err.Error()
-		}
-
-		// print output
-		fmt.Println(color.RedString(headline))
-		if subtext != "" {
-			fmt.Println(subtext)
-		}
-		os.Exit(1)
+	if err == nil {
+		return
 	}
+
+	var headline string
+	var subtext string
+
+	switch {
+	case err.Error() == "":
+		headline = "Unknown error."
+	case IsEndpointMissingError(err):
+		headline = "No endpoint specified."
+		subtext = "Please give an endpoint URL to use. Use --help for details."
+	default:
+		headline = err.Error()
+	}
+
+	// print output
+	fmt.Println(color.RedString(headline))
+	if subtext != "" {
+		fmt.Println(subtext)
+	}
+	os.Exit(1)
 }
 
 func verifySelectEndpointPreconditions(cmdLineArgs []string) error {

--- a/commands/select_endpoint.go
+++ b/commands/select_endpoint.go
@@ -39,8 +39,8 @@ func init() {
 func selectEndpointPreRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 	err := verifySelectEndpointPreconditions(cmdLineArgs)
 	if err != nil {
-		headline := ""
-		subtext := ""
+		var headline string
+		var subtext string
 
 		switch {
 		case err.Error() == "":

--- a/commands/show_cluster.go
+++ b/commands/show_cluster.go
@@ -67,13 +67,16 @@ func init() {
 func showClusterPreRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 	args := defaultShowClusterArguments()
 	err := verifyShowClusterPreconditions(args, cmdLineArgs)
-	if err != nil {
-		handleCommonErrors(err)
 
-		// handle non-common errors
-		fmt.Println(color.RedString(err.Error()))
-		os.Exit(1)
+	if err == nil {
+		return
 	}
+
+	handleCommonErrors(err)
+
+	// handle non-common errors
+	fmt.Println(color.RedString(err.Error()))
+	os.Exit(1)
 }
 
 func verifyShowClusterPreconditions(args showClusterArguments, cmdLineArgs []string) error {

--- a/docs/Command-Blueprint.md
+++ b/docs/Command-Blueprint.md
@@ -85,15 +85,20 @@ func verbNounPreRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
     return
   }
 
+  // Handles many errors that can occur in validation and execution,
+  // e. g. user not logged in.
+  handleCommonErrors(err)
+
+  // From here on we handle errors that can only occur in this command
 	headline := ""
 	subtext := ""
 
 	switch {
 	case err.Error() == "":
 		return
-	case IsNotLoggedInError(err):
-		headline = "You are not logged in."
-		subtext = fmt.Sprintf("Use '%s login' to login or '--auth-token' to pass a valid auth token.", config.ProgramName)
+	case IsVerySpecificError(err):
+		headline = "Some very specific error occurred."
+		subtext = "Something happened that can only happen in this command."
 	default:
 		headline = err.Error()
 	}
@@ -122,15 +127,17 @@ func verbNounRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 	result, err := verbNoun()
 
 	if err != nil {
+    handleCommonErrors(err)
+
 		var headline = ""
 		var subtext = ""
 
 		switch {
 		case err.Error() == "":
 			return
-		case IsCouldNotCreateClientError(err):
-			headline = "Failed to create API client."
-			subtext = "Details: " + err.Error()
+		case IsVerySpecificError(err):
+      headline = "Some very specific error occurred."
+  		subtext = "Something happened that can only happen in this command."
 		default:
 			headline = err.Error()
 		}

--- a/docs/Command-Blueprint.md
+++ b/docs/Command-Blueprint.md
@@ -162,39 +162,41 @@ func verbNounRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 
 // verbNoun performs our actual function. It usually creates an API client,
 // configures it, configures an API request and performs it.
+// verbNoun performs our actual function. It usually creates an API client,
+// configures it, configures an API request and performs it.
 func verbNoun(args verbNoundArguments) (verbNounResult, error) {
-  result := verbNounResult{}
+	result := verbNounResult{}
 
-  // prepare client
-  clientConfig := client.Configuration{
+	// prepare client
+	clientConfig := client.Configuration{
 		Endpoint:  args.apiEndpoint,
 		Timeout:   10 * time.Second,
 		UserAgent: config.UserAgent(),
 	}
-  apiClient, clientErr := client.NewClient(clientConfig)
+	apiClient, clientErr := client.NewClient(clientConfig)
 	if clientErr != nil {
 		return result, microerror.Mask(couldNotCreateClientError)
 	}
 
-  authHeader := "giantswarm " + args.token
+	authHeader := "giantswarm " + args.token
 	someResponse, rawResponse, err := apiClient.DoSomething(authHeader,
 		requestIDHeader, verbNounActivityName, cmdLine)
 
-  if rawResponse == nil || rawResponse.Response == nil {
-    return result, microerror.Mask(noResponseError)
-  }
+	if rawResponse == nil || rawResponse.Response == nil {
+		return result, microerror.Mask(noResponseError)
+	}
 
-  // handle request errors
-  if err != nil {
+	// handle request errors
+	if err != nil {
 
-    switch rawResponse.StatusCode {
-    case http.StatusNotFound:
-      return result, microerror.Mask(clusterNotFoundError)
-    case http.StatusUnauthorized:
-      return result, microerror.Mask(notAuthorizedError)
-    case http.StatusForbidden:
-      return result, microerror.Mask(accessForbiddenError)
-    }
+		switch rawResponse.StatusCode {
+		case http.StatusNotFound:
+			return result, microerror.Mask(clusterNotFoundError)
+		case http.StatusUnauthorized:
+			return result, microerror.Mask(notAuthorizedError)
+		case http.StatusForbidden:
+			return result, microerror.Mask(accessForbiddenError)
+		}
 
 		if rawResponse.StatusCode >= 500 {
 			return result, microerror.Maskf(internalServerError, err.Error())
@@ -203,9 +205,9 @@ func verbNoun(args verbNoundArguments) (verbNounResult, error) {
 		return result, microerror.Mask(err)
 	}
 
-  // populate result base on some response information etc.
-  result.someAttribute = someResponse.someValue
+	// populate result base on some response information etc.
+	result.someAttribute = someResponse.someValue
 
-  return result, nil
+	return result, nil
 }
 ```


### PR DESCRIPTION
For https://github.com/giantswarm/gsctl/issues/196

Preview:

```
$ gsctl login dev@example.io
Password for dev@example.io on <endpoint>:
Access Forbidden
The client has been denied access to the API endpoint with an HTTP status of 403.
Please make sure that you are in the right network or VPN. Once that is verified,
check back with Giant Swarm support that your network is permitted access.
```

### Commands touched:

- `create cluster`
  - move out handling of common errors
  - handle 403 forbidden error
- `create kubeconfig`
  - move out handling of common errors
  - handle 403 forbidden error
- `create keypair`
  - refactored to match command blueprint, applied structure according to `create kubeconfig`
  - applied same client timeout as for `create kubeconfig`
  - handle 403 Forbidden error
- `delete cluster`
  - move out handling of common errors
  - handle 403 forbidden error
- `list keypairs`
  - move out handling of common errors
  - handle 403 forbidden error
- `login`:
  - move out handling of common errors
  - handle 403 forbidden error
- `logout`
  - handle 403 forbidden error
- `ping`
  - move out handling of common errors
  - handle 403 forbidden error
- `scale cluster`
  - move out handling of common errors
  - handle 403 forbidden error