### PR TITLE
Remove storage from 'gsctl show cluster' output (AWS, Azure)

### DIFF
--- a/commands/show_cluster.go
+++ b/commands/show_cluster.go
@@ -210,7 +210,10 @@ func showClusterRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 
 	output = append(output, color.YellowString("CPU cores in workers:")+"|"+fmt.Sprintf("%d", sumWorkerCPUs(clusterDetails.Workers)))
 	output = append(output, color.YellowString("RAM in worker nodes (GB):")+"|"+fmt.Sprintf("%.2f", sumWorkerMemory(clusterDetails.Workers)))
-	output = append(output, color.YellowString("Storage in worker nodes (GB):")+"|"+fmt.Sprintf("%.2f", sumWorkerStorage(clusterDetails.Workers)))
+
+	if clusterDetails.Kvm != nil {
+		output = append(output, color.YellowString("Storage in worker nodes (GB):")+"|"+fmt.Sprintf("%.2f", sumWorkerStorage(clusterDetails.Workers)))
+	}
 
 	if clusterDetails.Kvm != nil && len(clusterDetails.Kvm.PortMappings) > 0 {
 		for _, portMapping := range clusterDetails.Kvm.PortMappings {


### PR DESCRIPTION
For https://github.com/giantswarm/giantswarm/issues/3953

As the worker node's local storage cannot be used by end users, for both AWS and Azure, we remove the display of that information from the output of `gsctl show cluster`.