### PR TITLE
Relax cn prefix validation for key pairs

### DIFF
--- a/commands/create_keypair.go
+++ b/commands/create_keypair.go
@@ -135,7 +135,7 @@ func createKeyPairPreRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 		return
 	case IsInvalidCNPrefixError(err):
 		headline = "Bad characters in CN prefix (--cn-prefix)"
-		subtext = "Please use thes characters only: a-z A-Z 0-9 . @ -"
+		subtext = "Please use these characters only: a-z A-Z 0-9 . @ -"
 	default:
 		headline = err.Error()
 	}

--- a/commands/create_keypair.go
+++ b/commands/create_keypair.go
@@ -135,7 +135,7 @@ func createKeyPairPreRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 		return
 	case IsInvalidCNPrefixError(err):
 		headline = "Bad characters in CN prefix (--cn-prefix)"
-		subtext = "Please use the characters a-z, 0-9, or . @ - only."
+		subtext = "Please use thes characters only: a-z A-Z 0-9 . @ -"
 	default:
 		headline = err.Error()
 	}

--- a/commands/create_keypair.go
+++ b/commands/create_keypair.go
@@ -135,7 +135,7 @@ func createKeyPairPreRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 		return
 	case IsInvalidCNPrefixError(err):
 		headline = "Bad characters in CN prefix (--cn-prefix)"
-		subtext = "Please use the characters a-z, 0-9, or - only."
+		subtext = "Please use the characters a-z, 0-9, or . @ - only."
 	default:
 		headline = err.Error()
 	}
@@ -161,7 +161,7 @@ func verifyCreateKeypairPreconditions(args createKeypairArguments) error {
 
 	// validate CN prefix character set
 	if args.commonNamePrefix != "" {
-		cnPrefixRE := regexp.MustCompile("^[a-z0-9][a-z0-9-]*[a-z0-9]$")
+		cnPrefixRE := regexp.MustCompile("^[a-zA-Z0-9][a-zA-Z0-9@\\.-]*[a-zA-Z0-9]$")
 		if !cnPrefixRE.MatchString(args.commonNamePrefix) {
 			return microerror.Mask(invalidCNPrefixError)
 		}

--- a/commands/create_kubeconfig.go
+++ b/commands/create_kubeconfig.go
@@ -245,7 +245,7 @@ func createKubeconfigPreRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 		}
 	case IsInvalidCNPrefixError(err):
 		headline = "Bad characters in CN prefix (--cn-prefix)"
-		subtext = "Please use the characters a-z, 0-9, or . @ - only."
+		subtext = "Please use thes characters only: a-z A-Z 0-9 . @ -"
 	default:
 		headline = err.Error()
 	}

--- a/commands/create_kubeconfig.go
+++ b/commands/create_kubeconfig.go
@@ -245,7 +245,7 @@ func createKubeconfigPreRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 		}
 	case IsInvalidCNPrefixError(err):
 		headline = "Bad characters in CN prefix (--cn-prefix)"
-		subtext = "Please use the characters a-z, 0-9, or - only."
+		subtext = "Please use the characters a-z, 0-9, or . @ - only."
 	default:
 		headline = err.Error()
 	}
@@ -274,7 +274,7 @@ func verifyCreateKubeconfigPreconditions(args createKubeconfigArguments, cmdLine
 
 	// validate CN prefix character set
 	if args.cnPrefix != "" {
-		cnPrefixRE := regexp.MustCompile("^[a-z0-9][a-z0-9-]*[a-z0-9]$")
+		cnPrefixRE := regexp.MustCompile("^[a-zA-Z0-9][a-zA-Z0-9@\\.-]*[a-zA-Z0-9]$")
 		if !cnPrefixRE.MatchString(args.cnPrefix) {
 			return microerror.Mask(invalidCNPrefixError)
 		}

--- a/commands/create_kubeconfig.go
+++ b/commands/create_kubeconfig.go
@@ -245,7 +245,7 @@ func createKubeconfigPreRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 		}
 	case IsInvalidCNPrefixError(err):
 		headline = "Bad characters in CN prefix (--cn-prefix)"
-		subtext = "Please use thes characters only: a-z A-Z 0-9 . @ -"
+		subtext = "Please use these characters only: a-z A-Z 0-9 . @ -"
 	default:
 		headline = err.Error()
 	}


### PR DESCRIPTION
As our previously introduced validation doesn't allow for email addresses, this relaxes the validation.