### PR TITLE
upgrade cluster: ensure the target release is active

### DIFF
--- a/commands/upgrade_cluster.go
+++ b/commands/upgrade_cluster.go
@@ -212,6 +212,11 @@ func upgradeCluster(args upgradeClusterArguments) (upgradeClusterResult, error) 
 
 	releaseVersions := []string{}
 	for _, r := range releasesResult {
+		// filter out non-active releases
+		if !r.Active {
+			continue
+		}
+
 		releaseVersions = append(releaseVersions, *r.Version)
 	}
 

--- a/commands/upgrade_cluster.go
+++ b/commands/upgrade_cluster.go
@@ -186,8 +186,8 @@ func upgradeClusterExecutionOutput(cmd *cobra.Command, cmdLineArgs []string) {
 	}
 
 	fmt.Println(color.GreenString("Starting to upgrade cluster '%s' to release version %s",
-		color.CyanString(result.clusterID),
-		color.CyanString(result.versionAfter)))
+		result.clusterID,
+		result.versionAfter))
 }
 
 // upgradeCluster performs our actual function. It usually creates an API client,


### PR DESCRIPTION
For https://github.com/giantswarm/giantswarm/issues/4553

This ensures that gsctl selects an active release as the target release to upgrade to.