### PR TITLE
Activate two steps in CircleCI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,12 +48,12 @@ jobs:
       - run:
           name: Create GitHub release
           command: ./.circleci/release.sh $CIRCLE_TAG $RELEASE_TOKEN
-      # - run:
-      #     name: Update Homebrew tap
-      #     command: ./.circleci/update-homebrew.sh $CIRCLE_TAG
-      # - run:
-      #     name: Update scoop bucket
-      #     command: ./.circleci/update-scoop.sh $CIRCLE_TAG
+      - run:
+          name: Update Homebrew tap
+          command: ./.circleci/update-homebrew.sh $CIRCLE_TAG
+      - run:
+          name: Update scoop bucket
+          command: ./.circleci/update-scoop.sh $CIRCLE_TAG
 
 workflows:
   version: 2


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/4810

This activates the two scripts which update the homebrew and scoop repos.