### PR TITLE
Add workaround for 1.14 not counting workers correctly

### DIFF
--- a/commands/show_cluster.go
+++ b/commands/show_cluster.go
@@ -245,6 +245,10 @@ func showClusterRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 		// Count all nodes as workers which are not explicitly marked as master.
 		for _, node := range clusterStatus.Cluster.Nodes {
 			val, ok := node.Labels["role"]
+			if !ok {
+				// Workaround for k8s 1.14 because the label changed.
+				val, ok = node.Labels["kubernetes.io/role"]
+			}
 			if ok && val == "master" {
 				// don't count this
 			} else {


### PR DESCRIPTION
With k8s 1.14 the labels for node roles changed. This is a backwards compatible way to display the number of worker nodes.

towards https://github.com/giantswarm/giantswarm/issues/5688