### PR TITLE
Fix delete cluster flag change to positional argument

### DIFF
--- a/client/clienterror/clienterror.go
+++ b/client/clienterror/clienterror.go
@@ -126,6 +126,14 @@ func New(err error) *APIError {
 			ErrorDetails:   "You don't have permission to delete this cluster.",
 		}
 	}
+	if deleteClusterNotFoundErr, ok := err.(*clusters.DeleteClusterNotFound); ok {
+		return &APIError{
+			HTTPStatusCode: http.StatusNotFound,
+			OriginalError:  deleteClusterNotFoundErr,
+			ErrorMessage:   "Not found",
+			ErrorDetails:   "The given cluster doesn't seem to exist.",
+		}
+	}
 	if deleteClusterDefaultErr, ok := err.(*clusters.DeleteClusterDefault); ok {
 		return &APIError{
 			HTTPStatusCode: deleteClusterDefaultErr.Code(),

--- a/commands/delete_cluster.go
+++ b/commands/delete_cluster.go
@@ -161,7 +161,11 @@ func deleteClusterExecutionOutput(cmd *cobra.Command, args []string) {
 
 	// non-error output
 	if deleted {
-		fmt.Println(color.GreenString("The cluster with ID '%s' will be deleted as soon as all workloads are terminated.", dca.clusterID))
+		clusterID := dca.legacyClusterID
+		if dca.clusterID != "" {
+			clusterID = dca.clusterID
+		}
+		fmt.Println(color.GreenString("The cluster with ID '%s' will be deleted as soon as all workloads are terminated.", clusterID))
 	} else {
 		if dca.verbose {
 			fmt.Println(color.GreenString("Aborted."))

--- a/commands/delete_cluster.go
+++ b/commands/delete_cluster.go
@@ -77,7 +77,7 @@ func init() {
 	DeleteClusterCommand.Flags().StringVarP(&cmdClusterID, "cluster", "c", "", "ID of the cluster to delete")
 	DeleteClusterCommand.Flags().BoolVarP(&cmdForce, "force", "", false, "If set, no interactive confirmation will be required (risky!).")
 
-	CreateClusterCommand.Flags().MarkDeprecated("cluster", "You no longer need to pass the cluster ID with -c/--cluster. Use --help for details.")
+	DeleteClusterCommand.Flags().MarkDeprecated("cluster", "You no longer need to pass the cluster ID with -c/--cluster. Use --help for details.")
 
 	DeleteCommand.AddCommand(DeleteClusterCommand)
 }


### PR DESCRIPTION
- Handle 404 case
- Show the cluster ID in success message when using legacy `-c`/`--cluster` flag
- Actually deprecate the flag