### PR TITLE
Get the status only when we are sure that it holds useful information

### DIFF
--- a/commands/scale_cluster.go
+++ b/commands/scale_cluster.go
@@ -226,8 +226,6 @@ func scaleClusterRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 		}
 		if n == 0 || n == 1 {
 			autoScalingEnabled = true
-		} else {
-			autoScalingEnabled = false
 		}
 	}
 


### PR DESCRIPTION
This is really just about saving us an unnecessary api call.