### PR TITLE
SSO login: add verbose output, handle connection error

### DIFF
--- a/commands/login_sso.go
+++ b/commands/login_sso.go
@@ -3,8 +3,11 @@ package commands
 import (
 	"fmt"
 	"math/rand"
+	"net/http"
 	"time"
 
+	"github.com/fatih/color"
+	"github.com/giantswarm/gsctl/client/clienterror"
 	"github.com/giantswarm/gsctl/config"
 	"github.com/giantswarm/gsctl/pkce"
 	"github.com/giantswarm/microerror"
@@ -19,8 +22,9 @@ func loginSSO(args loginArguments) (loginResult, error) {
 
 	pkceResponse, err := pkce.Run()
 	if err != nil {
-		fmt.Printf("DEBUG Error in pkce.Run(): %#v\n", err)
-		fmt.Printf("DEBUG pkce.Run() pkceResponse.ErrorDescription: %#v\n", pkceResponse.ErrorDescription)
+		if args.verbose {
+			fmt.Println(color.WhiteString("Attempt to run the OAuth2 PKCE workflow with a local callback HTTP server failed."))
+		}
 		return loginResult{}, microerror.Maskf(ssoError, pkceResponse.ErrorDescription)
 	}
 
@@ -33,17 +37,35 @@ func loginSSO(args loginArguments) (loginResult, error) {
 	// Check if the access token works by fetching the installation's name.
 	alias, err := getAlias(args.apiEndpoint, "Bearer", pkceResponse.AccessToken)
 	if err != nil {
-		fmt.Printf("DEBUG Error in getAlias: %#v\n", err)
-		return loginResult{}, microerror.Maskf(ssoError, "Unable to fetch installation information. Our api might be experiencing difficulties")
+		if args.verbose {
+			fmt.Println(color.WhiteString("Attempt to use new token against the API failed."))
+			if cErr, ok := err.(*clienterror.APIError); ok {
+				fmt.Println(color.WhiteString("Underlying error details: %s", cErr.OriginalError.Error()))
+			} else {
+				fmt.Println(color.WhiteString("Error details: %s", err.Error()))
+			}
+		}
+
+		if clientErr, ok := err.(*clienterror.APIError); ok {
+			if clientErr.HTTPStatusCode == http.StatusForbidden {
+				return loginResult{}, microerror.Mask(accessForbiddenError)
+			}
+
+			return loginResult{}, clientErr
+		}
+
+		return loginResult{}, microerror.Maskf(ssoError, err.Error())
 	}
 
 	// Store the token in the config file.
 	if err := config.Config.StoreEndpointAuth(args.apiEndpoint, alias, idToken.Email, "Bearer", pkceResponse.AccessToken); err != nil {
-		fmt.Printf("DEBUG Error in StoreEndpointAuth: %#v\n", err)
+		if args.verbose {
+			fmt.Println(color.WhiteString("Attempt to store our authentication data with the endpoint in the configuration failed."))
+			fmt.Println(color.WhiteString("Error details: %s", err.Error()))
+		}
 		return loginResult{}, microerror.Maskf(ssoError, "Error while attempting to store the token in the config file")
 	}
 	if err := config.Config.SelectEndpoint(args.apiEndpoint); err != nil {
-		fmt.Printf("DEBUG Error in SelectEndpoint: %#v\n", err)
 		return loginResult{}, microerror.Mask(err)
 	}
 

--- a/commands/login_sso.go
+++ b/commands/login_sso.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"fmt"
 	"math/rand"
 	"time"
 
@@ -18,6 +19,8 @@ func loginSSO(args loginArguments) (loginResult, error) {
 
 	pkceResponse, err := pkce.Run()
 	if err != nil {
+		fmt.Printf("DEBUG Error in pkce.Run(): %#v\n", err)
+		fmt.Printf("DEBUG pkce.Run() pkceResponse.ErrorDescription: %#v\n", pkceResponse.ErrorDescription)
 		return loginResult{}, microerror.Maskf(ssoError, pkceResponse.ErrorDescription)
 	}
 
@@ -30,14 +33,17 @@ func loginSSO(args loginArguments) (loginResult, error) {
 	// Check if the access token works by fetching the installation's name.
 	alias, err := getAlias(args.apiEndpoint, "Bearer", pkceResponse.AccessToken)
 	if err != nil {
+		fmt.Printf("DEBUG Error in getAlias: %#v\n", err)
 		return loginResult{}, microerror.Maskf(ssoError, "Unable to fetch installation information. Our api might be experiencing difficulties")
 	}
 
 	// Store the token in the config file.
 	if err := config.Config.StoreEndpointAuth(args.apiEndpoint, alias, idToken.Email, "Bearer", pkceResponse.AccessToken); err != nil {
+		fmt.Printf("DEBUG Error in StoreEndpointAuth: %#v\n", err)
 		return loginResult{}, microerror.Maskf(ssoError, "Error while attempting to store the token in the config file")
 	}
 	if err := config.Config.SelectEndpoint(args.apiEndpoint); err != nil {
+		fmt.Printf("DEBUG Error in SelectEndpoint: %#v\n", err)
 		return loginResult{}, microerror.Mask(err)
 	}
 


### PR DESCRIPTION
This originated in user feedback regarding a problem with `gsctl login --sso`. The root cause was VPN issues.

With the new client, a bad VPN connection or IP-based blocking from the API results in an error that originates from the attempt to parse the response body as JSON. In this case we don't even get the HTTP status response code back, so all we have to test against is the error string.

While at it, I added optional output to be activated using `-v|--verbose` in case of an error.