### PR TITLE
Support the bearer scheme (SSO)

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -25,6 +25,9 @@ var (
 	// token flag
 	cmdToken string
 
+	// schemeflag
+	cmdScheme string
+
 	// configuration path to use temporarily
 	cmdConfigDirPath string
 

--- a/commands/create_cluster.go
+++ b/commands/create_cluster.go
@@ -29,6 +29,7 @@ type addClusterArguments struct {
 	inputYAMLFile           string
 	numWorkers              int
 	owner                   string
+	scheme                  string
 	token                   string
 	wokerAwsEc2InstanceType string
 	wokerAzureVmSize        string
@@ -42,6 +43,7 @@ type addClusterArguments struct {
 func defaultAddClusterArguments() addClusterArguments {
 	endpoint := config.Config.ChooseEndpoint(cmdAPIEndpoint)
 	token := config.Config.ChooseToken(endpoint, cmdToken)
+	scheme := config.Config.ChooseScheme(endpoint, cmdScheme)
 	return addClusterArguments{
 		apiEndpoint:             endpoint,
 		clusterName:             cmdClusterName,
@@ -49,6 +51,7 @@ func defaultAddClusterArguments() addClusterArguments {
 		inputYAMLFile:           cmdInputYAMLFile,
 		numWorkers:              cmdNumWorkers,
 		owner:                   cmdOwner,
+		scheme:                  scheme,
 		token:                   token,
 		releaseVersion:          cmdRelease,
 		wokerAwsEc2InstanceType: cmdWorkerAwsEc2InstanceType,
@@ -498,7 +501,7 @@ func addCluster(args addClusterArguments) (addClusterResult, error) {
 		fmt.Printf("Requesting new cluster for organization '%s'\n", color.CyanString(result.definition.Owner))
 
 		// perform API call
-		authHeader := "giantswarm " + args.token
+		authHeader := args.scheme + " " + args.token
 		clientConfig := client.Configuration{
 			Endpoint:  args.apiEndpoint,
 			UserAgent: config.UserAgent(),

--- a/commands/create_keypair.go
+++ b/commands/create_keypair.go
@@ -35,6 +35,7 @@ const (
 // to the validation function
 type createKeypairArguments struct {
 	apiEndpoint              string
+	scheme                   string
 	authToken                string
 	certificateOrganizations string
 	clusterID                string
@@ -47,6 +48,7 @@ type createKeypairArguments struct {
 func defaultCreateKeypairArguments() (createKeypairArguments, error) {
 	endpoint := config.Config.ChooseEndpoint(cmdAPIEndpoint)
 	token := config.Config.ChooseToken(endpoint, cmdToken)
+	scheme := config.Config.ChooseScheme(endpoint, cmdScheme)
 
 	description := cmdDescription
 	if description == "" {
@@ -60,6 +62,7 @@ func defaultCreateKeypairArguments() (createKeypairArguments, error) {
 
 	return createKeypairArguments{
 		apiEndpoint:              endpoint,
+		scheme:                   scheme,
 		authToken:                token,
 		certificateOrganizations: cmdCertificateOrganizations,
 		clusterID:                cmdClusterID,
@@ -199,7 +202,7 @@ func createKeypair(args createKeypairArguments) (createKeypairResult, error) {
 		return result, microerror.Maskf(couldNotCreateClientError, clientErr.Error())
 	}
 
-	authHeader := "giantswarm " + args.authToken
+	authHeader := args.scheme + " " + args.authToken
 
 	addKeyPairBody := gsclientgen.V4AddKeyPairBody{
 		Description:              args.description,

--- a/commands/delete_cluster.go
+++ b/commands/delete_cluster.go
@@ -20,6 +20,8 @@ type deleteClusterArguments struct {
 	clusterID string
 	// don't prompt
 	force bool
+	// auth scheme
+	scheme string
 	// auth token
 	token string
 	// verbosity
@@ -29,10 +31,13 @@ type deleteClusterArguments struct {
 func defaultDeleteClusterArguments() deleteClusterArguments {
 	endpoint := config.Config.ChooseEndpoint(cmdAPIEndpoint)
 	token := config.Config.ChooseToken(endpoint, cmdToken)
+	scheme := config.Config.ChooseScheme(endpoint, cmdScheme)
+
 	return deleteClusterArguments{
 		apiEndpoint: endpoint,
 		clusterID:   cmdClusterID,
 		force:       cmdForce,
+		scheme:      scheme,
 		token:       token,
 		verbose:     cmdVerbose,
 	}
@@ -151,7 +156,7 @@ func deleteCluster(args deleteClusterArguments) (bool, error) {
 	}
 
 	// prepare API client
-	authHeader := "giantswarm " + args.token
+	authHeader := args.scheme + " " + args.token
 	clientConfig := client.Configuration{
 		Endpoint:  args.apiEndpoint,
 		UserAgent: config.UserAgent(),

--- a/commands/info.go
+++ b/commands/info.go
@@ -31,6 +31,7 @@ var (
 
 // infoArguments represents the arguments we can make use of in this command
 type infoArguments struct {
+	scheme      string
 	token       string
 	verbose     bool
 	apiEndpoint string
@@ -41,8 +42,10 @@ type infoArguments struct {
 func defaultInfoArguments() infoArguments {
 	endpoint := config.Config.ChooseEndpoint(cmdAPIEndpoint)
 	token := config.Config.ChooseToken(endpoint, cmdToken)
+	scheme := config.Config.ChooseScheme(endpoint, cmdScheme)
 
 	return infoArguments{
+		scheme:      scheme,
 		token:       token,
 		verbose:     cmdVerbose,
 		apiEndpoint: endpoint,
@@ -185,7 +188,7 @@ func info(args infoArguments) (infoResult, error) {
 		if clientErr != nil {
 			return result, microerror.Mask(clientErr)
 		}
-		authHeader := "giantswarm " + args.token
+		authHeader := args.scheme + " " + args.token
 		infoResponse, _, infoErr := apiClient.GetInfo(authHeader, requestIDHeader, infoActivityName, cmdLine)
 		if infoErr != nil {
 			return result, microerror.Mask(infoErr)

--- a/commands/list_clusters.go
+++ b/commands/list_clusters.go
@@ -36,15 +36,18 @@ const (
 type listClustersArguments struct {
 	apiEndpoint string
 	authToken   string
+	scheme      string
 }
 
 func defaultListClustersArguments() listClustersArguments {
 	endpoint := config.Config.ChooseEndpoint(cmdAPIEndpoint)
 	token := config.Config.ChooseToken(endpoint, cmdToken)
+	scheme := config.Config.ChooseScheme(endpoint, cmdScheme)
 
 	return listClustersArguments{
 		apiEndpoint: endpoint,
 		authToken:   token,
+		scheme:      scheme,
 	}
 }
 
@@ -105,7 +108,7 @@ func clustersTable(args listClustersArguments) (string, error) {
 	if clientErr != nil {
 		return "", microerror.Mask(couldNotCreateClientError)
 	}
-	authHeader := "giantswarm " + args.authToken
+	authHeader := args.scheme + " " + args.authToken
 
 	clusters, apiResponse, err := apiClient.GetClusters(authHeader,
 		requestIDHeader, listClustersActivityName, cmdLine)

--- a/commands/list_endpoints.go
+++ b/commands/list_endpoints.go
@@ -16,6 +16,7 @@ import (
 // listing endpoints and printing endpoints lists
 type listEndpointsArguments struct {
 	apiEndpoint string
+	scheme      string
 	token       string
 }
 
@@ -39,9 +40,11 @@ func init() {
 func defaultListEndpointArguments() listEndpointsArguments {
 	endpoint := config.Config.ChooseEndpoint(cmdAPIEndpoint)
 	token := config.Config.ChooseToken(endpoint, cmdToken)
+	scheme := config.Config.ChooseScheme(endpoint, cmdScheme)
 	return listEndpointsArguments{
 		apiEndpoint: endpoint,
 		token:       token,
+		scheme:      scheme,
 	}
 }
 

--- a/commands/list_keypairs.go
+++ b/commands/list_keypairs.go
@@ -42,6 +42,7 @@ type listKeypairsArguments struct {
 	clusterID   string
 	full        bool
 	token       string
+	scheme      string
 }
 
 // defaultListKeypairsArguments returns a new listKeypairsArguments struct
@@ -49,12 +50,14 @@ type listKeypairsArguments struct {
 func defaultListKeypairsArguments() listKeypairsArguments {
 	endpoint := config.Config.ChooseEndpoint(cmdAPIEndpoint)
 	token := config.Config.ChooseToken(endpoint, cmdToken)
+	scheme := config.Config.ChooseScheme(endpoint, cmdScheme)
 
 	return listKeypairsArguments{
 		apiEndpoint: endpoint,
 		clusterID:   cmdClusterID,
 		full:        cmdFull,
 		token:       token,
+		scheme:      scheme,
 	}
 }
 
@@ -185,7 +188,7 @@ func listKeypairs(args listKeypairsArguments) (listKeypairsResult, error) {
 	if clientErr != nil {
 		return result, microerror.Mask(couldNotCreateClientError)
 	}
-	authHeader := "giantswarm " + args.token
+	authHeader := args.scheme + " " + args.token
 	keypairsResponse, apiResponse, err := apiClient.GetKeyPairs(authHeader,
 		cmdClusterID, requestIDHeader, listKeypairsActivityName, cmdLine)
 

--- a/commands/list_organizations.go
+++ b/commands/list_organizations.go
@@ -62,6 +62,7 @@ func listOrgs(cmd *cobra.Command, args []string) {
 func orgsTable() (string, error) {
 	endpoint := config.Config.ChooseEndpoint(cmdAPIEndpoint)
 	token := config.Config.ChooseToken(endpoint, cmdToken)
+	scheme := config.Config.ChooseScheme(endpoint, cmdScheme)
 
 	clientConfig := client.Configuration{
 		Endpoint:  endpoint,
@@ -73,7 +74,7 @@ func orgsTable() (string, error) {
 		return "", microerror.Mask(couldNotCreateClientError)
 	}
 
-	authHeader := "giantswarm " + token
+	authHeader := scheme + " " + token
 	organizations, apiResponse, err := apiClient.GetUserOrganizations(authHeader, requestIDHeader, listOrganizationsActivityName, cmdLine)
 	if err != nil {
 		return "", APIError{err.Error(), *apiResponse}

--- a/commands/list_releases.go
+++ b/commands/list_releases.go
@@ -41,6 +41,7 @@ A release is a software bundle that constitutes a cluster. It is identified by i
 type listReleasesArguments struct {
 	apiEndpoint string
 	token       string
+	scheme      string
 }
 
 // defaultListReleasesArguments returns a new listReleasesArguments struct
@@ -48,10 +49,12 @@ type listReleasesArguments struct {
 func defaultListReleasesArguments() listReleasesArguments {
 	endpoint := config.Config.ChooseEndpoint(cmdAPIEndpoint)
 	token := config.Config.ChooseToken(endpoint, cmdToken)
+	scheme := config.Config.ChooseScheme(endpoint, cmdScheme)
 
 	return listReleasesArguments{
 		apiEndpoint: endpoint,
 		token:       token,
+		scheme:      scheme,
 	}
 }
 
@@ -156,7 +159,7 @@ func listReleases(args listReleasesArguments) (listReleasesResult, error) {
 	if clientErr != nil {
 		return result, microerror.Mask(couldNotCreateClientError)
 	}
-	authHeader := "giantswarm " + args.token
+	authHeader := args.scheme + " " + args.token
 	releasesResponse, apiResponse, err := apiClient.GetReleases(authHeader,
 		requestIDHeader, listReleasesActivityName, cmdLine)
 

--- a/commands/root.go
+++ b/commands/root.go
@@ -20,6 +20,7 @@ func init() {
 
 	RootCommand.PersistentFlags().StringVarP(&cmdAPIEndpoint, "endpoint", "e", "", "The API endpoint to use")
 	RootCommand.PersistentFlags().StringVarP(&cmdToken, "auth-token", "", "", "Authorization token to use")
+	RootCommand.PersistentFlags().StringVarP(&cmdScheme, "auth-scheme", "", "giantswarm", "Authorization scheme to use (giantswarm or Bearer, case sensitive)")
 	RootCommand.PersistentFlags().StringVarP(&cmdConfigDirPath, "config-dir", "", config.DefaultConfigDirPath, "Configuration directory path to use")
 	RootCommand.PersistentFlags().BoolVarP(&cmdVerbose, "verbose", "v", false, "Print more information")
 }

--- a/commands/scale_cluster.go
+++ b/commands/scale_cluster.go
@@ -57,6 +57,7 @@ type scaleClusterArguments struct {
 	verbose             bool
 	apiEndpoint         string
 	authToken           string
+	scheme              string
 	workerNumCPUs       int
 	workerMemorySizeGB  float32
 	workerStorageSizeGB float32
@@ -65,10 +66,12 @@ type scaleClusterArguments struct {
 func defaultScaleClusterArguments() scaleClusterArguments {
 	endpoint := config.Config.ChooseEndpoint(cmdAPIEndpoint)
 	token := config.Config.ChooseToken(endpoint, cmdToken)
+	scheme := config.Config.ChooseScheme(endpoint, cmdScheme)
 
 	return scaleClusterArguments{
 		apiEndpoint:         endpoint,
 		authToken:           token,
+		scheme:              scheme,
 		clusterID:           cmdClusterID,
 		numWorkersDesired:   cmdNumWorkers,
 		workerNumCPUs:       cmdWorkerNumCPUs,
@@ -200,7 +203,7 @@ func scaleCluster(args scaleClusterArguments) (scaleClusterResults, error) {
 	}
 
 	clusterDetails, err := getClusterDetails(args.clusterID,
-		args.authToken, args.apiEndpoint)
+		args.scheme, args.authToken, args.apiEndpoint)
 	if err != nil {
 		return results, microerror.Mask(err)
 	}
@@ -241,10 +244,10 @@ func scaleCluster(args scaleClusterArguments) (scaleClusterResults, error) {
 	reqBody := gsclientgen.V4ModifyClusterRequest{Workers: workers}
 
 	// perform API call
-	authHeader := "giantswarm " + config.Config.Token
+	authHeader := args.scheme + " " + config.Config.Token
 	if args.authToken != "" {
 		// command line flag overwrites
-		authHeader = "giantswarm " + args.authToken
+		authHeader = args.scheme + " " + args.authToken
 	}
 	clientConfig := client.Configuration{
 		Endpoint:  args.apiEndpoint,

--- a/commands/show_cluster.go
+++ b/commands/show_cluster.go
@@ -44,6 +44,7 @@ const (
 type showClusterArguments struct {
 	apiEndpoint string
 	authToken   string
+	scheme      string
 	clusterID   string
 	verbose     bool
 }
@@ -51,10 +52,12 @@ type showClusterArguments struct {
 func defaultShowClusterArguments() showClusterArguments {
 	endpoint := config.Config.ChooseEndpoint(cmdAPIEndpoint)
 	token := config.Config.ChooseToken(endpoint, cmdToken)
+	scheme := config.Config.ChooseScheme(endpoint, cmdScheme)
 
 	return showClusterArguments{
 		apiEndpoint: endpoint,
 		authToken:   token,
+		scheme:      scheme,
 		clusterID:   "",
 		verbose:     cmdVerbose,
 	}
@@ -90,11 +93,11 @@ func verifyShowClusterPreconditions(args showClusterArguments, cmdLineArgs []str
 }
 
 // getClusterDetails returns details for one cluster.
-func getClusterDetails(clusterID, token, endpoint string) (gsclientgen.V4ClusterDetailsModel, error) {
+func getClusterDetails(clusterID, scheme, token, endpoint string) (gsclientgen.V4ClusterDetailsModel, error) {
 	result := gsclientgen.V4ClusterDetailsModel{}
 
 	// perform API call
-	authHeader := "giantswarm " + token
+	authHeader := scheme + " " + token
 	clientConfig := client.Configuration{
 		Endpoint:  endpoint,
 		UserAgent: config.UserAgent(),
@@ -163,7 +166,7 @@ func showClusterRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 	args := defaultShowClusterArguments()
 	args.clusterID = cmdLineArgs[0]
 
-	clusterDetails, err := getClusterDetails(args.clusterID,
+	clusterDetails, err := getClusterDetails(args.clusterID, args.scheme,
 		args.authToken, args.apiEndpoint)
 
 	if err != nil {

--- a/commands/show_cluster_test.go
+++ b/commands/show_cluster_test.go
@@ -40,6 +40,7 @@ func TestShowAWSCluster(t *testing.T) {
 	testArgs := showClusterArguments{
 		apiEndpoint: mockServer.URL,
 		clusterID:   "cluster-id",
+		scheme:      "giantswarm",
 		authToken:   "my-token",
 	}
 
@@ -49,7 +50,7 @@ func TestShowAWSCluster(t *testing.T) {
 	}
 
 	details, showErr := getClusterDetails(testArgs.clusterID,
-		testArgs.authToken, testArgs.apiEndpoint)
+		testArgs.scheme, testArgs.authToken, testArgs.apiEndpoint)
 	if showErr != nil {
 		t.Error(showErr)
 	}
@@ -81,6 +82,7 @@ func TestShowClusterNotAuthorized(t *testing.T) {
 	testArgs := showClusterArguments{
 		apiEndpoint: mockServer.URL,
 		clusterID:   "cluster-id",
+		scheme:      "giantswarm",
 		authToken:   "my-wrong-token",
 	}
 
@@ -90,7 +92,7 @@ func TestShowClusterNotAuthorized(t *testing.T) {
 	}
 
 	_, err = getClusterDetails(testArgs.clusterID,
-		testArgs.authToken, testArgs.apiEndpoint)
+		testArgs.scheme, testArgs.authToken, testArgs.apiEndpoint)
 
 	if err == nil {
 		t.Fatal("Expected notAuthorizedError, got nil")
@@ -122,6 +124,7 @@ func TestShowClusterNotFound(t *testing.T) {
 	testArgs := showClusterArguments{
 		apiEndpoint: mockServer.URL,
 		clusterID:   "non-existing-cluster-id",
+		scheme:      "giantswarm",
 		authToken:   "my-token",
 	}
 
@@ -131,7 +134,7 @@ func TestShowClusterNotFound(t *testing.T) {
 	}
 
 	_, err = getClusterDetails(testArgs.clusterID,
-		testArgs.authToken, testArgs.apiEndpoint)
+		testArgs.scheme, testArgs.authToken, testArgs.apiEndpoint)
 
 	if err == nil {
 		t.Fatal("Expected clusterNotFoundError, got nil")
@@ -163,6 +166,7 @@ func TestShowClusterInternalServerError(t *testing.T) {
 	testArgs := showClusterArguments{
 		apiEndpoint: mockServer.URL,
 		clusterID:   "non-existing-cluster-id",
+		scheme:      "giantswarm",
 		authToken:   "my-token",
 	}
 
@@ -172,7 +176,7 @@ func TestShowClusterInternalServerError(t *testing.T) {
 	}
 
 	_, err = getClusterDetails(testArgs.clusterID,
-		testArgs.authToken, testArgs.apiEndpoint)
+		testArgs.scheme, testArgs.authToken, testArgs.apiEndpoint)
 
 	if err == nil {
 		t.Fatal("Expected internalServerError, got nil")

--- a/config/config.go
+++ b/config/config.go
@@ -94,6 +94,11 @@ type configStruct struct {
 	// SelectedEndpoint is the URL of the selected endpoint
 	SelectedEndpoint string `yaml:"selected_endpoint"`
 
+	// Scheme is the scheme found for the selected endpoint. Might be empty.
+	// Not marshalled back to the config file, as it is contained in the
+	// endpoint's entry.
+	Scheme string `yaml:"-"`
+
 	// Token is the token found for the selected endpoint. Might be empty.
 	// Not marshalled back to the config file, as it is contained in the
 	// endpoint's entry.
@@ -115,7 +120,7 @@ type endpointConfig struct {
 	Token string `yaml:"token"`
 
 	// Scheme is the scheme to be used in the Authorization header.
-	Scheme string `yaml:"sceme"`
+	Scheme string `yaml:"scheme"`
 
 	// Alias is a friendly shortcut for the endpoint
 	Alias string `yaml:"alias,omitempty"`
@@ -155,9 +160,10 @@ func (c *configStruct) StoreEndpointAuth(endpointURL string, alias string, email
 	}
 
 	c.Endpoints[ep] = &endpointConfig{
-		Alias: aliasBefore,
-		Email: email,
-		Token: token,
+		Alias:  aliasBefore,
+		Email:  email,
+		Scheme: "giantswarm",
+		Token:  token,
 	}
 
 	if alias != "" && aliasBefore == "" {
@@ -199,7 +205,13 @@ func (c *configStruct) SelectEndpoint(endpointAliasOrURL string) error {
 		}
 	}
 
+	// Migrate empty scheme to 'giantswarm'
+	if c.Endpoints[ep].Scheme == "" {
+		c.Endpoints[ep].Scheme = "giantswarm"
+	}
+
 	c.SelectedEndpoint = ep
+	c.Scheme = c.Endpoints[ep].Scheme
 	c.Token = c.Endpoints[ep].Token
 	c.Email = c.Endpoints[ep].Email
 

--- a/config/config.go
+++ b/config/config.go
@@ -542,7 +542,7 @@ func GetDefaultCluster(requestIDHeader, activityName, cmdLine, apiEndpoint strin
 		return "", microerror.Mask(clientErr)
 	}
 
-	authHeader := "giantswarm " + Config.Token
+	authHeader := Config.Scheme + " " + Config.Token
 
 	clustersResponse, _, err := apiClient.GetClusters(authHeader, requestIDHeader, activityName, cmdLine)
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -114,6 +114,9 @@ type endpointConfig struct {
 	// Token is the session token of the authenticated user.
 	Token string `yaml:"token"`
 
+	// Scheme is the scheme to be used in the Authorization header.
+	Scheme string `yaml:"sceme"`
+
 	// Alias is a friendly shortcut for the endpoint
 	Alias string `yaml:"alias,omitempty"`
 }
@@ -240,6 +243,27 @@ func (c *configStruct) ChooseToken(endpoint, overridingToken string) string {
 	if endpointStruct, ok := c.Endpoints[ep]; ok {
 		if endpointStruct != nil && endpointStruct.Token != "" {
 			return endpointStruct.Token
+		}
+	}
+
+	return ""
+}
+
+// ChooseScheme chooses a scheme to use, according to a rule set.
+// - If the given scheme is not empty, we use (return) that
+// - If the given scheme is empty and we have an auth scheme for the given
+//   endpoint, we return that
+// - otherwise we return an empty string
+func (c *configStruct) ChooseScheme(endpoint, overridingScheme string) string {
+	ep := normalizeEndpoint(endpoint)
+
+	if overridingScheme != "" {
+		return overridingScheme
+	}
+
+	if endpointStruct, ok := c.Endpoints[ep]; ok {
+		if endpointStruct != nil && endpointStruct.Scheme != "" {
+			return endpointStruct.Scheme
 		}
 	}
 


### PR DESCRIPTION
Let gsctl support the alternative Bearer scheme for passing a JWT token to the API.

This adds the `--auth-scheme` optional global parameter to gsctl, which will let users effectively change the Authorization header that gsctl's api client uses.

This is part of multiple steps towards supporting SSO in gsctl.

```
$ ./gsctl list releases --help
Prints detail on all available releases.

A release is a software bundle that constitutes a cluster. It is identified by its semantic version number.

Usage:
  gsctl list releases [flags]

Flags:
  -h, --help   help for releases

Global Flags:
      --auth-scheme string   Authorization scheme to use (giantswarm or Bearer, case sensitive) (default "giantswarm")
      --auth-token string    Authorization token to use
      --config-dir string    Configuration directory path to use (default "/Users/oponder/.config/gsctl")
  -e, --endpoint string      The API endpoint to use
  -v, --verbose              Print more information
```

Related to: https://github.com/giantswarm/giantswarm/issues/2480