### PR TITLE
Use Github releases URL for update check

### DIFF
--- a/commands/error.go
+++ b/commands/error.go
@@ -542,3 +542,13 @@ var credentialsAlreadySetError = &microerror.Error{
 func IsCredentialsAlreadySetError(err error) bool {
 	return microerror.Cause(err) == credentialsAlreadySetError
 }
+
+// updateCheckFailed means that checking for a newer gsctl version failed.
+var updateCheckFailed = &microerror.Error{
+	Kind: "updateCheckFailed",
+}
+
+// IsUpdateCheckFailed asserts updateCheckFailed.
+func IsUpdateCheckFailed(err error) bool {
+	return microerror.Cause(err) == updateCheckFailed
+}

--- a/commands/version.go
+++ b/commands/version.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"time"
@@ -79,20 +78,27 @@ func printVersion(cmd *cobra.Command, args []string) {
 
 // latestVersion returns the latest available version as semver.Version
 func latestVersion(url string) (*semver.Version, error) {
-	// to be unobstructive, we timeout quickly.
-	timeout := time.Duration(updateCheckTimeout)
-	client := http.Client{Timeout: timeout}
+	// an HTTP client that doesn't follow redirects and timeouts quickly
+	// in order to not let the user wait too long
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+		Timeout: time.Duration(updateCheckTimeout),
+	}
+
 	resp, err := client.Get(url)
 	if err != nil {
-		return semver.New("0.0.0"), microerror.Mask(err)
+		return nil, microerror.Mask(err)
 	}
-	defer resp.Body.Close()
-	contentBytes, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return semver.New("0.0.0"), microerror.Mask(err)
+
+	location := resp.Header.Get("Location")
+	if location == "" {
+		return nil, microerror.Mask(updateCheckFailed)
 	}
-	content := strings.TrimSpace(string(contentBytes))
-	return semver.New(content), nil
+
+	parts := strings.Split(location, "/")
+	return semver.New(parts[len(parts)-1]), nil
 }
 
 // currentVersion returns the current gsctl version as semver.Version.

--- a/commands/version.go
+++ b/commands/version.go
@@ -91,6 +91,7 @@ func latestVersion(url string) (*semver.Version, error) {
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
+	defer resp.Body.Close()
 
 	location := resp.Header.Get("Location")
 	if location == "" {

--- a/commands/version_test.go
+++ b/commands/version_test.go
@@ -37,14 +37,21 @@ func Test_CurrentVersion(t *testing.T) {
 }
 
 func Test_CheckUpdateAvailable(t *testing.T) {
+	latestPath := "/giantswarm/gsctl/releases/latest"
+
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/plain")
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("0.1.0\n"))
+		if r.URL.Path == latestPath {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			w.Header().Set("Location", "https://github.com/giantswarm/gsctl/releases/tag/1.2.3")
+			w.WriteHeader(http.StatusFound)
+			w.Write([]byte("<html><body>You are being redirected</body></html>"))
+		} else {
+			t.Errorf("Unhandled URL called: %s", r.URL.String())
+		}
 	}))
 	defer mockServer.Close()
 
-	info, err := checkUpdateAvailable(mockServer.URL)
+	info, err := checkUpdateAvailable(mockServer.URL + latestPath)
 	if err != nil {
 		t.Error(err)
 	}

--- a/commands/version_test.go
+++ b/commands/version_test.go
@@ -8,26 +8,6 @@ import (
 	"github.com/coreos/go-semver/semver"
 )
 
-// Test_LatestVersion checks the basic functions of latestVersion()
-func Test_LatestVersion(t *testing.T) {
-	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/plain")
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("0.6.1\n"))
-	}))
-	defer mockServer.Close()
-
-	version, err := latestVersion(mockServer.URL)
-	if err != nil {
-		t.Error(err)
-	}
-
-	testVersion := semver.New("0.6.1")
-	if !version.Equal(*testVersion) {
-		t.Error("Version equality check failed.")
-	}
-}
-
 func Test_CurrentVersion(t *testing.T) {
 	testVersion := semver.New("0.0.0")
 	current := currentVersion()

--- a/config/config.go
+++ b/config/config.go
@@ -34,7 +34,7 @@ const (
 	ProgramName = "gsctl"
 
 	// VersionCheckURL is the URL telling us what the latest gsctl version is
-	VersionCheckURL = "https://downloads.giantswarm.io/gsctl/VERSION"
+	VersionCheckURL = "https://github.com/giantswarm/gsctl/releases/latest"
 
 	// VersionCheckInterval is the minimum time to wait between two version checks
 	VersionCheckInterval = time.Hour * 24


### PR DESCRIPTION
Towards release automation: https://github.com/giantswarm/giantswarm/issues/4810

This changes the check for the latest version to use the Github releases instead of our VERSION file on S3.