### PR TITLE
Handle keypair exceeding limits

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -138,8 +138,7 @@ func handleCommonErrors(err error) {
 	var subtext = ""
 
 	// V2 client error handling
-	convertedErr, ok := err.(*clienterror.APIError)
-	if ok {
+	if convertedErr, ok := err.(*clienterror.APIError); ok {
 		headline = convertedErr.ErrorMessage
 		subtext = convertedErr.ErrorDetails
 	} else {

--- a/commands/create_keypair.go
+++ b/commands/create_keypair.go
@@ -55,8 +55,12 @@ func defaultCreateKeypairArguments() (createKeypairArguments, error) {
 	}
 
 	ttl, err := util.ParseDuration(cmdTTL)
-	if err != nil {
+	if IsInvalidDurationError(err) {
 		return createKeypairArguments{}, microerror.Mask(invalidDurationError)
+	} else if IsDurationExceededError(err) {
+		return createKeypairArguments{}, microerror.Mask(durationExceededError)
+	} else if err != nil {
+		return createKeypairArguments{}, microerror.Mask(durationExceededError)
 	}
 
 	return createKeypairArguments{
@@ -104,6 +108,9 @@ func createKeyPairPreRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 		if IsInvalidDurationError(argsErr) {
 			fmt.Println(color.RedString("The value passed with --ttl is invalid."))
 			fmt.Println("Please provide a number and a unit, e. g. '10h', '1d', '1w'.")
+		} else if IsDurationExceededError(argsErr) {
+			fmt.Println(color.RedString("The expiration period passed with --ttl is too long."))
+			fmt.Println("The maximum possible value is the eqivalent of 292 years.")
 		} else {
 			fmt.Println(color.RedString(argsErr.Error()))
 		}

--- a/commands/create_keypair.go
+++ b/commands/create_keypair.go
@@ -169,6 +169,10 @@ func createKeyPairRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 		var subtext string
 
 		switch {
+		case IsBadRequestError(err):
+			headline = "API Error 400: Bad Request"
+			subtext = "The key pair could not be created with the given parameters. Please try a shorter expiry period (--ttl)\n"
+			subtext += "and check the other arguments, too. Please contact the Giant Swarm support team if you need assistance."
 		default:
 			headline = err.Error()
 		}
@@ -219,6 +223,8 @@ func createKeypair(args createKeypairArguments) (createKeypairResult, error) {
 				return result, microerror.Mask(clusterNotFoundError)
 			} else if clientErr.HTTPStatusCode == http.StatusForbidden {
 				return result, microerror.Mask(accessForbiddenError)
+			} else if clientErr.HTTPStatusCode == http.StatusBadRequest {
+				return result, microerror.Maskf(badRequestError, clientErr.ErrorDetails)
 			}
 		}
 

--- a/commands/create_kubeconfig.go
+++ b/commands/create_kubeconfig.go
@@ -98,8 +98,12 @@ func defaultCreateKubeconfigArguments() (createKubeconfigArguments, error) {
 	}
 
 	ttl, err := util.ParseDuration(cmdTTL)
-	if err != nil {
+	if IsInvalidDurationError(err) {
 		return createKubeconfigArguments{}, microerror.Mask(invalidDurationError)
+	} else if IsDurationExceededError(err) {
+		return createKubeconfigArguments{}, microerror.Mask(durationExceededError)
+	} else if err != nil {
+		return createKubeconfigArguments{}, microerror.Mask(err)
 	}
 
 	return createKubeconfigArguments{
@@ -205,6 +209,9 @@ func createKubeconfigPreRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 		if IsInvalidDurationError(argsErr) {
 			fmt.Println(color.RedString("The value passed with --ttl is invalid."))
 			fmt.Println("Please provide a number and a unit, e. g. '10h', '1d', '1w'.")
+		} else if IsDurationExceededError(argsErr) {
+			fmt.Println(color.RedString("The expiration period passed with --ttl is too long."))
+			fmt.Println("The maximum possible value is the eqivalent of 292 years.")
 		} else {
 			fmt.Println(color.RedString(argsErr.Error()))
 		}

--- a/commands/create_kubeconfig.go
+++ b/commands/create_kubeconfig.go
@@ -319,6 +319,10 @@ func createKubeconfigRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 		case IsCouldNotWriteFileError(err):
 			headline = "Error: File could not be written"
 			subtext = fmt.Sprintf("Details: %s", err.Error())
+		case IsBadRequestError(err):
+			headline = "API Error 400: Bad Request"
+			subtext = "The key pair could not be created with the given parameters. Please try a shorter expiry period (--ttl)\n"
+			subtext += "and check the other arguments, too. Please contact the Giant Swarm support team if you need assistance."
 		default:
 			headline = err.Error()
 		}
@@ -401,6 +405,8 @@ func createKubeconfig(args createKubeconfigArguments) (createKubeconfigResult, e
 				return result, microerror.Mask(clusterNotFoundError)
 			} else if clientErr.HTTPStatusCode == http.StatusForbidden {
 				return result, microerror.Mask(accessForbiddenError)
+			} else if clientErr.HTTPStatusCode == http.StatusBadRequest {
+				return result, microerror.Maskf(badRequestError, clientErr.ErrorDetails)
 			}
 		}
 

--- a/commands/error.go
+++ b/commands/error.go
@@ -340,6 +340,14 @@ func IsInvalidDurationError(err error) bool {
 	return errgo.Cause(err) == invalidDurationError
 }
 
+// durationExceededError is thrown when a duration value is larger than can be represented internally
+var durationExceededError = errgo.New("duration limit exceeded")
+
+// IsDurationExceededError asserts durationExceededError
+func IsDurationExceededError(err error) bool {
+	return errgo.Cause(err) == durationExceededError
+}
+
 // ssoError means something went wrong during the SSO process
 var ssoError = errgo.New("sso error")
 

--- a/util/duration.go
+++ b/util/duration.go
@@ -10,6 +10,15 @@ import (
 	"github.com/giantswarm/microerror"
 )
 
+const (
+	// roughly the largest time.Duration values representable
+	maxDurationInHours  = 2562047
+	maxDurationInDays   = 106751
+	maxDurationInWeeks  = 15250
+	maxDurationInMonths = 3558
+	maxDurationInYears  = 292
+)
+
 // DurationPhrase creates a human-friendly phrase from a number of hours
 // expressing a duration, like "3 days, 2 hours". Precision of output
 // is limited in favour of readability.
@@ -101,17 +110,36 @@ func ParseDuration(durationString string) (time.Duration, error) {
 	number := int64(numberInt)
 
 	unit := match[2]
-	if unit == "h" {
+
+	//
+
+	switch unit {
+	case "h":
+		if number > maxDurationInHours {
+			return duration, microerror.Mask(durationExceededError)
+		}
 		duration = 3600 * time.Duration(number) * time.Second
-	} else if unit == "d" {
+	case "d":
+		if number > maxDurationInDays {
+			return duration, microerror.Mask(durationExceededError)
+		}
 		duration = 24 * 3600 * time.Duration(number) * time.Second
-	} else if unit == "w" {
+	case "w":
+		if number > maxDurationInWeeks {
+			return duration, microerror.Mask(durationExceededError)
+		}
 		duration = 7 * 24 * 3600 * time.Duration(number) * time.Second
-	} else if unit == "m" {
+	case "m":
+		if number > maxDurationInMonths {
+			return duration, microerror.Mask(durationExceededError)
+		}
 		duration = 30 * 24 * 3600 * time.Duration(number) * time.Second
-	} else if unit == "y" {
+	case "y":
+		if number > maxDurationInYears {
+			return duration, microerror.Mask(durationExceededError)
+		}
 		duration = 365 * 24 * 3600 * time.Duration(number) * time.Second
-	} else {
+	default:
 		return duration, microerror.Mask(InvalidDurationStringError)
 	}
 

--- a/util/duration_test.go
+++ b/util/duration_test.go
@@ -50,6 +50,13 @@ func TestParseDuration(t *testing.T) {
 		{"1w", 7 * 24 * time.Hour},
 		{"1m", 30 * 24 * time.Hour},
 		{"1y", 365 * 24 * time.Hour},
+		{"10y", 10 * 365 * 24 * time.Hour},
+		{"100y", 100 * 365 * 24 * time.Hour},
+		{"2562047h", 2562047 * time.Hour},
+		{"106751d", 106751 * 24 * time.Hour},
+		{"15250w", 15250 * 7 * 24 * time.Hour},
+		{"3558m", 3558 * 30 * 24 * time.Hour},
+		{"292y", 292 * 365 * 24 * time.Hour},
 	}
 
 	for _, tc := range testCases {
@@ -58,6 +65,29 @@ func TestParseDuration(t *testing.T) {
 			t.Errorf("Value '%s' yielded error: '%s'", tc.in, err)
 		} else if duration != tc.out {
 			t.Errorf("Value '%s', got '%v', wanted '%v'", tc.in, duration, tc.out)
+		}
+	}
+}
+
+// TestParseDurationError tests the parsing of durations which is supposed to fail
+func TestParseDurationError(t *testing.T) {
+	testCases := []struct {
+		in           string
+		errorMatcher func(error) bool
+	}{
+		{"", IsInvalidDurationStringError},
+		{"10f", IsInvalidDurationStringError},
+		{"293y", IsDurationExceededError},
+		{"3559m", IsDurationExceededError},
+		{"15251w", IsDurationExceededError},
+		{"106752d", IsDurationExceededError},
+		{"2562048h", IsDurationExceededError},
+	}
+
+	for _, tc := range testCases {
+		_, err := ParseDuration(tc.in)
+		if !tc.errorMatcher(err) {
+			t.Errorf("test case '%s': Expected error, got '%#v'", tc.in, err)
 		}
 	}
 }

--- a/util/duration_test.go
+++ b/util/duration_test.go
@@ -5,56 +5,59 @@ import (
 	"time"
 )
 
-var friendlyDurationTest = []struct {
-	in  int
-	out string
-}{
-	{1, "1 hour"},
-	{12, "12 hours"},
-	{24, "1 day"},
-	{25, "1 day, 1 hour"},
-	{26, "1 day, 2 hours"},
-	{48, "2 days"},
-	{49, "2 days, 1 hour"},
-	{75, "3 days, 3 hours"},
-	{24 * 7, "1 week"},
-	{24*7*2 - 5, "1 week, 6 days"},
-	{24 * 7 * 2, "2 weeks"},
-	{24*7*2 + 5, "2 weeks, 5 hours"},
-	{11 * 24 * 30, "11 months"},
-	{365 * 24, "1 year"},
-	{365*24 + 4, "1 year, 4 hours"},
-	{365*24 + 30, "1 year, 1 day"},
-	{365*24*2 + 30, "2 years, 1 day"},
-}
-
+// TestFriendlyDuration tests the conversion from duration integers
+// into user-friendly phrases.
 func TestFriendlyDuration(t *testing.T) {
-	for _, tt := range friendlyDurationTest {
-		phrase := DurationPhrase(tt.in)
-		if phrase != tt.out {
-			t.Errorf("Value '%d', got '%s', wanted '%s'", tt.in, phrase, tt.out)
+	var testCases = []struct {
+		in  int
+		out string
+	}{
+		{1, "1 hour"},
+		{12, "12 hours"},
+		{24, "1 day"},
+		{25, "1 day, 1 hour"},
+		{26, "1 day, 2 hours"},
+		{48, "2 days"},
+		{49, "2 days, 1 hour"},
+		{75, "3 days, 3 hours"},
+		{24 * 7, "1 week"},
+		{24*7*2 - 5, "1 week, 6 days"},
+		{24 * 7 * 2, "2 weeks"},
+		{24*7*2 + 5, "2 weeks, 5 hours"},
+		{11 * 24 * 30, "11 months"},
+		{365 * 24, "1 year"},
+		{365*24 + 4, "1 year, 4 hours"},
+		{365*24 + 30, "1 year, 1 day"},
+		{365*24*2 + 30, "2 years, 1 day"},
+	}
+
+	for _, tc := range testCases {
+		phrase := DurationPhrase(tc.in)
+		if phrase != tc.out {
+			t.Errorf("Value '%d', got '%s', wanted '%s'", tc.in, phrase, tc.out)
 		}
 	}
 }
 
-var parseDurationTest = []struct {
-	in  string
-	out time.Duration
-}{
-	{"1h", 1 * time.Hour},
-	{"1d", 24 * time.Hour},
-	{"1w", 7 * 24 * time.Hour},
-	{"1m", 30 * 24 * time.Hour},
-	{"1y", 365 * 24 * time.Hour},
-}
-
+// TestParseDuration tests the parsing of durations into time.Duration values
 func TestParseDuration(t *testing.T) {
-	for _, tt := range parseDurationTest {
-		duration, err := ParseDuration(tt.in)
+	var testCases = []struct {
+		in  string
+		out time.Duration
+	}{
+		{"1h", 1 * time.Hour},
+		{"1d", 24 * time.Hour},
+		{"1w", 7 * 24 * time.Hour},
+		{"1m", 30 * 24 * time.Hour},
+		{"1y", 365 * 24 * time.Hour},
+	}
+
+	for _, tc := range testCases {
+		duration, err := ParseDuration(tc.in)
 		if err != nil {
-			t.Errorf("Value '%s' yielded error: '%s'", tt.in, err)
-		} else if duration != tt.out {
-			t.Errorf("Value '%s', got '%v', wanted '%v'", tt.in, duration, tt.out)
+			t.Errorf("Value '%s' yielded error: '%s'", tc.in, err)
+		} else if duration != tc.out {
+			t.Errorf("Value '%s', got '%v', wanted '%v'", tc.in, duration, tc.out)
 		}
 	}
 }

--- a/util/error.go
+++ b/util/error.go
@@ -41,3 +41,11 @@ var InvalidDurationStringError = errgo.New("could not parse duration string")
 func IsInvalidDurationStringError(err error) bool {
 	return errgo.Cause(err) == InvalidDurationStringError
 }
+
+// durationExceededError is thrown when a duration value is larger than can be represented internally
+var durationExceededError = errgo.New("duration limit exceeded")
+
+// IsDurationExceededError asserts durationExceededError
+func IsDurationExceededError(err error) bool {
+	return errgo.Cause(err) == durationExceededError
+}


### PR DESCRIPTION
For https://github.com/giantswarm/giantswarm/issues/3731

This PR does two things:

- Adds handling of a bad request error with a hint to adjust the TTL. Unfortunately the API doesn't give a specific error currently, so we can't be more specific than that.

- Adds validation for the TTL time being above 292 years, which is maybe a bit silly, but it's the absolute maximum that can be represented using a Go `time.Duration`.