### PR TITLE
fix azure scale down

### DIFF
--- a/cmd/cluster/scale/defaulting/scaling.go
+++ b/cmd/cluster/scale/defaulting/scaling.go
@@ -93,7 +93,6 @@ func (s *Scaling) Default(ctx context.Context, scaling request.Scaling) request.
 		},
 		{
 			Conditions: []func() bool{
-				func() bool { return s.autoScalingEnabled },
 				func() bool { return not(s.desiredScalingMinChanged) },
 				func() bool { return not(s.desiredScalingMaxChanged) },
 				func() bool { return s.desiredNumWorkersChanged },

--- a/cmd/cluster/scale/defaulting/scaling_test.go
+++ b/cmd/cluster/scale/defaulting/scaling_test.go
@@ -58,7 +58,7 @@ func Test_Cmd_Cluster_Scale_Defaulting(t *testing.T) {
 			},
 		},
 		{
-			Name:                     "case 2 ensures --num-workers=5 sets scaling.max and scaling.min to 5",
+			Name:                     "case 2 ensures --num-workers=5 sets scaling.max and scaling.min to 5 when AS is enabled",
 			AutoScalingEnabled:       true,
 			CurrentScalingMax:        3,
 			CurrentScalingMin:        3,
@@ -74,7 +74,23 @@ func Test_Cmd_Cluster_Scale_Defaulting(t *testing.T) {
 			},
 		},
 		{
-			Name:                     "case 3 ensures --workers-max=5 sets scaling.max and scaling.min to 5 when AS is not enabled",
+			Name:                     "case 3 ensures --num-workers=5 sets scaling.max and scaling.min to 5 when AS is not enabled",
+			AutoScalingEnabled:       false,
+			CurrentScalingMax:        3,
+			CurrentScalingMin:        3,
+			DesiredNumWorkers:        5,
+			DesiredNumWorkersChanged: true,
+			DesiredScalingMax:        0,
+			DesiredScalingMaxChanged: false,
+			DesiredScalingMin:        0,
+			DesiredScalingMinChanged: false,
+			ExpectedScaling: request.Scaling{
+				Min: 5,
+				Max: 5,
+			},
+		},
+		{
+			Name:                     "case 4 ensures --workers-max=5 sets scaling.max and scaling.min to 5 when AS is not enabled",
 			AutoScalingEnabled:       false,
 			CurrentScalingMax:        3,
 			CurrentScalingMin:        3,
@@ -90,7 +106,7 @@ func Test_Cmd_Cluster_Scale_Defaulting(t *testing.T) {
 			},
 		},
 		{
-			Name:                     "case 4 ensures --workers-min=5 sets scaling.max and scaling.min to 5 when AS is not enabled",
+			Name:                     "case 5 ensures --workers-min=5 sets scaling.max and scaling.min to 5 when AS is not enabled",
 			AutoScalingEnabled:       false,
 			CurrentScalingMax:        3,
 			CurrentScalingMin:        3,


### PR DESCRIPTION
Fixing an issue on Azure where a cluster pinned to 5 nodes is scaled down. The confirmation asks to pin to 0 but should ask to pin to 3. The fix is to always consider `--num-workers`, no matter if AS is enabled or not. 

```
$ gsctl scale cluster mne2v --num-workers 3
Flag --num-workers has been deprecated, Please use --workers-min and --workers-max to specify the node count to use.
The cluster currently has 5 worker nodes running.
Do you want to pin the number of worker nodes to 0? [y/n]: n
command aborted error
```