### PR TITLE
Allow handling of microerror type errors

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/fatih/color"
+	"github.com/giantswarm/microerror"
 
 	"github.com/giantswarm/gsctl/client"
 	"github.com/giantswarm/gsctl/client/clienterror"
@@ -139,7 +140,10 @@ func handleCommonErrors(err error) {
 	var subtext = ""
 
 	// V2 client error handling
-	if convertedErr, ok := err.(*clienterror.APIError); ok {
+	if convertedErr, ok := microerror.Cause(err).(*clienterror.APIError); ok {
+		headline = convertedErr.ErrorMessage
+		subtext = convertedErr.ErrorDetails
+	} else if convertedErr, ok := err.(*clienterror.APIError); ok {
 		headline = convertedErr.ErrorMessage
 		subtext = convertedErr.ErrorDetails
 	} else {


### PR DESCRIPTION
For https://github.com/giantswarm/giantswarm/issues/3932

This adds handling of `microerror` masked errors to `handleCommonErrors`, in order to print full error details. This surfaced in `gsctl list clusters`, where the output was only:

```
Error: Malformed response
```

After the change, the output is

```
Malformed response
The response we received did not match the expected format. The reason could be that we
don't have access to the actual API server. Please check whether your network has access
using the 'gsctl ping' command with the according endpoint.
```