### PR TITLE
Fix possible nil pointer dereference in "create kubeconfig"

### DIFF
--- a/commands/create_kubeconfig.go
+++ b/commands/create_kubeconfig.go
@@ -362,7 +362,7 @@ func createKubeconfig(args createKubeconfigArguments) (createKubeconfigResult, e
 		cmdLine)
 	if err != nil {
 		var errorMessage string
-		if apiResponse != nil {
+		if apiResponse != nil && apiResponse.StatusCode != nil {
 			errorMessage = fmt.Sprintf("HTTP status: %d", apiResponse.StatusCode)
 		} else {
 			errorMessage = "No response received from the API"

--- a/commands/create_kubeconfig.go
+++ b/commands/create_kubeconfig.go
@@ -362,7 +362,7 @@ func createKubeconfig(args createKubeconfigArguments) (createKubeconfigResult, e
 		cmdLine)
 	if err != nil {
 		var errorMessage string
-		if apiResponse != nil && apiResponse.StatusCode != nil {
+		if apiResponse != nil && apiResponse.Response != nil {
 			errorMessage = fmt.Sprintf("HTTP status: %d", apiResponse.StatusCode)
 		} else {
 			errorMessage = "No response received from the API"


### PR DESCRIPTION
This fixes a possible nil pointer exception in `create kubeconfig` where `apiResponse` is not nil, but apiResponse.StatusCode is nil.

```
gsctl --endpoint REDACTED create kubeconfig --cluster REDACTED --certificate-organizations system:masters --auth-token REDACTED
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x7611d4]

goroutine 1 [running]:
github.com/giantswarm/gsctl/commands.createKubeconfig(0xc4200a47e0, 0x17, 0x7fffe079634a, 0x24, 0x7fffe079630c, 0x5, 0xc42009e390, 0x2e, 0x0, 0x0, ...)
        /go/src/github.com/giantswarm/gsctl/commands/create_kubeconfig.go:366 +0x2f4
github.com/giantswarm/gsctl/commands.createKubeconfigRunOutput(0xaa19a0, 0xc42014e300, 0x0, 0x8)
        /go/src/github.com/giantswarm/gsctl/commands/create_kubeconfig.go:269 +0xa2
github.com/giantswarm/gsctl/vendor/github.com/spf13/cobra.(*Command).execute(0xaa19a0, 0xc42014e200, 0x8, 0x8, 0xaa19a0, 0xc42014e200)
        /go/src/github.com/giantswarm/gsctl/vendor/github.com/spf13/cobra/command.go:757 +0x2c1
github.com/giantswarm/gsctl/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xaa0dc0, 0x0, 0x77a556, 0x855742)
        /go/src/github.com/giantswarm/gsctl/vendor/github.com/spf13/cobra/command.go:843 +0x30a
github.com/giantswarm/gsctl/vendor/github.com/spf13/cobra.(*Command).Execute(0xaa0dc0, 0xc420067f78, 0xc42008c058)
        /go/src/github.com/giantswarm/gsctl/vendor/github.com/spf13/cobra/command.go:791 +0x2b
main.main()
        /go/src/github.com/giantswarm/gsctl/main.go:24 +0x2d
```