### PR TITLE
Use golang 1.11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ _testmain.go
 # Generated files
 bin-dist
 build
+/go-build-cache
 release
 /gsctl
 /gsctl.exe

--- a/Makefile
+++ b/Makefile
@@ -36,43 +36,59 @@ crosscompile: build/bin/$(BIN)-darwin-amd64 build/bin/$(BIN)-linux-amd64 build/b
 # platform-specific build
 build/bin/$(BIN)-darwin-amd64: $(SOURCE)
 	@mkdir -p build/bin
-	docker run --rm -v $(shell pwd):/go/src/github.com/$(ORGANISATION)/$(PROJECT) \
+	@mkdir -p go-build-cache
+	docker run --rm \
+		-v $(shell pwd):/go/src/github.com/$(ORGANISATION)/$(PROJECT) \
+		-v $(shell pwd)/go-build-cache:/.cache \
 		-e GOPATH=/go -e GOOS=darwin -e GOARCH=amd64 -e CGO_ENABLED=0 \
 		-w /go/src/github.com/$(ORGANISATION)/$(PROJECT) \
 		--user ${USERID}:${GROUPID} \
 		golang:$(GOVERSION)-alpine go build -a -installsuffix cgo -o build/bin/$(BIN)-darwin-amd64 \
 		-ldflags "-X 'github.com/giantswarm/gsctl/config.Version=$(VERSION)' -X 'github.com/giantswarm/gsctl/config.BuildDate=$(BUILDDATE)' -X 'github.com/giantswarm/gsctl/config.Commit=$(COMMIT)'"
+	rm -rf go-build-cache
 
 # platform-specific build for linux-amd64
 # - here we have CGO_ENABLED=1
 build/bin/$(BIN)-linux-amd64: $(SOURCE)
 	@mkdir -p build/bin
-	docker run --rm -v $(shell pwd):/go/src/github.com/$(ORGANISATION)/$(PROJECT) \
+	@mkdir -p go-build-cache
+	docker run --rm \
+		-v $(shell pwd):/go/src/github.com/$(ORGANISATION)/$(PROJECT) \
+		-v $(shell pwd)/go-build-cache:/.cache \
 		-e GOPATH=/go -e GOOS=linux -e GOARCH=amd64 -e CGO_ENABLED=1 \
 		-w /go/src/github.com/$(ORGANISATION)/$(PROJECT) \
 		--user ${USERID}:${GROUPID} \
 		golang:$(GOVERSION)-stretch go build -a -installsuffix cgo -o build/bin/$(BIN)-linux-amd64 \
 		-ldflags "-X 'github.com/giantswarm/gsctl/config.Version=$(VERSION)' -X 'github.com/giantswarm/gsctl/config.BuildDate=$(BUILDDATE)' -X 'github.com/giantswarm/gsctl/config.Commit=$(COMMIT)'"
+	rm -rf go-build-cache
 
 # platform-specific build
 build/bin/$(BIN)-windows-386: $(SOURCE)
 	@mkdir -p build/bin
-	docker run --rm -v $(shell pwd):/go/src/github.com/$(ORGANISATION)/$(PROJECT) \
+	@mkdir -p go-build-cache
+	docker run --rm \
+		-v $(shell pwd):/go/src/github.com/$(ORGANISATION)/$(PROJECT) \
+		-v $(shell pwd)/go-build-cache:/.cache \
 		-e GOPATH=/go -e GOOS=windows -e GOARCH=386 -e CGO_ENABLED=0 \
 		-w /go/src/github.com/$(ORGANISATION)/$(PROJECT) \
 		--user ${USERID}:${GROUPID} \
 		golang:$(GOVERSION)-alpine go build -a -installsuffix cgo -o build/bin/$(BIN)-windows-386 \
 		-ldflags "-X 'github.com/giantswarm/gsctl/config.Version=$(VERSION)' -X 'github.com/giantswarm/gsctl/config.BuildDate=$(BUILDDATE)' -X 'github.com/giantswarm/gsctl/config.Commit=$(COMMIT)'"
+	rm -rf go-build-cache
 
 # platform-specific build
 build/bin/$(BIN)-windows-amd64: $(SOURCE)
 	@mkdir -p build/bin
-	docker run --rm -v $(shell pwd):/go/src/github.com/$(ORGANISATION)/$(PROJECT) \
+	@mkdir -p go-build-cache
+	docker run --rm \
+		-v $(shell pwd):/go/src/github.com/$(ORGANISATION)/$(PROJECT) \
+		-v $(shell pwd)/go-build-cache:/.cache \
 		-e GOPATH=/go -e GOOS=windows -e GOARCH=amd64 -e CGO_ENABLED=0 \
 		-w /go/src/github.com/$(ORGANISATION)/$(PROJECT) \
 		--user ${USERID}:${GROUPID} \
 		golang:$(GOVERSION)-alpine go build -a -installsuffix cgo -o build/bin/$(BIN)-windows-amd64 \
 		-ldflags "-X 'github.com/giantswarm/gsctl/config.Version=$(VERSION)' -X 'github.com/giantswarm/gsctl/config.BuildDate=$(BUILDDATE)' -X 'github.com/giantswarm/gsctl/config.Commit=$(COMMIT)'"
+	rm -rf go-build-cache
 
 gotest:
 	go test -cover ./...
@@ -145,4 +161,4 @@ bin-dist: crosscompile
 
 # remove generated stuff
 clean:
-	rm -rf bin-dist build release ./gsctl
+	rm -rf bin-dist build go-build-cache release ./gsctl

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PROJECT=gsctl
 ORGANISATION=giantswarm
 BIN=$(PROJECT)
-GOVERSION := 1.10
+GOVERSION := 1.11.1
 BUILDDATE := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 VERSION := $(shell cat VERSION)
 COMMIT := $(shell git rev-parse HEAD | cut -c1-10)


### PR DESCRIPTION
This sets the Go version in builds to 1.11.1.

In addition, this sets a `/.cache` volume for the build, to prevent this error:

```
go: disabling cache (/.cache/go-build) due to initialization failure: mkdir /.cache: permission denied
```
