### PR TITLE
Fix the show cluster example inside the cluster upgrade help text

### DIFF
--- a/commands/upgrade_cluster.go
+++ b/commands/upgrade_cluster.go
@@ -36,7 +36,7 @@ building blocks of a cluster with newer versions. See details at
 A cluster will always be upgraded to the subsequent release. To find out what
 release version is used currently, use
 
-    gsctl show cluster -c <cluster-id>
+    gsctl show cluster <cluster-id>
 
 To find out what is the subsequent version, list all available versions using
 


### PR DESCRIPTION
-c is not a valid option for show cluster

See: 
```
$ gsctl show cluster -c 48d4u
Error: unknown shorthand flag: 'c' in -c
```

vs

```
$ gsctl show cluster -c 48d4u
ID:                        48d4u
...
```


Show Cluster Help Text:
```
$ gsctl show cluster --help
Display details of a cluster

Examples:

  gsctl show cluster c7t2o

Usage:
  gsctl show cluster [flags]

Flags:
  -h, --help   help for cluster

```