### PR TITLE
Prevent error when cluster status endpoint cannot be fetched

### DIFF
--- a/commands/error.go
+++ b/commands/error.go
@@ -365,7 +365,7 @@ var apiError = &microerror.Error{
 	Kind: "apiError",
 }
 
-// IsAIPError asserts apiError.
+// IsAPIError asserts apiError.
 func IsAPIError(err error) bool {
 	c := microerror.Cause(err)
 	_, ok := c.(*clienterror.APIError)

--- a/commands/scale_cluster.go
+++ b/commands/scale_cluster.go
@@ -116,7 +116,7 @@ func confirmScaleCluster(args scaleClusterArguments, maxBefore int64, minBefore 
 }
 
 // defaultScaleClusterArguments defaults arguments supplied by the users.
-func defaultScaleClusterArguments(cmd *cobra.Command, clusterId string, maxBefore int64, minBefore int64) scaleClusterArguments {
+func defaultScaleClusterArguments(cmd *cobra.Command, clusterID string, maxBefore int64, minBefore int64) scaleClusterArguments {
 	endpoint := config.Config.ChooseEndpoint(cmdAPIEndpoint)
 	token := config.Config.ChooseToken(endpoint, cmdToken)
 	scheme := config.Config.ChooseScheme(endpoint, cmdToken)
@@ -124,7 +124,7 @@ func defaultScaleClusterArguments(cmd *cobra.Command, clusterId string, maxBefor
 	scaleArgs := scaleClusterArguments{
 		apiEndpoint:         endpoint,
 		authToken:           token,
-		clusterID:           clusterId,
+		clusterID:           clusterID,
 		numWorkersDesired:   cmdNumWorkers,
 		oppressConfirmation: cmdForce,
 		scheme:              scheme,

--- a/commands/show_cluster.go
+++ b/commands/show_cluster.go
@@ -342,7 +342,7 @@ func showClusterRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 		fmt.Println("\nInfo: Could not fetch cluster status, so the worker node count displayed might derive from the actual number.")
 
 		if time.Since(created) < clusterCreationExpectedDuration {
-			fmt.Println("This is expected for clusters which are still in creation.")
+			fmt.Println("This is expected for clusters which are most likely still in creation.")
 		}
 	}
 }

--- a/commands/show_cluster.go
+++ b/commands/show_cluster.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/fatih/color"
 	"github.com/giantswarm/columnize"
@@ -198,12 +199,6 @@ func showClusterRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 	clusterStatus := <-clusterStatusChan
 	clusterStatusErr := <-clusterStatusErrChan
 
-	// Cluster status isn't crucual, so we inform about problems, but don't exit.
-	if clusterStatusErr != nil {
-		fmt.Println(color.RedString("Error: Could not fetch cluster status."))
-		fmt.Println("The worker node count displayed might derive from the actual number.")
-	}
-
 	if clusterDetailsErr != nil {
 		handleCommonErrors(clusterDetailsErr)
 
@@ -335,6 +330,18 @@ func showClusterRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 			output = append(output, color.YellowString(fmt.Sprintf("Ingress port for %s:", portMapping.Protocol))+"|"+fmt.Sprintf("%d", portMapping.Port))
 		}
 	}
+
+	// Here we inform about problems fetching the cluster status, which happens regularly for new clusters
+	// and isn't a problem.
+	if clusterStatusErr != nil {
+		fmt.Println("\nInfo: Could not fetch cluster status, so the worker node count displayed might derive from the actual number.")
+
+		if time.Since(created).Minutes() < 5 {
+			fmt.Println("This is expected for clusters which are still in creation.")
+		}
+	}
+	
+	
 
 	fmt.Println(columnize.SimpleFormat(output))
 }

--- a/commands/show_cluster.go
+++ b/commands/show_cluster.go
@@ -39,6 +39,9 @@ Examples:
 		// Run calls the business function and prints results and errors.
 		Run: showClusterRunOutput,
 	}
+
+	// Time after which a new cluster should be up, roughly.
+	clusterCreationExpectedDuration = 20 * time.Minute
 )
 
 const (
@@ -331,17 +334,15 @@ func showClusterRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 		}
 	}
 
+	fmt.Println(columnize.SimpleFormat(output))
+
 	// Here we inform about problems fetching the cluster status, which happens regularly for new clusters
 	// and isn't a problem.
 	if clusterStatusErr != nil {
 		fmt.Println("\nInfo: Could not fetch cluster status, so the worker node count displayed might derive from the actual number.")
 
-		if time.Since(created).Minutes() < 5 {
+		if time.Since(created) < clusterCreationExpectedDuration {
 			fmt.Println("This is expected for clusters which are still in creation.")
 		}
 	}
-	
-	
-
-	fmt.Println(columnize.SimpleFormat(output))
 }


### PR DESCRIPTION
Part of autoscaling changes.

This prevents the error info in the top of the `show cluster` output that occurred when the cluster status endpoint could not yet be accessed.

Here is how it will appear for a cluster after a creation period:

```nohighlight
...
Worker node scaling:       pinned at 0
Worker nodes running:      0
CPU cores in workers:      0
RAM in worker nodes (GB):  0.00

Info: Could not fetch cluster status, so the worker node count displayed might derive from the actual number.
```

Within 20 minutes from creation, an additional line will be shown:

```nohighlight
...
Worker node scaling:       pinned at 0
Worker nodes running:      0
CPU cores in workers:      0
RAM in worker nodes (GB):  0.00

Info: Could not fetch cluster status, so the worker node count displayed might derive from the actual number.
This is expected for clusters which are still in creation.
```