### PR TITLE
Make sure auth0 errors before recieving the code bubble up to the CLI

### DIFF
--- a/pkce/pkce.go
+++ b/pkce/pkce.go
@@ -73,6 +73,17 @@ func Run() (pkceResponse, error) {
 	p, err := startCallbackServer("8085", "/oauth/callback", func(w http.ResponseWriter, r *http.Request) (interface{}, error) {
 		// Get the code that Auth0 gave us.
 		code := r.URL.Query().Get("code")
+		errorCode := r.URL.Query().Get("error")
+		errorDescription := r.URL.Query().Get("error_description")
+
+		if errorCode != "" {
+			pkceResponse := pkceResponse{
+				Error:            errorCode,
+				ErrorDescription: errorDescription,
+			}
+
+			return pkceResponse, microerror.Maskf(authorizationError, pkceResponse.ErrorDescription)
+		}
 
 		// We now have the 'code' which we can then finally exchange
 		// for a real id token by doing a final request to Auth0 and passing the code


### PR DESCRIPTION
This lets users know what went wrong if we couldn't get the 'code' from Auth0