### PR TITLE
Add validation for CN prefix

### DIFF
--- a/commands/error.go
+++ b/commands/error.go
@@ -437,6 +437,16 @@ func IsUnspecifiedAPIError(err error) bool {
 	return microerror.Cause(err) == unspecifiedAPIError
 }
 
+// invalidCNPrefixError means the user has used bad characters in the CN prefix argument
+var invalidCNPrefixError = &microerror.Error{
+	Kind: "invalidCNPrefixError",
+}
+
+// IsInvalidCNPrefixError asserts invalidCNPrefixError
+func IsInvalidCNPrefixError(err error) bool {
+	return microerror.Cause(err) == invalidCNPrefixError
+}
+
 // invalidDurationError means that a user-provided duration string could not be parsed
 var invalidDurationError = &microerror.Error{
 	Kind: "invalidDurationError",


### PR DESCRIPTION
For https://github.com/giantswarm/giantswarm/issues/4275

This adds validation for the `--cn-prefix` flag to the `create kubeconfig` and `create keypair` commands.