### PR TITLE
Highlight expiring key pair

### DIFF
--- a/commands/list_keypairs.go
+++ b/commands/list_keypairs.go
@@ -155,13 +155,19 @@ func listKeypairsOutput(cmd *cobra.Command, extraArgs []string) {
 		output = append(output, strings.Join(headers, "|"))
 
 		for _, keypair := range result.keypairs {
-			created := util.ParseDate(keypair.CreateDate)
-			expires := util.ParseDate(keypair.CreateDate).Add(time.Duration(keypair.TTLHours) * time.Hour)
+			createdTime := util.ParseDate(keypair.CreateDate)
+			expiryTime := createdTime.Add(time.Duration(keypair.TTLHours) * time.Hour)
+			expiryDuration := expiryTime.Sub(time.Now())
+			expires := util.ShortDate(expiryTime)
+
+			if expiryDuration < (24 * time.Hour) {
+				expires = color.YellowString(expires)
+			}
 
 			// Idea: skip if expired, or only display when verbose
 			row := []string{
-				util.ShortDate(created),
-				util.ShortDate(expires),
+				util.ShortDate(createdTime),
+				expires,
 				util.Truncate(util.CleanKeypairID(keypair.ID), 10, !args.full),
 				keypair.Description,
 				util.Truncate(keypair.CommonName, 24, !args.full),


### PR DESCRIPTION
This PR highlights the expiry value of key pairs that are about to expire within 24 hours, to raise awareness.

Does the same as https://github.com/giantswarm/happa/pull/356 does in happa.

### Preview

![image](https://user-images.githubusercontent.com/273727/43245846-06651b62-90b0-11e8-9afb-3c5c1b06aa26.png)
