### PR TITLE
Fix download URL for homebrew and scoop

### DIFF
--- a/.circleci/update-homebrew.sh
+++ b/.circleci/update-homebrew.sh
@@ -28,7 +28,7 @@ require "formula"
 class Gsctl < Formula
   desc "Controls things on Giant Swarm"
   homepage "https://github.com/giantswarm/gsctl"
-  url "http://downloads.giantswarm.io/gsctl/$VERSION/gsctl-$VERSION-darwin-amd64.tar.gz"
+  url "https://github.com/giantswarm/gsctl/releases/download/$VERSION/gsctl-$VERSION-darwin-amd64.tar.gz"
   version "$VERSION"
   # openssl dgst -sha256 <file>
   sha256 "$SHA256"

--- a/.circleci/update-scoop.sh
+++ b/.circleci/update-scoop.sh
@@ -28,12 +28,12 @@ cat > gsctl.json << EOF
   "license": "APACHE-2.0",
   "architecture": {
     "64bit": {
-      "url": "https://downloads.giantswarm.io/gsctl/$VERSION/gsctl-$VERSION-windows-amd64.zip",
+      "url": "https://github.com/giantswarm/gsctl/releases/download/$VERSION/gsctl-$VERSION-windows-amd64.zip",
       "hash": "$SHA256_64BIT",
       "extract_dir": "gsctl-$VERSION-windows-amd64"
     },
     "32bit": {
-      "url": "https://downloads.giantswarm.io/gsctl/$VERSION/gsctl-$VERSION-windows-386.zip",
+      "url": "https://github.com/giantswarm/gsctl/releases/download/$VERSION/gsctl-$VERSION-windows-386.zip",
       "hash": "$SHA256_32BIT",
       "extract_dir": "gsctl-$VERSION-windows-386"
     }


### PR DESCRIPTION
Still aftermath for https://github.com/giantswarm/giantswarm/issues/4810

See also: 

- https://github.com/giantswarm/homebrew-giantswarm/pull/9
- https://github.com/giantswarm/scoop-bucket/pull/2