### PR TITLE
Make endpoints configuration access thread safe

### DIFF
--- a/commands/info.go
+++ b/commands/info.go
@@ -161,8 +161,8 @@ func info(args infoArguments) (infoResult, error) {
 	result.version = config.Version
 	result.buildDate = config.BuildDate
 
-	if config.Config.Endpoints[result.apiEndpoint] != nil {
-		result.apiEndpointAlias = config.Config.Endpoints[result.apiEndpoint].Alias
+	if config.Config.EndpointConfig(result.apiEndpoint) != nil {
+		result.apiEndpointAlias = config.Config.EndpointConfig(result.apiEndpoint).Alias
 	}
 
 	result.configFilePath = config.ConfigFilePath

--- a/commands/list_endpoints.go
+++ b/commands/list_endpoints.go
@@ -59,21 +59,21 @@ func listEndpoints(cmd *cobra.Command, args []string) {
 
 // endpointsTable returns a table of clusters the user has access to
 func endpointsTable(args listEndpointsArguments) string {
-	if len(config.Config.Endpoints) == 0 {
+	if len(config.Config.Endpoints()) == 0 {
 		return fmt.Sprintf("No endpoints configured.\n\nTo add an endpoint and authenticate for it, use\n\n\t%s\n",
 			color.YellowString("gsctl login <email> -e <endpoint>"))
 	}
 
 	// get keys (URLs) and sort by them
-	endpointURLs := make([]string, 0, len(config.Config.Endpoints))
-	for u := range config.Config.Endpoints {
+	endpointURLs := make([]string, 0, len(config.Config.Endpoints()))
+	for _, u := range config.Config.Endpoints() {
 		endpointURLs = append(endpointURLs, u)
 	}
 
 	// detect if we want to show the alias column
 	hasAlias := false
 	for _, endpoint := range endpointURLs {
-		if config.Config.Endpoints[endpoint].Alias != "" {
+		if config.Config.EndpointConfig(endpoint).Alias != "" {
 			hasAlias = true
 		}
 	}
@@ -83,8 +83,8 @@ func endpointsTable(args listEndpointsArguments) string {
 		return endpointURLs[i] < endpointURLs[j]
 	})
 	sort.Slice(endpointURLs, func(i, j int) bool {
-		aliasi := config.Config.Endpoints[endpointURLs[i]].Alias
-		aliasj := config.Config.Endpoints[endpointURLs[j]].Alias
+		aliasi := config.Config.EndpointConfig(endpointURLs[i]).Alias
+		aliasj := config.Config.EndpointConfig(endpointURLs[j]).Alias
 		// sort empty alias to bottom position
 		if aliasi == "" {
 			aliasi = "zzzzz"
@@ -109,25 +109,27 @@ func endpointsTable(args listEndpointsArguments) string {
 	output = append(output, strings.Join(headers, "|"))
 
 	for _, endpoint := range endpointURLs {
+		endpointConfig := config.Config.EndpointConfig(endpoint)
+
 		selected := "no"
 		loggedIn := "no"
 		email := "n/a"
 		alias := "n/a"
 
-		if config.Config.Endpoints[endpoint].Alias != "" {
-			alias = config.Config.Endpoints[endpoint].Alias
+		if endpointConfig.Alias != "" {
+			alias = endpointConfig.Alias
 		}
 
 		if endpoint == args.apiEndpoint {
 			selected = "yes"
 		}
 
-		if config.Config.Endpoints[endpoint].Token != "" {
+		if endpointConfig.Token != "" {
 			loggedIn = "yes"
 		}
 
-		if config.Config.Endpoints[endpoint].Email != "" {
-			email = config.Config.Endpoints[endpoint].Email
+		if endpointConfig.Email != "" {
+			email = endpointConfig.Email
 		}
 
 		columns := []string{}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -294,8 +294,8 @@ selected_endpoint: https://other.endpoint`
 	defer os.RemoveAll(dir)
 
 	// first, selected endpoint must have empty alias
-	if Config.Endpoints[Config.SelectedEndpoint].Alias != "" {
-		t.Errorf("Expected alias '', got '%s'", Config.Endpoints[Config.SelectedEndpoint].Alias)
+	if Config.EndpointConfig(Config.SelectedEndpoint).Alias != "" {
+		t.Errorf("Expected alias '', got '%s'", Config.EndpointConfig(Config.SelectedEndpoint).Alias)
 	}
 
 	err = Config.SelectEndpoint("myalias")
@@ -309,8 +309,8 @@ selected_endpoint: https://other.endpoint`
 	}
 
 	// after selection, selected endpoint must have alias
-	if Config.Endpoints[ep].Alias != "myalias" {
-		t.Errorf("Expected alias 'myalias', got '%s'", Config.Endpoints[Config.SelectedEndpoint].Alias)
+	if Config.EndpointConfig(ep).Alias != "myalias" {
+		t.Errorf("Expected alias 'myalias', got '%s'", Config.EndpointConfig(Config.SelectedEndpoint).Alias)
 	}
 
 	// try selecting using a non-existing alias/URL

--- a/config/config_yaml.go
+++ b/config/config_yaml.go
@@ -1,0 +1,47 @@
+package config
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+func (c *configStruct) MarshalYAML() (interface{}, error) {
+	type configStructClone configStruct
+
+	v := struct {
+		ConfigStruct configStructClone          `yaml:",inline"`
+		Endpoints    map[string]*endpointConfig `yaml:"endpoints"`
+	}{
+		// Due to yaml library quirks it has to be a value:
+		// https://github.com/go-yaml/yaml/issues/55. Otherwise we
+		// have:
+		//
+		//	panic: Option ,inline needs a struct value field.
+		//
+		ConfigStruct: (configStructClone)(*c),
+		Endpoints:    c.endpoints,
+	}
+
+	return &v, nil
+}
+
+func (c *configStruct) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	v := struct {
+		Endpoints map[string]*endpointConfig `yaml:"endpoints"`
+	}{}
+
+	err := unmarshal(&v)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	type configStructClone configStruct
+
+	err = unmarshal((*configStructClone)(c))
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	c.endpoints = v.Endpoints
+
+	return nil
+}


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/5433.

The race was happening during concurrent `AuthHeaderGetter` calls.
I could just add a mutex around this call but it didn't feel right. We
could have another concurrent access and have the issue again. In the
future we could add the lock to the endpoints and not remove lock from
`AuthHeaderGetter` because we would lose track what it was actually
guarding. I think better idea is trying to make configStruct thread-safe
instead. This comes at a price of uglifying YAML marshaling.

Below panic stack from the linked issue:

```
#: gsctl show cluster 82mxu
fatal error: concurrent map read and map write

goroutine 24 [running]:
runtime.throw(0xbf2e43, 0x21)
	/usr/lib/golang/src/runtime/panic.go:608 +0x72 fp=0xc00072fa90 sp=0xc00072fa60 pc=0x42c842
runtime.mapaccess1_faststr(0xb04fc0, 0xc000428f90, 0xc0000c78c0, 0x35, 0xc000496d98)
	/usr/lib/golang/src/runtime/map_faststr.go:21 +0x418 fp=0xc00072fb00 sp=0xc00072fa90 pc=0x413818
github.com/giantswarm/gsctl/config.(*configStruct).EndpointByAlias(0x1233480, 0xc0004b43e0, 0x6, 0x1, 0x770000c000191810, 0xc000578750, 0x0)
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/config/config.go:317 +0xd3 fp=0xc00072fbc8 sp=0xc00072fb00 pc=0xa28283
github.com/giantswarm/gsctl/config.(*configStruct).StoreEndpointAuth(0x1233480, 0xc00003ab80, 0x33, 0xc0004b43e0, 0x6, 0xc0004a2f00, 0x14, 0xbe02bf, 0x6, 0xc000012800, ...)
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/config/config.go:156 +0x442 fp=0xc00072fc38 sp=0xc00072fbc8 pc=0xa277e2
github.com/giantswarm/gsctl/config.(*configStruct).AuthHeaderGetter.func1(0x40de88, 0x60, 0xba58c0, 0x1)
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/config/config.go:382 +0x428 fp=0xc00072fe18 sp=0xc00072fc38 pc=0xa2b8b8
github.com/giantswarm/gsctl/client.setParamsWithAuthorization(0xc0004cfb80, 0xc0004cfb40, 0xcb5b20, 0xc0000cb7a0, 0xc000071eb0, 0x9de611)
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/client/client.go:268 +0x9d fp=0xc00072fe50 sp=0xc00072fe18 pc=0x9de8ed
github.com/giantswarm/gsctl/client.(*WrapperV2).GetClusterStatus(0xc0004cfb40, 0x7fffbd1a067d, 0x5, 0xc0004cfb80, 0x0, 0x0, 0x0)
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/client/client.go:507 +0x94 fp=0xc00072fec0 sp=0xc00072fe50 pc=0x9dffe4
github.com/giantswarm/gsctl/commands.getClusterStatus(0x7fffbd1a067d, 0x5, 0xbe3e6b, 0xc, 0x0, 0x0, 0x0)
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/commands/scale_cluster.go:182 +0x7e fp=0xc00072ff08 sp=0xc00072fec0 pc=0xa51b5e
github.com/giantswarm/gsctl/commands.showClusterRunOutput.func2(0xc00003ab80, 0x33, 0xc0003a4800, 0x3f0, 0xc0004b4428, 0x6, 0x7fffbd1a067d, 0x5, 0x0, 0xc0000b0660, ...)
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/commands/show_cluster.go:195 +0x54 fp=0xc00072ff78 sp=0xc00072ff08 pc=0xa5e5b4
runtime.goexit()
	/usr/lib/golang/src/runtime/asm_amd64.s:1333 +0x1 fp=0xc00072ff80 sp=0xc00072ff78 pc=0x459011
created by github.com/giantswarm/gsctl/commands.showClusterRunOutput
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/commands/show_cluster.go:194 +0x23a

goroutine 1 [chan receive]:
github.com/giantswarm/gsctl/commands.showClusterRunOutput(0x1221300, 0xc0004efdb0, 0x1, 0x1)
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/commands/show_cluster.go:200 +0x264
github.com/giantswarm/gsctl/vendor/github.com/spf13/cobra.(*Command).execute(0x1221300, 0xc0004efd60, 0x1, 0x1, 0x1221300, 0xc0004efd60)
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/vendor/github.com/spf13/cobra/command.go:766 +0x2cc
github.com/giantswarm/gsctl/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0x1222600, 0xc0000b0058, 0x0, 0xbe869d)
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/vendor/github.com/spf13/cobra/command.go:852 +0x2fd
github.com/giantswarm/gsctl/vendor/github.com/spf13/cobra.(*Command).Execute(0x1222600, 0xc00055df88, 0xc0000b0058)
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/vendor/github.com/spf13/cobra/command.go:800 +0x2b
main.main()
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/main.go:24 +0x2d

goroutine 22 [chan receive]:
github.com/giantswarm/gsctl/vendor/k8s.io/klog.(*loggingT).flushDaemon(0x1233640)
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/vendor/k8s.io/klog/klog.go:941 +0x8b
created by github.com/giantswarm/gsctl/vendor/k8s.io/klog.init.0
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/vendor/k8s.io/klog/klog.go:403 +0x69

goroutine 23 [runnable]:
github.com/giantswarm/gsctl/vendor/gopkg.in/yaml%2ev2.yaml_emitter_state_machine(0xc0003e42c0, 0xc000682ec0, 0x1)
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/vendor/gopkg.in/yaml.v2/emitterc.go:212 +0x3e5
github.com/giantswarm/gsctl/vendor/gopkg.in/yaml%2ev2.yaml_emitter_emit(0xc0003e42c0, 0xc0003e4498, 0xc00067d000)
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/vendor/gopkg.in/yaml.v2/emitterc.go:121 +0x14b
github.com/giantswarm/gsctl/vendor/gopkg.in/yaml%2ev2.(*encoder).emit(0xc0003e42c0)
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/vendor/gopkg.in/yaml.v2/encode.go:76 +0x39
github.com/giantswarm/gsctl/vendor/gopkg.in/yaml%2ev2.(*encoder).emitScalar(0xc0003e42c0, 0xc00038e800, 0x3ac, 0x0, 0x0, 0x0, 0x0, 0xc0002d4e01)
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/vendor/gopkg.in/yaml.v2/encode.go:389 +0x1f5
github.com/giantswarm/gsctl/vendor/gopkg.in/yaml%2ev2.(*encoder).stringv(0xc0003e42c0, 0x0, 0x0, 0xad9340, 0xc0000e0d10, 0x198)
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/vendor/gopkg.in/yaml.v2/encode.go:334 +0x142
github.com/giantswarm/gsctl/vendor/gopkg.in/yaml%2ev2.(*encoder).marshal(0xc0003e42c0, 0x0, 0x0, 0xad9340, 0xc0000e0d10, 0x198)
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/vendor/gopkg.in/yaml.v2/encode.go:169 +0x808
github.com/giantswarm/gsctl/vendor/gopkg.in/yaml%2ev2.(*encoder).structv.func1()
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/vendor/gopkg.in/yaml.v2/encode.go:226 +0x2c6
github.com/giantswarm/gsctl/vendor/gopkg.in/yaml%2ev2.(*encoder).mappingv(0xc0003e42c0, 0x0, 0x0, 0xc00072ab68)
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/vendor/gopkg.in/yaml.v2/encode.go:256 +0x14d
github.com/giantswarm/gsctl/vendor/gopkg.in/yaml%2ev2.(*encoder).structv(0xc0003e42c0, 0x0, 0x0, 0xb8d1c0, 0xc0000e0cd0, 0x199)
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/vendor/gopkg.in/yaml.v2/encode.go:213 +0xf7
github.com/giantswarm/gsctl/vendor/gopkg.in/yaml%2ev2.(*encoder).marshal(0xc0003e42c0, 0x0, 0x0, 0xb8d1c0, 0xc0000e0cd0, 0x199)
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/vendor/gopkg.in/yaml.v2/encode.go:160 +0x757
github.com/giantswarm/gsctl/vendor/gopkg.in/yaml%2ev2.(*encoder).marshal(0xc0003e42c0, 0x0, 0x0, 0xab16c0, 0xc0000e0cd0, 0x16)
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/vendor/gopkg.in/yaml.v2/encode.go:154 +0x5ca
github.com/giantswarm/gsctl/vendor/gopkg.in/yaml%2ev2.(*encoder).mapv.func1()
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/vendor/gopkg.in/yaml.v2/encode.go:193 +0x1b3
github.com/giantswarm/gsctl/vendor/gopkg.in/yaml%2ev2.(*encoder).mappingv(0xc0003e42c0, 0x0, 0x0, 0xc00072b020)
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/vendor/gopkg.in/yaml.v2/encode.go:256 +0x14d
github.com/giantswarm/gsctl/vendor/gopkg.in/yaml%2ev2.(*encoder).mapv(0xc0003e42c0, 0x0, 0x0, 0xb04fc0, 0xc000424228, 0x195)
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/vendor/gopkg.in/yaml.v2/encode.go:188 +0x95
github.com/giantswarm/gsctl/vendor/gopkg.in/yaml%2ev2.(*encoder).marshal(0xc0003e42c0, 0x0, 0x0, 0xb04fc0, 0xc000424228, 0x195)
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/vendor/gopkg.in/yaml.v2/encode.go:149 +0x67f
github.com/giantswarm/gsctl/vendor/gopkg.in/yaml%2ev2.(*encoder).structv.func1()
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/vendor/gopkg.in/yaml.v2/encode.go:226 +0x2c6
github.com/giantswarm/gsctl/vendor/gopkg.in/yaml%2ev2.(*encoder).mappingv(0xc0003e42c0, 0x0, 0x0, 0xc00072b490)
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/vendor/gopkg.in/yaml.v2/encode.go:256 +0x14d
github.com/giantswarm/gsctl/vendor/gopkg.in/yaml%2ev2.(*encoder).structv(0xc0003e42c0, 0x0, 0x0, 0xba4fc0, 0xc000424200, 0x199)
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/vendor/gopkg.in/yaml.v2/encode.go:213 +0xf7
github.com/giantswarm/gsctl/vendor/gopkg.in/yaml%2ev2.(*encoder).marshal(0xc0003e42c0, 0x0, 0x0, 0xba4fc0, 0xc000424200, 0x199)
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/vendor/gopkg.in/yaml.v2/encode.go:160 +0x757
github.com/giantswarm/gsctl/vendor/gopkg.in/yaml%2ev2.(*encoder).marshal(0xc0003e42c0, 0x0, 0x0, 0xb938a0, 0xc000424200, 0x16)
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/vendor/gopkg.in/yaml.v2/encode.go:154 +0x5ca
github.com/giantswarm/gsctl/vendor/gopkg.in/yaml%2ev2.(*encoder).marshalDoc(0xc0003e42c0, 0x0, 0x0, 0xb938a0, 0xc000424200, 0x16)
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/vendor/gopkg.in/yaml.v2/encode.go:93 +0x110
github.com/giantswarm/gsctl/vendor/gopkg.in/yaml%2ev2.Marshal(0xb938a0, 0xc000424200, 0x0, 0x0, 0x0, 0x0, 0x0)
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/vendor/gopkg.in/yaml.v2/yaml.go:203 +0x387
github.com/giantswarm/gsctl/config.WriteToFile(0xb04fc0, 0xc000428f90)
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/config/config.go:562 +0xba
github.com/giantswarm/gsctl/config.(*configStruct).StoreEndpointAuth(0x1233480, 0xc00003ab80, 0x33, 0xc0004b43e0, 0x6, 0xc0004a3680, 0x14, 0xbe02bf, 0x6, 0xc000012c00, ...)
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/config/config.go:184 +0x240
github.com/giantswarm/gsctl/config.(*configStruct).AuthHeaderGetter.func1(0x40de88, 0x60, 0xba57a0, 0x1)
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/config/config.go:382 +0x428
github.com/giantswarm/gsctl/client.setParamsWithAuthorization(0xc0004f41c0, 0xc0004cfb40, 0xcb5ae0, 0xc000444000, 0xe, 0x18)
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/client/client.go:268 +0x9d
github.com/giantswarm/gsctl/client.(*WrapperV2).GetCluster(0xc0004cfb40, 0x7fffbd1a067d, 0x5, 0xc0004f41c0, 0x0, 0x0, 0x0)
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/client/client.go:379 +0x8e
github.com/giantswarm/gsctl/commands.getClusterDetails(0x7fffbd1a067d, 0x5, 0xbe3e6b, 0xc, 0x0, 0x0, 0x0)
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/commands/show_cluster.go:108 +0x7e
github.com/giantswarm/gsctl/commands.showClusterRunOutput.func1(0xc00003ab80, 0x33, 0xc0003a4800, 0x3f0, 0xc0004b4428, 0x6, 0x7fffbd1a067d, 0x5, 0x0, 0xc0000b05a0, ...)
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/commands/show_cluster.go:186 +0x54
created by github.com/giantswarm/gsctl/commands.showClusterRunOutput
	/home/calvix/giantswarm/src/github.com/giantswarm/gsctl/commands/show_cluster.go:185 +0x179

goroutine 12 [IO wait]:
internal/poll.runtime_pollWait(0x7faa54452e30, 0x72, 0xc00070f870)
	/usr/lib/golang/src/runtime/netpoll.go:173 +0x66
internal/poll.(*pollDesc).wait(0xc0003b8498, 0x72, 0xffffffffffffff00, 0xcae180, 0x11dc788)
	/usr/lib/golang/src/internal/poll/fd_poll_runtime.go:85 +0x9a
internal/poll.(*pollDesc).waitRead(0xc0003b8498, 0xc0006f1000, 0x1000, 0x1000)
	/usr/lib/golang/src/internal/poll/fd_poll_runtime.go:90 +0x3d
internal/poll.(*FD).Read(0xc0003b8480, 0xc0006f1000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/usr/lib/golang/src/internal/poll/fd_unix.go:169 +0x179
net.(*netFD).Read(0xc0003b8480, 0xc0006f1000, 0x1000, 0x1000, 0x40a4eb, 0xc00001e000, 0xb2a740)
	/usr/lib/golang/src/net/fd_unix.go:202 +0x4f
net.(*conn).Read(0xc0004e6008, 0xc0006f1000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/usr/lib/golang/src/net/net.go:177 +0x68
crypto/tls.(*block).readFromUntil(0xc000356150, 0xcad080, 0xc0004e6008, 0x5, 0xc0004e6008, 0x0)
	/usr/lib/golang/src/crypto/tls/conn.go:492 +0x89
crypto/tls.(*Conn).readRecord(0xc000236a80, 0xc1d217, 0xc000236ba0, 0x0)
	/usr/lib/golang/src/crypto/tls/conn.go:593 +0xdd
crypto/tls.(*Conn).Read(0xc000236a80, 0xc00040b000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/usr/lib/golang/src/crypto/tls/conn.go:1145 +0xf1
bufio.(*Reader).Read(0xc000444720, 0xc0003102d8, 0x9, 0x9, 0xc00009a000, 0xc00070fc58, 0xc00070fc70)
	/usr/lib/golang/src/bufio/bufio.go:216 +0x22f
io.ReadAtLeast(0xcab8e0, 0xc000444720, 0xc0003102d8, 0x9, 0x9, 0x9, 0xc00070fcf8, 0x6b1e9b, 0xc0004448a0)
	/usr/lib/golang/src/io/io.go:310 +0x88
io.ReadFull(0xcab8e0, 0xc000444720, 0xc0003102d8, 0x9, 0x9, 0xc00070fd28, 0x6b1dad, 0xc00070ffb8)
	/usr/lib/golang/src/io/io.go:329 +0x58
net/http.http2readFrameHeader(0xc0003102d8, 0x9, 0x9, 0xcab8e0, 0xc000444720, 0x0, 0x0, 0xc000578e10, 0x0)
	/usr/lib/golang/src/net/http/h2_bundle.go:1545 +0x7b
net/http.(*http2Framer).ReadFrame(0xc0003102a0, 0xc000578e10, 0x0, 0x0, 0x0)
	/usr/lib/golang/src/net/http/h2_bundle.go:1803 +0xa3
net/http.(*http2clientConnReadLoop).run(0xc00070ffb8, 0xc1cb78, 0xc000481fb8)
	/usr/lib/golang/src/net/http/h2_bundle.go:8263 +0x9e
net/http.(*http2ClientConn).readLoop(0xc000338fc0)
	/usr/lib/golang/src/net/http/h2_bundle.go:8191 +0x76
created by net/http.(*http2Transport).newClientConn
	/usr/lib/golang/src/net/http/h2_bundle.go:7264 +0x636
```