### PR TITLE
show release version when listing clusters

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -41,7 +41,7 @@
   branch = "master"
   name = "github.com/giantswarm/gsclientgen"
   packages = ["."]
-  revision = "4ce48ca368d3bc16a0e6e7619bd207a39d0c2902"
+  revision = "39bc522c6c6fdd85654480e260a887117b3771ec"
 
 [[projects]]
   branch = "master"
@@ -113,7 +113,7 @@
   branch = "master"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
-  revision = "91a49db82a88618983a78a06c1cbd4e00ab749ab"
+  revision = "85f98707c97e11569271e4d9b3d397e079c4f4d0"
 
 [[projects]]
   branch = "master"

--- a/commands/list_clusters.go
+++ b/commands/list_clusters.go
@@ -135,11 +135,16 @@ func clustersTable(args listClustersArguments) (string, error) {
 
 	for _, cluster := range clusters {
 		created := util.ShortDate(util.ParseDate(cluster.CreateDate))
+		releaseVersion := cluster.ReleaseVersion
+		if releaseVersion == "" {
+			releaseVersion = "n/a"
+		}
+
 		output = append(output, strings.Join([]string{
 			cluster.Id,
 			cluster.Owner,
 			cluster.Name,
-			cluster.ReleaseVersion,
+			releaseVersion,
 			created,
 		}, "|"))
 	}

--- a/commands/list_clusters.go
+++ b/commands/list_clusters.go
@@ -124,6 +124,7 @@ func clustersTable(args listClustersArguments) (string, error) {
 		color.CyanString("ID"),
 		color.CyanString("ORGANIZATION"),
 		color.CyanString("NAME"),
+		color.CyanString("RELEASE"),
 		color.CyanString("CREATED"),
 	}, "|")}
 
@@ -138,6 +139,7 @@ func clustersTable(args listClustersArguments) (string, error) {
 			cluster.Id,
 			cluster.Owner,
 			cluster.Name,
+			cluster.ReleaseVersion,
 			created,
 		}, "|"))
 	}

--- a/vendor/github.com/giantswarm/gsclientgen/v4_cluster_list_item.go
+++ b/vendor/github.com/giantswarm/gsclientgen/v4_cluster_list_item.go
@@ -23,4 +23,7 @@ type V4ClusterListItem struct {
 
 	// Name of the organization owning the cluster
 	Owner string `json:"owner,omitempty"`
+
+	// The semantic version number of this cluster
+	ReleaseVersion string `json:"release_version,omitempty"`
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/2760. This is successfully tested on `gauss`. 

```
$ gsctl list clusters
ID     ORGANIZATION  NAME                     RELEASE  CREATED
omq8y  giantswarm    Timo: first update test  3.1.1    2018 Mar 07, 13:45 UTC
```