### PR TITLE
Allow passing endpoint alias with the -e/--endpoint flag and GSCTL_ENDPOINT env variable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -224,6 +224,11 @@ func (c *configStruct) ChooseEndpoint(overridingEndpointAliasOrURL string) strin
 	// use environment variable
 	envEndpoint := os.Getenv("GSCTL_ENDPOINT")
 	if envEndpoint != "" {
+		if c.HasEndpointAlias(envEndpoint) {
+			ep, _ := c.EndpointByAlias(envEndpoint)
+			return ep
+		}
+
 		ep := normalizeEndpoint(envEndpoint)
 		return ep
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -207,9 +207,8 @@ func (c *configStruct) SelectEndpoint(endpointAliasOrURL string) error {
 
 // ChooseEndpoint makes a choice which should be the endpoint to use.
 // If the argument overridingEndpointAliasOrURL is not empty, this will
-// be used as the returned endpoint URL.
-// Errors are only printed to inform users, but not returned, to simplify
-// usage of this function.
+// be used to look up an alias to return an endpoint for. If there is none,
+// it will be the used endpoint URL.
 func (c *configStruct) ChooseEndpoint(overridingEndpointAliasOrURL string) string {
 	if overridingEndpointAliasOrURL != "" {
 		// check if overridingEndpointAliasOrURL is an alias

--- a/config/config.go
+++ b/config/config.go
@@ -225,6 +225,12 @@ func (c *configStruct) SelectEndpoint(endpointAliasOrURL string) error {
 // be used to look up an alias to return an endpoint for. If there is none,
 // it will be the used endpoint URL.
 func (c *configStruct) ChooseEndpoint(overridingEndpointAliasOrURL string) string {
+
+	// if no local param is given, try the environment variable
+	if overridingEndpointAliasOrURL == "" {
+		overridingEndpointAliasOrURL = os.Getenv("GSCTL_ENDPOINT")
+	}
+
 	if overridingEndpointAliasOrURL != "" {
 		// check if overridingEndpointAliasOrURL is an alias
 		if c.HasEndpointAlias(overridingEndpointAliasOrURL) {
@@ -233,18 +239,6 @@ func (c *configStruct) ChooseEndpoint(overridingEndpointAliasOrURL string) strin
 		}
 
 		ep := normalizeEndpoint(overridingEndpointAliasOrURL)
-		return ep
-	}
-
-	// use environment variable
-	envEndpoint := os.Getenv("GSCTL_ENDPOINT")
-	if envEndpoint != "" {
-		if c.HasEndpointAlias(envEndpoint) {
-			ep, _ := c.EndpointByAlias(envEndpoint)
-			return ep
-		}
-
-		ep := normalizeEndpoint(envEndpoint)
 		return ep
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -206,22 +206,30 @@ func (c *configStruct) SelectEndpoint(endpointAliasOrURL string) error {
 }
 
 // ChooseEndpoint makes a choice which should be the endpoint to use.
-// If the argument overridingEndpointURL is not empty, this will
+// If the argument overridingEndpointAliasOrURL is not empty, this will
 // be used as the returned endpoint URL.
 // Errors are only printed to inform users, but not returned, to simplify
 // usage of this function.
-func (c *configStruct) ChooseEndpoint(overridingEndpointURL string) string {
-	if overridingEndpointURL != "" {
-		ep := normalizeEndpoint(overridingEndpointURL)
+func (c *configStruct) ChooseEndpoint(overridingEndpointAliasOrURL string) string {
+	if overridingEndpointAliasOrURL != "" {
+		// check if overridingEndpointAliasOrURL is an alias
+		if c.HasEndpointAlias(overridingEndpointAliasOrURL) {
+			ep, _ := c.EndpointByAlias(overridingEndpointAliasOrURL)
+			return ep
+		}
+
+		ep := normalizeEndpoint(overridingEndpointAliasOrURL)
 		return ep
 	}
 
+	// use environment variable
 	envEndpoint := os.Getenv("GSCTL_ENDPOINT")
 	if envEndpoint != "" {
 		ep := normalizeEndpoint(envEndpoint)
 		return ep
 	}
 
+	// as a last resort, return the currently selected endpoint
 	return c.SelectedEndpoint
 }
 


### PR DESCRIPTION
Fixes https://github.com/giantswarm/gsctl/issues/229

This allows to use endpoint aliases instead of endpoint URLs with the `-e` or `--endpoint` flag in all commands, and with the `GSCTL_ENDPOINT` environment variable.