### PR TITLE
Reveal --release flag in 'create cluster' command

### DIFF
--- a/commands/create_cluster.go
+++ b/commands/create_cluster.go
@@ -105,11 +105,15 @@ Examples:
 
 	gsctl create cluster -o myorg -n "My Cluster" --num-workers 5 --num-cpus 2
 
-	gsctl create cluster --owner myorg --name "My AWS Cluster" --num-workers 2 --aws-instance-type m3.medium
+	gsctl create cluster -o myorg -n "My AWS Cluster" --num-workers 2 --aws-instance-type m3.medium
 
-	gsctl create cluster --owner myorg --name "My Azure Cluster" --num-workers 2 --azure-vm-size Standard_D2s_v3
+	gsctl create cluster -o myorg -n "My Azure Cluster" --num-workers 2 --azure-vm-size Standard_D2s_v3
 
-	gsctl create cluster --owner myorg --num-workers 3 --dry-run --verbose`,
+	gsctl create cluster -o myorg -n "Cluster using specifc version" -r 1.2.3
+
+	gsctl create cluster -o myorg --num-workers 3 --dry-run --verbose
+
+	`,
 		PreRun: createClusterValidationOutput,
 		Run:    createClusterExecutionOutput,
 	}

--- a/commands/create_cluster.go
+++ b/commands/create_cluster.go
@@ -52,7 +52,7 @@ func defaultAddClusterArguments() addClusterArguments {
 		token:                   token,
 		releaseVersion:          cmdRelease,
 		wokerAwsEc2InstanceType: cmdWorkerAwsEc2InstanceType,
-		wokerAzureVmSize:        cmdWorkerAzureVmSize,
+		wokerAzureVmSize:        cmdWorkerAzureVMSize,
 		workerNumCPUs:           cmdWorkerNumCPUs,
 		workerMemorySizeGB:      cmdWorkerMemorySizeGB,
 		workerStorageSizeGB:     cmdWorkerStorageSizeGB,
@@ -127,7 +127,7 @@ Examples:
 	// AWS EC2 instance type to use, provided as a command line flag
 	cmdWorkerAwsEc2InstanceType string
 	// Azure VmSize to use, provided as a command line flag
-	cmdWorkerAzureVmSize string
+	cmdWorkerAzureVMSize string
 	// cmdRelease sets a release to use, provided as a command line flag
 	cmdRelease string
 	// dry run command line flag
@@ -142,7 +142,7 @@ func init() {
 	CreateClusterCommand.Flags().StringVarP(&cmdRelease, "release", "r", "", "Release version to use, e. g. '1.2.3'. Defaults to the latest. See 'gsctl list releases --help' for details.")
 	CreateClusterCommand.Flags().IntVarP(&cmdNumWorkers, "num-workers", "", 0, "Number of worker nodes. Can't be used with -f|--file.")
 	CreateClusterCommand.Flags().StringVarP(&cmdWorkerAwsEc2InstanceType, "aws-instance-type", "", "", "EC2 instance type to use for workers (AWS only), e. g. 'm3.large'")
-	CreateClusterCommand.Flags().StringVarP(&cmdWorkerAzureVmSize, "azure-vm-size", "", "", "VmSize to use for workers (Azure only), e. g. 'Standard_D2s_v3'")
+	CreateClusterCommand.Flags().StringVarP(&cmdWorkerAzureVMSize, "azure-vm-size", "", "", "VmSize to use for workers (Azure only), e. g. 'Standard_D2s_v3'")
 	CreateClusterCommand.Flags().IntVarP(&cmdWorkerNumCPUs, "num-cpus", "", 0, "Number of CPU cores per worker node. Can't be used with -f|--file.")
 	CreateClusterCommand.Flags().Float32VarP(&cmdWorkerMemorySizeGB, "memory-gb", "", 0, "RAM per worker node. Can't be used with -f|--file.")
 	CreateClusterCommand.Flags().Float32VarP(&cmdWorkerStorageSizeGB, "storage-gb", "", 0, "Local storage size per worker node. Can't be used with -f|--file.")

--- a/commands/create_cluster.go
+++ b/commands/create_cluster.go
@@ -139,7 +139,7 @@ func init() {
 	CreateClusterCommand.Flags().StringVarP(&cmdClusterName, "name", "n", "", "Cluster name")
 	CreateClusterCommand.Flags().StringVarP(&cmdKubernetesVersion, "kubernetes-version", "", "", "Kubernetes version of the cluster")
 	CreateClusterCommand.Flags().StringVarP(&cmdOwner, "owner", "o", "", "Organization to own the cluster")
-	CreateClusterCommand.Flags().StringVarP(&cmdRelease, "release", "r", "", "Release version to use, e. g. '0.3.0'. Defaults to the latest. See 'gsctl list releases -h' for details.")
+	CreateClusterCommand.Flags().StringVarP(&cmdRelease, "release", "r", "", "Release version to use, e. g. '1.2.3'. Defaults to the latest. See 'gsctl list releases --help' for details.")
 	CreateClusterCommand.Flags().IntVarP(&cmdNumWorkers, "num-workers", "", 0, "Number of worker nodes. Can't be used with -f|--file.")
 	CreateClusterCommand.Flags().StringVarP(&cmdWorkerAwsEc2InstanceType, "aws-instance-type", "", "", "EC2 instance type to use for workers (AWS only), e. g. 'm3.large'")
 	CreateClusterCommand.Flags().StringVarP(&cmdWorkerAzureVmSize, "azure-vm-size", "", "", "VmSize to use for workers (Azure only), e. g. 'Standard_D2s_v3'")
@@ -147,9 +147,6 @@ func init() {
 	CreateClusterCommand.Flags().Float32VarP(&cmdWorkerMemorySizeGB, "memory-gb", "", 0, "RAM per worker node. Can't be used with -f|--file.")
 	CreateClusterCommand.Flags().Float32VarP(&cmdWorkerStorageSizeGB, "storage-gb", "", 0, "Local storage size per worker node. Can't be used with -f|--file.")
 	CreateClusterCommand.Flags().BoolVarP(&cmdDryRun, "dry-run", "", false, "If set, the cluster won't be created. Useful with -v|--verbose.")
-
-	// we mark this hidden until while it is not useful and undocumented
-	CreateClusterCommand.Flags().MarkHidden("release")
 
 	// kubernetes-version never had any effect, and is deprecated now on the API side, too
 	CreateClusterCommand.Flags().MarkDeprecated("kubernetes-version", "please use --release-version to specify a release to use")

--- a/commands/create_cluster.go
+++ b/commands/create_cluster.go
@@ -149,7 +149,7 @@ func init() {
 	CreateClusterCommand.Flags().BoolVarP(&cmdDryRun, "dry-run", "", false, "If set, the cluster won't be created. Useful with -v|--verbose.")
 
 	// kubernetes-version never had any effect, and is deprecated now on the API side, too
-	CreateClusterCommand.Flags().MarkDeprecated("kubernetes-version", "please use --release-version to specify a release to use")
+	CreateClusterCommand.Flags().MarkDeprecated("kubernetes-version", "please use --release to specify a release to use")
 
 	CreateClusterCommand.MarkFlagRequired("owner")
 


### PR DESCRIPTION
This PR makes the `--release` flag visible, which allows to set a specific release version number to use when creating a new cluster.