### PR TITLE
Make cert garbage collection silent

### DIFF
--- a/config/garbage_collect.go
+++ b/config/garbage_collect.go
@@ -48,7 +48,6 @@ func GarbageCollectKeyPairs() error {
 	errorInfo := []string{}
 
 	for _, file := range expiredCerts {
-		fmt.Printf("Certificate %s is expired and will be deleted.\n", file)
 		certPath := CertsDirPath + "/" + file
 		err := os.Remove(certPath)
 		if err != nil {


### PR DESCRIPTION
Garbage collection seems to work without complaints. There is no need to inform the user any more about every deleted certificate.