### PR TITLE
Allow key pair lifetime shorter than 1 day (breaking change)

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -44,7 +44,7 @@ var (
 	cmdDescription string
 
 	// TTL (time to live) flag
-	cmdTTLDays int
+	cmdTTL string
 
 	// force flag. if set, no prompt should be displayed.
 	cmdForce bool

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -240,7 +240,7 @@ func handleCommonErrors(err error) {
 		subtext += "please try again in a few moments."
 	case IsUnknownError(err):
 		headline = "An error occurred."
-		subtext = "Please notify the Giant Swarm support team, or try listing releases again in a few moments.\n"
+		subtext = "Please notify the Giant Swarm support team, or try the command again in a few moments.\n"
 		subtext += fmt.Sprintf("Details: %s", err.Error())
 	default:
 		return

--- a/commands/create_keypair.go
+++ b/commands/create_keypair.go
@@ -60,7 +60,7 @@ func defaultCreateKeypairArguments() createKeypairArguments {
 		clusterID:                cmdClusterID,
 		commonNamePrefix:         cmdCNPrefix,
 		description:              description,
-		ttlHours:                 int32(cmdTTLDays) * 24,
+		ttlHours:                 int32(cmdTTL) * 24,
 	}
 }
 
@@ -82,7 +82,7 @@ func init() {
 	CreateKeypairCommand.Flags().StringVarP(&cmdDescription, "description", "d", "", "Description for the key pair")
 	CreateKeypairCommand.Flags().StringVarP(&cmdCNPrefix, "cn-prefix", "", "", "The common name prefix for the issued certificates 'CN' field.")
 	CreateKeypairCommand.Flags().StringVarP(&cmdCertificateOrganizations, "certificate-organizations", "", "", "A comma separated list of organizations for the issued certificates 'O' fields.")
-	CreateKeypairCommand.Flags().IntVarP(&cmdTTLDays, "ttl", "", 30, "Duration until expiry of the created key pair in days")
+	CreateKeypairCommand.Flags().StringVarP(&cmdTTL, "ttl", "", "30d", "Lifetime of the created key pair, e.g. 3h. Default: 30d (30 days).")
 
 	CreateKeypairCommand.MarkFlagRequired("cluster")
 

--- a/commands/create_keypair.go
+++ b/commands/create_keypair.go
@@ -98,7 +98,8 @@ func createKeyPairPreRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 	args, argsErr := defaultCreateKeypairArguments()
 	if argsErr != nil {
 		if IsInvalidDurationError(argsErr) {
-			fmt.Println(color.RedString("The value passed with --ttl could not be parsed"))
+			fmt.Println(color.RedString("The value passed with --ttl is invalid."))
+			fmt.Println("Please provide a number and a unit, e. g. '10h', '1d', '1w'.")
 		} else {
 			fmt.Println(color.RedString(argsErr.Error()))
 		}

--- a/commands/create_keypair.go
+++ b/commands/create_keypair.go
@@ -87,7 +87,7 @@ func init() {
 	CreateKeypairCommand.Flags().StringVarP(&cmdDescription, "description", "d", "", "Description for the key pair")
 	CreateKeypairCommand.Flags().StringVarP(&cmdCNPrefix, "cn-prefix", "", "", "The common name prefix for the issued certificates 'CN' field.")
 	CreateKeypairCommand.Flags().StringVarP(&cmdCertificateOrganizations, "certificate-organizations", "", "", "A comma separated list of organizations for the issued certificates 'O' fields.")
-	CreateKeypairCommand.Flags().StringVarP(&cmdTTL, "ttl", "", "30d", "Lifetime of the created key pair, e.g. 3h. Default: 30d (30 days).")
+	CreateKeypairCommand.Flags().StringVarP(&cmdTTL, "ttl", "", "30d", "Lifetime of the created key pair, e.g. 3h. Allowed units: h, d, w, m, y.")
 
 	CreateKeypairCommand.MarkFlagRequired("cluster")
 

--- a/commands/create_kubeconfig.go
+++ b/commands/create_kubeconfig.go
@@ -188,7 +188,7 @@ func init() {
 	CreateKubeconfigCommand.Flags().StringVarP(&cmdKubeconfigContextName, "context", "", "", "Set a custom context name. Defaults to 'giantswarm-<cluster-id>'.")
 	CreateKubeconfigCommand.Flags().StringVarP(&cmdCertificateOrganizations, "certificate-organizations", "", "", "A comma separated list of organizations for the issued certificates 'O' fields.")
 	CreateKubeconfigCommand.Flags().BoolVarP(&cmdForce, "force", "", false, "If set, --self-contained will overwrite existing files without interactive confirmation.")
-	CreateKubeconfigCommand.Flags().StringVarP(&cmdTTL, "ttl", "", "30d", "Lifetime of the created key pair, e.g. 3h. Default: 30d (30 days).")
+	CreateKubeconfigCommand.Flags().StringVarP(&cmdTTL, "ttl", "", "30d", "Lifetime of the created key pair, e.g. 3h. Allowed units: h, d, w, m, y.")
 
 	CreateKubeconfigCommand.MarkFlagRequired("cluster")
 

--- a/commands/create_kubeconfig.go
+++ b/commands/create_kubeconfig.go
@@ -200,7 +200,8 @@ func createKubeconfigPreRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 	args, argsErr := defaultCreateKubeconfigArguments()
 	if argsErr != nil {
 		if IsInvalidDurationError(argsErr) {
-			fmt.Println(color.RedString("The value passed with --ttl could not be parsed"))
+			fmt.Println(color.RedString("The value passed with --ttl is invalid."))
+			fmt.Println("Please provide a number and a unit, e. g. '10h', '1d', '1w'.")
 		} else {
 			fmt.Println(color.RedString(argsErr.Error()))
 		}

--- a/commands/create_kubeconfig.go
+++ b/commands/create_kubeconfig.go
@@ -46,7 +46,7 @@ Examples:
 
   gsctl create kubeconfig -c my0c3 --self-contained ./kubeconfig.yaml
 
-  gsctl create kubeconfig -c my0c3 --ttl 1 -d "Short lived key pair"
+  gsctl create kubeconfig -c my0c3 --ttl 3h -d "Key pair living for 3 hours"
 
   gsctl create kubeconfig -c my0c3 --certificate-organizations system:masters
 `,
@@ -83,7 +83,7 @@ type createKubeconfigArguments struct {
 
 // defaultCreateKubeconfigArguments creates arguments based on command line
 // flags and config and applies defaults
-func defaultCreateKubeconfigArguments() createKubeconfigArguments {
+func defaultCreateKubeconfigArguments() (createKubeconfigArguments, error) {
 	endpoint := config.Config.ChooseEndpoint(cmdAPIEndpoint)
 	token := config.Config.ChooseToken(endpoint, cmdToken)
 
@@ -97,6 +97,11 @@ func defaultCreateKubeconfigArguments() createKubeconfigArguments {
 		contextName = "giantswarm-" + cmdClusterID
 	}
 
+	ttl, err := time.ParseDuration(cmdTTL)
+	if err != nil {
+		return createKubeconfigArguments{}, microerror.Mask(invalidDurationError)
+	}
+
 	return createKubeconfigArguments{
 		apiEndpoint:       endpoint,
 		authToken:         token,
@@ -104,11 +109,11 @@ func defaultCreateKubeconfigArguments() createKubeconfigArguments {
 		description:       description,
 		cnPrefix:          cmdCNPrefix,
 		certOrgs:          cmdCertificateOrganizations,
-		ttlHours:          int32(cmdTTLDays) * 24,
+		ttlHours:          int32(ttl.Seconds() * 60 * 60),
 		selfContainedPath: cmdKubeconfigSelfContained,
 		force:             cmdForce,
 		contextName:       contextName,
-	}
+	}, nil
 }
 
 type createKubeconfigResult struct {
@@ -183,7 +188,7 @@ func init() {
 	CreateKubeconfigCommand.Flags().StringVarP(&cmdKubeconfigContextName, "context", "", "", "Set a custom context name. Defaults to 'giantswarm-<cluster-id>'.")
 	CreateKubeconfigCommand.Flags().StringVarP(&cmdCertificateOrganizations, "certificate-organizations", "", "", "A comma separated list of organizations for the issued certificates 'O' fields.")
 	CreateKubeconfigCommand.Flags().BoolVarP(&cmdForce, "force", "", false, "If set, --self-contained will overwrite existing files without interactive confirmation.")
-	CreateKubeconfigCommand.Flags().IntVarP(&cmdTTLDays, "ttl", "", 30, "Duration until expiry of the created key pair in days")
+	CreateKubeconfigCommand.Flags().StringVarP(&cmdTTL, "ttl", "", "30d", "Lifetime of the created key pair, e.g. 3h. Default: 30d (30 days).")
 
 	CreateKubeconfigCommand.MarkFlagRequired("cluster")
 
@@ -192,7 +197,11 @@ func init() {
 
 // createKubeconfigPreRunOutput shows our pre-check results
 func createKubeconfigPreRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
-	args := defaultCreateKubeconfigArguments()
+	args, argsErr := defaultCreateKubeconfigArguments()
+	if argsErr != nil {
+
+	}
+
 	err := verifyCreateKubeconfigPreconditions(args, cmdLineArgs)
 
 	if err == nil {
@@ -265,7 +274,7 @@ func verifyCreateKubeconfigPreconditions(args createKubeconfigArguments, cmdLine
 
 // createKubeconfig adds configuration for kubectl
 func createKubeconfigRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
-	args := defaultCreateKubeconfigArguments()
+	args, argsErr := defaultCreateKubeconfigArguments()
 	result, err := createKubeconfig(args)
 
 	if err != nil {

--- a/commands/error.go
+++ b/commands/error.go
@@ -306,3 +306,11 @@ var unspecifiedAPIError = errgo.New("unspecified API error")
 func IsUnspecifiedAPIError(err error) bool {
 	return errgo.Cause(err) == unspecifiedAPIError
 }
+
+// invalidDurationError means that a user-provided duration string could not be parsed
+var invalidDurationError = errgo.New("invalid duration")
+
+// IsInvalidDurationErrorr asserts invalidDurationError
+func IsInvalidDurationErrorr(err error) bool {
+	return errgo.Cause(err) == invalidDurationError
+}

--- a/commands/error.go
+++ b/commands/error.go
@@ -310,7 +310,7 @@ func IsUnspecifiedAPIError(err error) bool {
 // invalidDurationError means that a user-provided duration string could not be parsed
 var invalidDurationError = errgo.New("invalid duration")
 
-// IsInvalidDurationErrorr asserts invalidDurationError
-func IsInvalidDurationErrorr(err error) bool {
+// IsInvalidDurationError asserts invalidDurationError
+func IsInvalidDurationError(err error) bool {
 	return errgo.Cause(err) == invalidDurationError
 }

--- a/util/duration_test.go
+++ b/util/duration_test.go
@@ -1,8 +1,11 @@
 package util
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
-var durationTest = []struct {
+var friendlyDurationTest = []struct {
 	in  int
 	out string
 }{
@@ -26,10 +29,32 @@ var durationTest = []struct {
 }
 
 func TestFriendlyDuration(t *testing.T) {
-	for _, tt := range durationTest {
+	for _, tt := range friendlyDurationTest {
 		phrase := DurationPhrase(tt.in)
 		if phrase != tt.out {
 			t.Errorf("Value '%d', got '%s', wanted '%s'", tt.in, phrase, tt.out)
+		}
+	}
+}
+
+var parseDurationTest = []struct {
+	in  string
+	out time.Duration
+}{
+	{"1h", 1 * time.Hour},
+	{"1d", 24 * time.Hour},
+	{"1w", 7 * 24 * time.Hour},
+	{"1m", 30 * 24 * time.Hour},
+	{"1y", 365 * 24 * time.Hour},
+}
+
+func TestParseDuration(t *testing.T) {
+	for _, tt := range parseDurationTest {
+		duration, err := ParseDuration(tt.in)
+		if err != nil {
+			t.Errorf("Value '%s' yielded error: '%s'", tt.in, err)
+		} else if duration != tt.out {
+			t.Errorf("Value '%s', got '%v', wanted '%v'", tt.in, duration, tt.out)
 		}
 	}
 }

--- a/util/error.go
+++ b/util/error.go
@@ -29,3 +29,10 @@ var CouldNotUseKubectlContextError = errgo.New("could not apply context using 'k
 func IsCouldNotUseKubectlContextError(err error) bool {
 	return errgo.Cause(err) == CouldNotUseKubectlContextError
 }
+
+var InvalidDurationStringError = errgo.New("could not parse duration string")
+
+// IsInvalidDurationStringError asserts InvalidDurationStringError.
+func IsInvalidDurationStringError(err error) bool {
+	return errgo.Cause(err) == InvalidDurationStringError
+}


### PR DESCRIPTION
Solves https://github.com/giantswarm/gsctl/issues/137

This is a breaking change for the usage of the `gsctl create <kubeconfig|keypair>` commands when applying the `--ttl` flag. Before, a number like `10` was accepted as a value. Now, the value must be a combination of a number and a unit, like `10d`.

Supported units are `h` for hour, `w` for week, `m` for month, and `y` for year.

The change is easy to adapt to. Simply add a `d` to the value as it was used before.

### Preview:

```
$ gsctl create kubeconfig -c 0r93p --ttl 1h
New key pair created with ID 7f3f88daf… and expiry of 1 hour
Certificate and key files written to:
/Users/marian/.config/gsctl/certs/0r93p-ca.crt
/Users/marian/.config/gsctl/certs/0r93p-7f3f88dafe-client.crt
/Users/marian/.config/gsctl/certs/0r93p-7f3f88dafe-client.key
Switched to kubectl context 'giantswarm-0r93p'

kubectl is set up. Check it using this command:

    kubectl cluster-info

Whenever you want to switch to using this context:

    kubectl config use-context giantswarm-0r93p

```

```nohighlight
$ openssl x509 -in /Users/marian/.config/gsctl/certs/0r93p-7f3f88dafe-client.crt -noout -enddate
notAfter=Apr 20 15:06:49 2018 GMT
```

```nohighlight
$ gsctl create kubeconfig -c 0r93p --ttl 10
The value passed with --ttl is invalid.
Please provide a number and a unit, e. g. '10h', '1d', '1w'.
```