### PR TITLE
Print "No clusters available" when no clusters found with 'gsctl list clusters'

### DIFF
--- a/commands/list_clusters.go
+++ b/commands/list_clusters.go
@@ -120,7 +120,7 @@ func clustersTable(args listClustersArguments) (string, error) {
 	}
 
 	if len(response.Payload) == 0 {
-		return color.YellowString("No clusters available"), nil
+		return color.YellowString("No clusters"), nil
 	}
 	// table headers
 	output := []string{strings.Join([]string{

--- a/commands/list_clusters.go
+++ b/commands/list_clusters.go
@@ -120,7 +120,7 @@ func clustersTable(args listClustersArguments) (string, error) {
 	}
 
 	if len(response.Payload) == 0 {
-		return "", nil
+		return color.YellowString("No clusters available"), nil
 	}
 	// table headers
 	output := []string{strings.Join([]string{

--- a/commands/list_clusters_test.go
+++ b/commands/list_clusters_test.go
@@ -104,8 +104,8 @@ func Test_ListClustersEmpty(t *testing.T) {
 		t.Error(err)
 	}
 
-	if table != "" {
-		t.Errorf("Expected '', got '%s'", table)
+	if table != "No clusters available" {
+		t.Errorf("Expected 'No clusters available', got '%s'", table)
 	}
 }
 

--- a/commands/list_clusters_test.go
+++ b/commands/list_clusters_test.go
@@ -104,8 +104,8 @@ func Test_ListClustersEmpty(t *testing.T) {
 		t.Error(err)
 	}
 
-	if table != "No clusters available" {
-		t.Errorf("Expected 'No clusters available', got '%s'", table)
+	if table != "No clusters" {
+		t.Errorf("Expected 'No clusters', got '%s'", table)
 	}
 }
 


### PR DESCRIPTION
`gsctl list clusters` would, as the only command, not print anything when it successfully communicated with the API but didn't get any items back to print. Changing this to match other list commands, as it is really unexpected.