### PR TITLE
Introduce AuthHeaderGetter for eventual Access Token refreshing.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -76,6 +76,9 @@ type WrapperV2 struct {
 
 // NewV2 creates a client based on the latest gsclientgen version.
 func NewV2(conf *Configuration) (*WrapperV2, error) {
+	if conf.AuthHeaderGetter == nil {
+		conf.AuthHeaderGetter = func() (string, error) { return "", nil }
+	}
 	if conf.Endpoint == "" {
 		return nil, microerror.Mask(endpointNotSpecifiedError)
 	}

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/giantswarm/gsctl/client"
 	"github.com/giantswarm/gsctl/client/clienterror"
+	"github.com/giantswarm/gsctl/config"
 )
 
 var (
@@ -177,11 +178,15 @@ func handleCommonErrors(err error) {
 			headline = "The API didn't send a response."
 			subtext = "Please check your connection using 'gsctl ping'. If your connection is fine,\n"
 			subtext += "please try again in a few moments."
+		case config.IsUnableToRefreshTokenErrorr(err):
+			headline = "Unable to refresh your SSO Token."
+			subtext = "Please try loging in again using: gsctl login --sso"
 		case IsUnknownError(err):
 			headline = "An error occurred."
 			subtext = "Please notify the Giant Swarm support team, or try the command again in a few moments.\n"
 			subtext += fmt.Sprintf("Details: %s", err.Error())
 		}
+
 	}
 
 	if headline == "" {

--- a/commands/login.go
+++ b/commands/login.go
@@ -253,12 +253,15 @@ func loginRunOutput(cmd *cobra.Command, args []string) {
 // If it succeeds it returns the alias for that endpoint.
 func getAlias(apiEndpoint string, scheme string, accessToken string) (string, error) {
 	// Create an API client.
-	authHeader := scheme + " " + accessToken
+	authHeaderGetter := func() (string, error) {
+		return scheme + " " + accessToken, nil
+	}
+
 	clientConfig := &client.Configuration{
-		Endpoint:   apiEndpoint,
-		Timeout:    10 * time.Second,
-		UserAgent:  config.UserAgent(),
-		AuthHeader: authHeader,
+		Endpoint:         apiEndpoint,
+		Timeout:          10 * time.Second,
+		UserAgent:        config.UserAgent(),
+		AuthHeaderGetter: authHeaderGetter,
 	}
 	clientV2, err := client.NewV2(clientConfig)
 	if err != nil {

--- a/commands/login_giantswarm.go
+++ b/commands/login_giantswarm.go
@@ -63,7 +63,7 @@ func loginGiantSwarm(args loginArguments) (loginResult, error) {
 	}
 	result.alias = alias
 
-	if err := config.Config.StoreEndpointAuth(args.apiEndpoint, result.alias, args.email, "giantswarm", result.token); err != nil {
+	if err := config.Config.StoreEndpointAuth(args.apiEndpoint, result.alias, args.email, "giantswarm", result.token, ""); err != nil {
 		return result, microerror.Mask(err)
 	}
 	if err := config.Config.SelectEndpoint(args.apiEndpoint); err != nil {

--- a/commands/login_sso.go
+++ b/commands/login_sso.go
@@ -58,7 +58,7 @@ func loginSSO(args loginArguments) (loginResult, error) {
 	}
 
 	// Store the token in the config file.
-	if err := config.Config.StoreEndpointAuth(args.apiEndpoint, alias, idToken.Email, "Bearer", pkceResponse.AccessToken); err != nil {
+	if err := config.Config.StoreEndpointAuth(args.apiEndpoint, alias, idToken.Email, "Bearer", pkceResponse.AccessToken, pkceResponse.RefreshToken); err != nil {
 		if args.verbose {
 			fmt.Println(color.WhiteString("Attempt to store our authentication data with the endpoint in the configuration failed."))
 			fmt.Println(color.WhiteString("Error details: %s", err.Error()))

--- a/commands/root.go
+++ b/commands/root.go
@@ -54,11 +54,9 @@ func initConfig(cmd *cobra.Command, args []string) error {
 
 func initClient() error {
 	endpoint := config.Config.ChooseEndpoint(cmdAPIEndpoint)
-	token := config.Config.ChooseToken(endpoint, cmdToken)
-	scheme := config.Config.ChooseScheme(endpoint, cmdToken)
 
 	ClientConfig = &client.Configuration{
-		AuthHeader: scheme + " " + token,
+		AuthHeaderGetter: config.Config.AuthHeaderGetter(endpoint, cmdToken),
 		Endpoint:   endpoint,
 		Timeout:    10 * time.Second,
 		UserAgent:  config.UserAgent(),

--- a/config/config.go
+++ b/config/config.go
@@ -94,6 +94,11 @@ type configStruct struct {
 	// SelectedEndpoint is the URL of the selected endpoint
 	SelectedEndpoint string `yaml:"selected_endpoint"`
 
+	// RefreshToken is the refresh token found for the selected endpoint. Might be empty.
+	// Not marshalled back to the config file, as it is contained in the
+	// endpoint's entry.
+	RefreshToken string `yaml:"-"`
+
 	// Scheme is the scheme found for the selected endpoint. Might be empty.
 	// Not marshalled back to the config file, as it is contained in the
 	// endpoint's entry.
@@ -163,10 +168,11 @@ func (c *configStruct) StoreEndpointAuth(endpointURL string, alias string, email
 	}
 
 	c.Endpoints[ep] = &endpointConfig{
-		Alias:  aliasBefore,
-		Email:  email,
-		Scheme: scheme,
-		Token:  token,
+		Alias:        aliasBefore,
+		Email:        email,
+		RefreshToken: refreshToken,
+		Scheme:       scheme,
+		Token:        token,
 	}
 
 	if alias != "" && aliasBefore == "" {
@@ -214,6 +220,7 @@ func (c *configStruct) SelectEndpoint(endpointAliasOrURL string) error {
 	}
 
 	c.SelectedEndpoint = ep
+	c.RefreshToken = c.Endpoints[ep].RefreshToken
 	c.Scheme = c.Endpoints[ep].Scheme
 	c.Token = c.Endpoints[ep].Token
 	c.Email = c.Endpoints[ep].Email
@@ -327,6 +334,7 @@ func (c *configStruct) Logout(endpointURL string) {
 	}
 
 	if element, ok := c.Endpoints[ep]; ok {
+		element.RefreshToken = ""
 		element.Token = ""
 		element.Scheme = ""
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -113,22 +113,25 @@ type configStruct struct {
 // endpointConfig is used to serialize/deserialize endpoint configuration
 // to/from a config file
 type endpointConfig struct {
+	// Alias is a friendly shortcut for the endpoint
+	Alias string `yaml:"alias,omitempty"`
+
 	// Email is the email address of the authenticated user.
 	Email string `yaml:"email"`
 
-	// Token is the session token of the authenticated user.
-	Token string `yaml:"token,omitempty"`
+	// RefreshToken for acquiring a new token when using the bearer scheme.
+	RefreshToken string `yaml:"refresh_token,omitempty"`
 
 	// Scheme is the scheme to be used in the Authorization header.
 	Scheme string `yaml:"auth_scheme,omitempty"`
 
-	// Alias is a friendly shortcut for the endpoint
-	Alias string `yaml:"alias,omitempty"`
+	// Token is the session token of the authenticated user.
+	Token string `yaml:"token,omitempty"`
 }
 
 // StoreEndpointAuth adds an endpoint to the configStruct.Endpoints field
 // (if not yet there). This should only be done after successful authentication.
-func (c *configStruct) StoreEndpointAuth(endpointURL string, alias string, email string, scheme string, token string) error {
+func (c *configStruct) StoreEndpointAuth(endpointURL string, alias string, email string, scheme string, token string, refreshToken string) error {
 	ep := normalizeEndpoint(endpointURL)
 
 	if email == "" || token == "" {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -60,6 +60,7 @@ func Test_Initialize_Empty(t *testing.T) {
 
 	testEndpointURL := "https://myapi.domain.tld"
 	testEmail := "user@domain.tld"
+	testRefreshToken := "some-refresh-token"
 	testScheme := "some-scheme"
 	testToken := "some-token"
 	testAlias := "testalias"
@@ -71,7 +72,7 @@ func Test_Initialize_Empty(t *testing.T) {
 
 	// directly set some configuration
 	Config.LastVersionCheck = time.Time{}
-	err = Config.StoreEndpointAuth(testEndpointURL, testAlias, testEmail, testScheme, testToken)
+	err = Config.StoreEndpointAuth(testEndpointURL, testAlias, testEmail, testScheme, testToken, testRefreshToken)
 	if err != nil {
 		t.Error(err)
 	}

--- a/config/error.go
+++ b/config/error.go
@@ -48,3 +48,14 @@ var garbageCollectionPartiallyFailedError = &microerror.Error{
 func IsGarbageCollectionPartiallyFailedError(err error) bool {
 	return microerror.Cause(err) == garbageCollectionPartiallyFailedError
 }
+
+// unableToRefreshToken indicates that we were not able to get a new access token
+// when we attempted to do so
+var unableToRefreshTokenError = &microerror.Error{
+	Kind: "IsUnableToRefreshTokenError",
+}
+
+// IsUnableToRefreshTokenErrorr asserts unableToRefreshTokenError.
+func IsUnableToRefreshTokenErrorr(err error) bool {
+	return microerror.Cause(err) == unableToRefreshTokenError
+}


### PR DESCRIPTION
This PR introduces my mechanism for being able to run some code on each client run.

Instead of passing it the auth header to use, we pass it a function it can use to get the auth header.

This function will then in the next PR be further developed to check whether or not the token we have
is valid, and if not, it will refresh the token.