### PR TITLE
Update ping command to use / instead of /v1/ping

### DIFF
--- a/commands/ping.go
+++ b/commands/ping.go
@@ -46,7 +46,7 @@ func runPingCommand(cmd *cobra.Command, args []string) {
 	}
 
 	fmt.Println(color.GreenString("API connection is fine"))
-	fmt.Printf("Ping took %d Milliseconds\n", int(duration.Seconds()*1000))
+	fmt.Printf("Ping took %d Milliseconds\n", duration/time.Millisecond)
 }
 
 // ping checks the API connection and returns

--- a/commands/ping.go
+++ b/commands/ping.go
@@ -54,12 +54,12 @@ func runPingCommand(cmd *cobra.Command, args []string) {
 func ping(endpointURL string) (time.Duration, error) {
 	var duration time.Duration
 
-	// create URI
+	// create root URI for the endpoint
 	u, err := url.Parse(endpointURL)
 	if err != nil {
 		return duration, microerror.Mask(err)
 	}
-	u, err = u.Parse("/v1/ping")
+	u, err = u.Parse("/")
 	if err != nil {
 		return duration, microerror.Mask(err)
 	}

--- a/commands/ping.go
+++ b/commands/ping.go
@@ -46,7 +46,7 @@ func runPingCommand(cmd *cobra.Command, args []string) {
 	}
 
 	fmt.Println(color.GreenString("API connection is fine"))
-	fmt.Printf("Ping took %v\n", duration)
+	fmt.Printf("Ping took %d Milliseconds\n", int(duration.Seconds()*1000))
 }
 
 // ping checks the API connection and returns


### PR DESCRIPTION
In addition, the output is changed to a meaningful precision.

Before:

    Ping took 165.135135ms

After:

    Ping took 113 Milliseconds