### PR TITLE
Fix list releases panic

### DIFF
--- a/commands/list_releases.go
+++ b/commands/list_releases.go
@@ -31,8 +31,8 @@ var (
 		Long: `Prints detail on all available releases.
 
 A release is a software bundle that constitutes a cluster. It is identified by its semantic version number.`,
-		PreRun: listReleasesValidationOutput,
-		Run:    listReleasesOutput,
+		PreRun: listReleasesPreRunOutput,
+		Run:    listReleasesRunOutput,
 	}
 )
 
@@ -64,22 +64,25 @@ func init() {
 	ListCommand.AddCommand(ListReleasesCommand)
 }
 
-// listReleasesValidationOutput does our pre-checks and shows errors, in case
+// listReleasesPreRunOutput does our pre-checks and shows errors, in case
 // something is missing.
-func listReleasesValidationOutput(cmd *cobra.Command, extraArgs []string) {
+func listReleasesPreRunOutput(cmd *cobra.Command, extraArgs []string) {
 	args := defaultListReleasesArguments()
-	err := listReleasesValidate(&args)
-	if err != nil {
-		handleCommonErrors(err)
+	err := listReleasesPreconditions(&args)
 
-		fmt.Println(color.RedString(err.Error()))
-		os.Exit(1)
+	if err == nil {
+		return
 	}
+
+	handleCommonErrors(err)
+
+	fmt.Println(color.RedString(err.Error()))
+	os.Exit(1)
 }
 
-// listReleasesValidate validates our pre-conditions and returns an error in
+// listReleasesPreconditions validates our pre-conditions and returns an error in
 // case something is missing.
-func listReleasesValidate(args *listReleasesArguments) error {
+func listReleasesPreconditions(args *listReleasesArguments) error {
 	if config.Config.Token == "" && args.token == "" {
 		return microerror.Mask(notLoggedInError)
 	}
@@ -87,9 +90,9 @@ func listReleasesValidate(args *listReleasesArguments) error {
 	return nil
 }
 
-// listReleasesOutput is the function called to list releases and display
+// listReleasesRunOutput is the function called to list releases and display
 // errors in case they happen
-func listReleasesOutput(cmd *cobra.Command, extraArgs []string) {
+func listReleasesRunOutput(cmd *cobra.Command, extraArgs []string) {
 	args := defaultListReleasesArguments()
 	result, err := listReleases(args)
 

--- a/commands/list_releases_test.go
+++ b/commands/list_releases_test.go
@@ -43,6 +43,31 @@ func Test_ListReleases_Empty(t *testing.T) {
 	}
 }
 
+// Test_ListReleases_Connection_Unavailable simulates the situation where we
+// cannot reach the endpoint
+func Test_ListReleases_Connection_Unavailable(t *testing.T) {
+	dir, err := tempConfig("")
+	if err != nil {
+		t.Error(err)
+	}
+	defer os.RemoveAll(dir)
+
+	// needed to prevent search for the default cluster
+	args := listReleasesArguments{}
+	args.apiEndpoint = "http://localhost:45454"
+	args.token = "my-token"
+
+	err = listReleasesPreconditions(&args)
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, listErr := listReleases(args)
+	if !IsNoResponseError(listErr) {
+		t.Errorf("Expected noResponseError, got '%s'", listErr)
+	}
+}
+
 // Test_ListReleases_NotFound simulates the situation where the cluster
 // to list releases for is not found
 func Test_ListReleases_NotFound(t *testing.T) {

--- a/commands/list_releases_test.go
+++ b/commands/list_releases_test.go
@@ -29,7 +29,7 @@ func Test_ListReleases_Empty(t *testing.T) {
 	args.apiEndpoint = releasesMockServer.URL
 	args.token = "my-token"
 
-	err = listReleasesValidate(&args)
+	err = listReleasesPreconditions(&args)
 	if err != nil {
 		t.Error(err)
 	}
@@ -63,7 +63,7 @@ func Test_ListReleases_NotFound(t *testing.T) {
 	args.apiEndpoint = releasesMockServer.URL
 	args.token = "my-token"
 
-	err = listReleasesValidate(&args)
+	err = listReleasesPreconditions(&args)
 	if err != nil {
 		t.Error(err)
 	}
@@ -221,7 +221,7 @@ func Test_ListReleases_Nonempty(t *testing.T) {
 	args.apiEndpoint = releasesMockServer.URL
 	args.token = "my-token"
 
-	err = listReleasesValidate(&args)
+	err = listReleasesPreconditions(&args)
 	if err != nil {
 		t.Error(err)
 	}

--- a/commands/list_releases_test.go
+++ b/commands/list_releases_test.go
@@ -25,9 +25,10 @@ func Test_ListReleases_Empty(t *testing.T) {
 	defer releasesMockServer.Close()
 
 	// needed to prevent search for the default cluster
-	args := listReleasesArguments{}
-	args.apiEndpoint = releasesMockServer.URL
-	args.token = "my-token"
+	args := listReleasesArguments{
+		apiEndpoint: releasesMockServer.URL,
+		token:       "my-token",
+	}
 
 	err = listReleasesPreconditions(&args)
 	if err != nil {
@@ -53,9 +54,10 @@ func Test_ListReleases_Connection_Unavailable(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	// needed to prevent search for the default cluster
-	args := listReleasesArguments{}
-	args.apiEndpoint = "http://localhost:45454"
-	args.token = "my-token"
+	args := listReleasesArguments{
+		apiEndpoint: "http://localhost:45454",
+		token:       "my-token",
+	}
 
 	err = listReleasesPreconditions(&args)
 	if err != nil {
@@ -84,9 +86,10 @@ func Test_ListReleases_NotFound(t *testing.T) {
 	}))
 	defer releasesMockServer.Close()
 
-	args := listReleasesArguments{}
-	args.apiEndpoint = releasesMockServer.URL
-	args.token = "my-token"
+	args := listReleasesArguments{
+		apiEndpoint: releasesMockServer.URL,
+		token:       "my-token",
+	}
 
 	err = listReleasesPreconditions(&args)
 	if err != nil {
@@ -242,9 +245,10 @@ func Test_ListReleases_Nonempty(t *testing.T) {
 	}))
 	defer releasesMockServer.Close()
 
-	args := listReleasesArguments{}
-	args.apiEndpoint = releasesMockServer.URL
-	args.token = "my-token"
+	args := listReleasesArguments{
+		apiEndpoint: releasesMockServer.URL,
+		token:       "my-token",
+	}
 
 	err = listReleasesPreconditions(&args)
 	if err != nil {


### PR DESCRIPTION
Ensure that https://github.com/giantswarm/gsctl/issues/181 is fixed

This adds a test that shows the panic is not occuring.

In case the API endpoint is not responding, a user now sees

```
$ gsctl list releases
The API didn't send a response.
Please check your connection using 'gsctl ping'. If your connection is fine,
please try again in a few moments.
```