### PR TITLE
Wait if the token was issued in the 'future'

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -398,6 +398,7 @@ func (c *configStruct) AuthHeaderGetter(endpoint string, overridingToken string)
 // whether or not the access token is valid. Does not check if the signature is valid.
 // Only checkes time based claims.
 func isTokenValid(token string) (expired bool) {
+	return false
 	// Parse token
 	claims := jwt.MapClaims{}
 

--- a/config/config.go
+++ b/config/config.go
@@ -398,7 +398,6 @@ func (c *configStruct) AuthHeaderGetter(endpoint string, overridingToken string)
 // whether or not the access token is valid. Does not check if the signature is valid.
 // Only checkes time based claims.
 func isTokenValid(token string) (expired bool) {
-	return false
 	// Parse token
 	claims := jwt.MapClaims{}
 


### PR DESCRIPTION
When gsctl detects that the tokens `iat` claim is in the future, it will wait until the computer catches up to that time.

```
$ go build && ./gsctl list clusters

Your computer's clock appears to be a bit behind.
Issued at:  1538995180
Now:        1538995165
Difference: 15 seconds

Waiting...

ID     ORGANIZATION   NAME             RELEASE  CREATED
...
```

Towards: https://github.com/giantswarm/giantswarm/issues/4314