### PR TITLE
show cluster: Reduce memory and storage precision to 2 digits

### DIFF
--- a/commands/show_cluster.go
+++ b/commands/show_cluster.go
@@ -221,8 +221,8 @@ func showClusterRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 	}
 
 	output = append(output, color.YellowString("CPU cores in workers:")+"|"+fmt.Sprintf("%d", sumWorkerCPUs(clusterDetails.Workers)))
-	output = append(output, color.YellowString("RAM in worker nodes (GB):")+"|"+fmt.Sprintf("%v", sumWorkerMemory(clusterDetails.Workers)))
-	output = append(output, color.YellowString("Storage in worker nodes (GB):")+"|"+fmt.Sprintf("%v", sumWorkerStorage(clusterDetails.Workers)))
+	output = append(output, color.YellowString("RAM in worker nodes (GB):")+"|"+fmt.Sprintf("%.2f", sumWorkerMemory(clusterDetails.Workers)))
+	output = append(output, color.YellowString("Storage in worker nodes (GB):")+"|"+fmt.Sprintf("%.2f", sumWorkerStorage(clusterDetails.Workers)))
 
 	if len(clusterDetails.Kvm.PortMappings) > 0 {
 		for _, portMapping := range clusterDetails.Kvm.PortMappings {


### PR DESCRIPTION
For https://github.com/giantswarm/giantswarm/issues/2848

This PR sets the precision of the GB values in `gsctl show cluster` to 2 digits.

This also means that values like `40` will now show up as `40.00`.

#### Before

```
gsctl show cluster 6ur24
...
CPU cores in workers:          10
RAM in worker nodes (GB):      40.960003
Storage in worker nodes (GB):  81.920006
```

#### After

```
gsctl show cluster 6ur24
...
CPU cores in workers:          10
RAM in worker nodes (GB):      40.96
Storage in worker nodes (GB):  81.92
```
