### PR TITLE
Remove password from verbose output, colorize verbose output

### DIFF
--- a/commands/login_giantswarm.go
+++ b/commands/login_giantswarm.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 
+	"github.com/fatih/color"
 	"github.com/giantswarm/microerror"
 
 	"github.com/giantswarm/gsctl/config"
@@ -28,7 +29,7 @@ func loginGiantSwarm(args loginArguments) (loginResult, error) {
 	if config.Config.Token != "" {
 
 		if args.verbose {
-			fmt.Println("Logging out using a a previously stored token")
+			fmt.Println(color.WhiteString("Logging out using a a previously stored token"))
 		}
 
 		result.loggedOutBefore = true
@@ -43,7 +44,7 @@ func loginGiantSwarm(args loginArguments) (loginResult, error) {
 	ap.ActivityName = loginActivityName
 
 	if args.verbose {
-		fmt.Printf("Submitting API call with email '%s', password '%s'.\n", args.email, args.password)
+		fmt.Println(color.WhiteString("Submitting API call to create an authentication token with email '%s'", args.email))
 	}
 
 	response, err := ClientV2.CreateAuthToken(args.email, args.password, ap)
@@ -57,6 +58,10 @@ func loginGiantSwarm(args loginArguments) (loginResult, error) {
 	result.email = args.email
 
 	// fetch installation name as alias
+	if args.verbose {
+		fmt.Println(color.WhiteString("Fetching installation details"))
+	}
+
 	alias, err := getAlias(args.apiEndpoint, "giantswarm", result.token)
 	if err != nil {
 		return result, microerror.Mask(err)

--- a/commands/login_test.go
+++ b/commands/login_test.go
@@ -56,6 +56,7 @@ func Test_LoginValidPassword(t *testing.T) {
 		apiEndpoint: mockServer.URL,
 		email:       "email@example.com",
 		password:    "test password",
+		verbose:     true,
 	}
 
 	cmdAPIEndpoint = mockServer.URL


### PR DESCRIPTION
This PR removes the password from a terminal output of the `gsctl login` command.

In addition, it aligns the color with recent changes, to distinguish verbose output from normal output.