### PR TITLE
Capabilities package to simplify decision making around availability of features, persisting of provider info in config

### DIFF
--- a/capabilities/capabilities.go
+++ b/capabilities/capabilities.go
@@ -17,7 +17,7 @@ var (
 		},
 	}
 
-	// AvailabilityZones si the capability to spread the worker nodes of a tenant
+	// AvailabilityZones is the capability to spread the worker nodes of a tenant
 	// cluster over multiple availability zones.
 	AvailabilityZones = CapabilityDefinition{
 		Name: "AvailabilityZones",

--- a/capabilities/capabilities.go
+++ b/capabilities/capabilities.go
@@ -6,13 +6,25 @@ import (
 )
 
 var (
-	// Autoscaling si the capability to scale tenant clusters automatically.
+	// Autoscaling is the capability to scale tenant clusters automatically.
 	Autoscaling = CapabilityDefinition{
 		Name: "Autoscaling",
 		RequiredReleasePerProvider: []ReleaseProviderPair{
 			ReleaseProviderPair{
 				Provider:       "aws",
 				ReleaseVersion: semver.MustParse("6.3"),
+			},
+		},
+	}
+
+	// AvailabilityZones si the capability to spread the worker nodes of a tenant
+	// cluster over multiple availability zones.
+	AvailabilityZones = CapabilityDefinition{
+		Name: "AvailabilityZones",
+		RequiredReleasePerProvider: []ReleaseProviderPair{
+			ReleaseProviderPair{
+				Provider:       "aws",
+				ReleaseVersion: semver.MustParse("6.1"),
 			},
 		},
 	}
@@ -31,6 +43,7 @@ var (
 	// AllCapabilityDefinitions contains all the capabilities
 	AllCapabilityDefinitions = []CapabilityDefinition{
 		Autoscaling,
+		AvailabilityZones,
 		NodePools,
 	}
 )

--- a/capabilities/capabilities.go
+++ b/capabilities/capabilities.go
@@ -1,0 +1,82 @@
+// Package capabilities provides an API for capability detection.
+package capabilities
+
+import (
+	"github.com/Masterminds/semver"
+)
+
+var (
+	// Autoscaling si the capability to scale tenant clusters automatically.
+	Autoscaling = CapabilityDefinition{
+		Name: "Autoscaling",
+		RequiredReleasePerProvider: []ReleaseProviderPair{
+			ReleaseProviderPair{
+				Provider:       "aws",
+				ReleaseVersion: semver.MustParse("6.3"),
+			},
+		},
+	}
+
+	// NodePools is the capabilitiy to group tenant cluster workers logically.
+	NodePools = CapabilityDefinition{
+		Name: "NodePools",
+		RequiredReleasePerProvider: []ReleaseProviderPair{
+			ReleaseProviderPair{
+				Provider:       "aws",
+				ReleaseVersion: semver.MustParse("9"), // TODO: fix once the node pools release version is defined.
+			},
+		},
+	}
+
+	// AllCapabilityDefinitions contains all the capabilities
+	AllCapabilityDefinitions = []CapabilityDefinition{
+		Autoscaling,
+		NodePools,
+	}
+)
+
+// CapabilityDefinition is the type we use to describe the conditions that have to be met
+// so that we can assume a certain capability on the installation or API side.
+type CapabilityDefinition struct {
+	Name        string
+	Description string
+	// RequiredReleasePerProvider holds the combination(s) of provider and
+	// release version which have to be fulfilled so we assume a capability.
+	RequiredReleasePerProvider []ReleaseProviderPair
+}
+
+// ReleaseProviderPair is a combination of a providr ('aws', 'azure', 'kvm) and
+// a release version number.
+type ReleaseProviderPair struct {
+	Provider       string
+	ReleaseVersion *semver.Version
+}
+
+// GetCapabilities returns the capabilities available in the current context
+func GetCapabilities(provider string, releaseVersion *semver.Version) ([]CapabilityDefinition, error) {
+	cap := []CapabilityDefinition{}
+
+	// iterate all capabilities and find the ones that apply
+	for _, capability := range AllCapabilityDefinitions {
+		if HasCapability(provider, releaseVersion, capability) {
+			cap = append(cap, capability)
+		}
+	}
+
+	return cap, nil
+}
+
+// HasCapability returns true if the current context (provider, release) provides
+// the given capabililty.
+func HasCapability(provider string, releaseVersion *semver.Version, capability CapabilityDefinition) bool {
+	// check which release/provider pair matches ours
+	for _, releaseProviderPair := range capability.RequiredReleasePerProvider {
+		if provider == releaseProviderPair.Provider {
+			if !releaseVersion.LessThan(releaseProviderPair.ReleaseVersion) {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/capabilities/capabilities_test.go
+++ b/capabilities/capabilities_test.go
@@ -3,46 +3,57 @@ package capabilities
 import (
 	"testing"
 
-	"github.com/Masterminds/semver"
 	"github.com/google/go-cmp/cmp"
 )
 
+type testInput struct {
+	Provider       string
+	ReleaseVersion string
+}
+
 var capabilityTests = []struct {
-	in  ReleaseProviderPair
+	in  testInput
 	out []CapabilityDefinition
 }{
 	{
-		ReleaseProviderPair{
+		testInput{
 			Provider:       "aws",
-			ReleaseVersion: semver.MustParse("1.2.3"),
+			ReleaseVersion: "1.2.3",
 		},
 		[]CapabilityDefinition{},
 	},
 	{
-		ReleaseProviderPair{
+		testInput{
 			Provider:       "aws",
-			ReleaseVersion: semver.MustParse("6.4.0"),
+			ReleaseVersion: "6.1.2",
+		},
+		[]CapabilityDefinition{AvailabilityZones},
+	},
+	{
+		testInput{
+			Provider:       "aws",
+			ReleaseVersion: "6.4.0",
 		},
 		[]CapabilityDefinition{Autoscaling, AvailabilityZones},
 	},
 	{
-		ReleaseProviderPair{
+		testInput{
 			Provider:       "aws",
-			ReleaseVersion: semver.MustParse("9.0.0"),
+			ReleaseVersion: "9.0.0",
 		},
 		[]CapabilityDefinition{Autoscaling, AvailabilityZones, NodePools},
 	},
 	{
-		ReleaseProviderPair{
+		testInput{
 			Provider:       "aws",
-			ReleaseVersion: semver.MustParse("9.1.2"),
+			ReleaseVersion: "9.1.2",
 		},
 		[]CapabilityDefinition{Autoscaling, AvailabilityZones, NodePools},
 	},
 	{
-		ReleaseProviderPair{
+		testInput{
 			Provider:       "kvm",
-			ReleaseVersion: semver.MustParse("9.1.2"),
+			ReleaseVersion: "9.1.2",
 		},
 		[]CapabilityDefinition{},
 	},
@@ -52,7 +63,7 @@ func TestGetCapabilities(t *testing.T) {
 	for index, tt := range capabilityTests {
 		cap, err := GetCapabilities(tt.in.Provider, tt.in.ReleaseVersion)
 		if err != nil {
-			t.Error(err)
+			t.Errorf("Test %d: Error: %s", index, err)
 		}
 		if !cmp.Equal(cap, tt.out) {
 			t.Errorf("Test %d: Expected %#v but got %#v", index, tt.out, cap)

--- a/capabilities/capabilities_test.go
+++ b/capabilities/capabilities_test.go
@@ -1,0 +1,61 @@
+package capabilities
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver"
+	"github.com/google/go-cmp/cmp"
+)
+
+var capabilityTests = []struct {
+	in  ReleaseProviderPair
+	out []CapabilityDefinition
+}{
+	{
+		ReleaseProviderPair{
+			Provider:       "aws",
+			ReleaseVersion: semver.MustParse("1.2.3"),
+		},
+		[]CapabilityDefinition{},
+	},
+	{
+		ReleaseProviderPair{
+			Provider:       "aws",
+			ReleaseVersion: semver.MustParse("6.4.0"),
+		},
+		[]CapabilityDefinition{Autoscaling},
+	},
+	{
+		ReleaseProviderPair{
+			Provider:       "aws",
+			ReleaseVersion: semver.MustParse("9.0.0"),
+		},
+		[]CapabilityDefinition{Autoscaling, NodePools},
+	},
+	{
+		ReleaseProviderPair{
+			Provider:       "aws",
+			ReleaseVersion: semver.MustParse("9.1.2"),
+		},
+		[]CapabilityDefinition{Autoscaling, NodePools},
+	},
+	{
+		ReleaseProviderPair{
+			Provider:       "kvm",
+			ReleaseVersion: semver.MustParse("9.1.2"),
+		},
+		[]CapabilityDefinition{},
+	},
+}
+
+func TestGetCapabilities(t *testing.T) {
+	for index, tt := range capabilityTests {
+		cap, err := GetCapabilities(tt.in.Provider, tt.in.ReleaseVersion)
+		if err != nil {
+			t.Error(err)
+		}
+		if !cmp.Equal(cap, tt.out) {
+			t.Errorf("Test %d: Expected %#v but got %#v", index, tt.out, cap)
+		}
+	}
+}

--- a/capabilities/capabilities_test.go
+++ b/capabilities/capabilities_test.go
@@ -59,6 +59,19 @@ var capabilityTests = []struct {
 	},
 }
 
+var failingCapabilityTests = []struct {
+	in  testInput
+	out string
+}{
+	{
+		testInput{
+			Provider:       "aws",
+			ReleaseVersion: "1.2.3.4",
+		},
+		"Invalid Semantic Version",
+	},
+}
+
 func TestGetCapabilities(t *testing.T) {
 	for index, tt := range capabilityTests {
 		cap, err := GetCapabilities(tt.in.Provider, tt.in.ReleaseVersion)
@@ -67,6 +80,18 @@ func TestGetCapabilities(t *testing.T) {
 		}
 		if !cmp.Equal(cap, tt.out) {
 			t.Errorf("Test %d: Expected %#v but got %#v", index, tt.out, cap)
+		}
+	}
+}
+
+func TestFailingCapabilities(t *testing.T) {
+	for index, tt := range failingCapabilityTests {
+		_, err := GetCapabilities(tt.in.Provider, tt.in.ReleaseVersion)
+		if err == nil {
+			t.Errorf("Test %d: Expected error, got nil", index)
+		}
+		if err.Error() != tt.out {
+			t.Errorf("Test %d: Expected error '%s', got '%s'", index, tt.out, err.Error())
 		}
 	}
 }

--- a/capabilities/capabilities_test.go
+++ b/capabilities/capabilities_test.go
@@ -23,21 +23,21 @@ var capabilityTests = []struct {
 			Provider:       "aws",
 			ReleaseVersion: semver.MustParse("6.4.0"),
 		},
-		[]CapabilityDefinition{Autoscaling},
+		[]CapabilityDefinition{Autoscaling, AvailabilityZones},
 	},
 	{
 		ReleaseProviderPair{
 			Provider:       "aws",
 			ReleaseVersion: semver.MustParse("9.0.0"),
 		},
-		[]CapabilityDefinition{Autoscaling, NodePools},
+		[]CapabilityDefinition{Autoscaling, AvailabilityZones, NodePools},
 	},
 	{
 		ReleaseProviderPair{
 			Provider:       "aws",
 			ReleaseVersion: semver.MustParse("9.1.2"),
 		},
-		[]CapabilityDefinition{Autoscaling, NodePools},
+		[]CapabilityDefinition{Autoscaling, AvailabilityZones, NodePools},
 	},
 	{
 		ReleaseProviderPair{

--- a/commands/scale_cluster.go
+++ b/commands/scale_cluster.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/Masterminds/semver"
 	"github.com/fatih/color"
 	"github.com/giantswarm/gsclientgen/models"
 	"github.com/giantswarm/microerror"
@@ -244,13 +243,7 @@ func scaleClusterRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 		desiredScalingMin = cmdWorkersMin
 	}
 
-	ver, err := semver.NewVersion(releaseVersion)
-	if err != nil {
-		fmt.Println(color.RedString(err.Error()))
-		os.Exit(1)
-	}
-
-	autoScalingEnabled := capabilities.HasCapability(config.Config.Provider, ver, capabilities.Autoscaling)
+	autoScalingEnabled, err := capabilities.HasCapability(config.Config.Provider, releaseVersion, capabilities.Autoscaling)
 	if err != nil {
 		fmt.Println(color.RedString(err.Error()))
 		os.Exit(1)

--- a/commands/show_cluster.go
+++ b/commands/show_cluster.go
@@ -96,6 +96,13 @@ func verifyShowClusterPreconditions(args showClusterArguments, cmdLineArgs []str
 	if len(cmdLineArgs) == 0 {
 		return microerror.Mask(clusterIDMissingError)
 	}
+
+	// Make sure we have provider info in the current endpoint
+	err := config.Config.EnsureProvider(ClientV2)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
 	return nil
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -113,6 +113,11 @@ type configStruct struct {
 	// endpoint's entry.
 	Email string `yaml:"-"`
 
+	// provider is the provider found for the selected endpoint. Might be empty.
+	// Not marshalled back to the config file, as it is contained in the
+	// endpoint's entry.
+	Provider string `yaml:"-"`
+
 	endpoints      map[string]*endpointConfig
 	endpointsMutex *sync.RWMutex
 }
@@ -153,6 +158,9 @@ type endpointConfig struct {
 
 	// Email is the email address of the authenticated user.
 	Email string `yaml:"email"`
+
+	// Provider is the cloud provider used in the installation.
+	Provider string `yaml:"provider"`
 
 	// RefreshToken for acquiring a new token when using the bearer scheme.
 	RefreshToken string `yaml:"refresh_token,omitempty"`
@@ -578,6 +586,7 @@ func populateConfigStruct(cs *configStruct) {
 		endpointConfig := cs.EndpointConfig(cs.SelectedEndpoint)
 		if endpointConfig != nil {
 			Config.Email = endpointConfig.Email
+			Config.Provider = endpointConfig.Provider
 			Config.Token = endpointConfig.Token
 		}
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -379,7 +379,7 @@ func (c *configStruct) Endpoints() []string {
 	defer c.endpointsMutex.RUnlock()
 
 	var endpoints []string
-	for k, _ := range c.endpoints {
+	for k := range c.endpoints {
 		endpoints = append(endpoints, k)
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -153,6 +153,7 @@ func Test_Initialize_NonEmpty(t *testing.T) {
 updated: 2017-09-29T11:23:15+02:00
 endpoints:
   https://myapi.domain.tld:
+    provider: testprovider
     email: email@example.com
     token: some-token
 selected_endpoint: https://myapi.domain.tld`
@@ -165,6 +166,9 @@ selected_endpoint: https://myapi.domain.tld`
 	}
 	defer os.RemoveAll(dir)
 
+	if Config.Provider != "testprovider" {
+		t.Errorf("Expected provider testprovider, got '%s'", Config.Provider)
+	}
 	if Config.Email != email {
 		t.Errorf("Expected email '%s', got '%s'", email, Config.Email)
 	}


### PR DESCRIPTION
To be merged into https://github.com/giantswarm/gsctl/pull/355

This PR

- Adds the `provider` key to the config to persist the provider together with an endpoint, and also adds an `EnsureProvider` function to be called in every command that needs this info.
- introduces the `capabilities` package which makes it relatively easy to encode and query the capabilities based on provider and tenant cluster release version.
- Applies both to the `scale cluster` command.