### PR TITLE
Handle org not found error

### DIFF
--- a/commands/create_cluster.go
+++ b/commands/create_cluster.go
@@ -242,7 +242,7 @@ func createClusterExecutionOutput(cmd *cobra.Command, args []string) {
 			subtext += " Please check your credentials or, to make sure, use 'gsctl login' to log in again."
 		case IsOrganizationNotFoundError(err):
 			headline = "Organization not found"
-			subtext = "The organization to own the cluster does not exist, or you are not a member of it."
+			subtext = "The organization set to own the cluster does not exist."
 		case IsCouldNotCreateClusterError(err):
 			headline = "The cluster could not be created."
 			subtext = "You might try again in a few moments. If that doesn't work, please contact the Giant Swarm support team."

--- a/commands/create_cluster.go
+++ b/commands/create_cluster.go
@@ -240,6 +240,9 @@ func createClusterExecutionOutput(cmd *cobra.Command, args []string) {
 			headline = "Not authorized"
 			subtext = "No cluster has been created, as you are are not authenticated or not authorized to perform this action."
 			subtext += " Please check your credentials or, to make sure, use 'gsctl login' to log in again."
+		case IsOrganizationNotFoundError(err):
+			headline = "Organization not found"
+			subtext = "The organization to own the cluster does not exist, or you are not a member of it."
 		case IsCouldNotCreateClusterError(err):
 			headline = "The cluster could not be created."
 			subtext = "You might try again in a few moments. If that doesn't work, please contact the Giant Swarm support team."
@@ -507,6 +510,11 @@ func addCluster(args addClusterArguments) (addClusterResult, error) {
 
 		if apiResponse.StatusCode == 401 {
 			return result, microerror.Mask(notAuthorizedError)
+		} else if apiResponse.StatusCode == 404 {
+			// deal with non-existing org error
+			if strings.Contains(responseBody.Message, "organization") && strings.Contains(responseBody.Message, "not found") {
+				return result, microerror.Mask(organizationNotFoundError)
+			}
 		}
 
 		// handle API result

--- a/commands/error.go
+++ b/commands/error.go
@@ -163,6 +163,14 @@ func IsClusterOwnerMissingError(err error) bool {
 	return errgo.Cause(err) == clusterOwnerMissingError
 }
 
+// organizationNotFoundError means that the specified organization could not be found
+var organizationNotFoundError = errgo.New("organization not found")
+
+// IsOrganizationNotFoundError asserts organizationNotFoundError
+func IsOrganizationNotFoundError(err error) bool {
+	return errgo.Cause(err) == organizationNotFoundError
+}
+
 // yamlFileNotReadableError means a YAML file was not readable
 var yamlFileNotReadableError = errgo.New("could not read YAML file")
 


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/2083

Preview:

```nohighlight
gsctl create cluster -n Test -o nonexisting
Requesting new cluster for organization 'nonexisting'
Organization not found
The organization set as owner does not exist, or you are not a member of it.
```