### PR TITLE
Add capabilities API and provider awareness, fix client initialization

### DIFF
--- a/capabilities/capabilities.go
+++ b/capabilities/capabilities.go
@@ -1,0 +1,105 @@
+// Package capabilities provides an API for capability detection.
+package capabilities
+
+import (
+	"github.com/Masterminds/semver"
+	"github.com/giantswarm/microerror"
+)
+
+var (
+	// Autoscaling is the capability to scale tenant clusters automatically.
+	Autoscaling = CapabilityDefinition{
+		Name: "Autoscaling",
+		RequiredReleasePerProvider: []ReleaseProviderPair{
+			ReleaseProviderPair{
+				Provider:       "aws",
+				ReleaseVersion: semver.MustParse("6.3"),
+			},
+		},
+	}
+
+	// AvailabilityZones is the capability to spread the worker nodes of a tenant
+	// cluster over multiple availability zones.
+	AvailabilityZones = CapabilityDefinition{
+		Name: "AvailabilityZones",
+		RequiredReleasePerProvider: []ReleaseProviderPair{
+			ReleaseProviderPair{
+				Provider:       "aws",
+				ReleaseVersion: semver.MustParse("6.1"),
+			},
+		},
+	}
+
+	// NodePools is the capabilitiy to group tenant cluster workers logically.
+	NodePools = CapabilityDefinition{
+		Name: "NodePools",
+		RequiredReleasePerProvider: []ReleaseProviderPair{
+			ReleaseProviderPair{
+				Provider:       "aws",
+				ReleaseVersion: semver.MustParse("9"), // TODO: fix once the node pools release version is defined.
+			},
+		},
+	}
+
+	// AllCapabilityDefinitions contains all the capabilities
+	AllCapabilityDefinitions = []CapabilityDefinition{
+		Autoscaling,
+		AvailabilityZones,
+		NodePools,
+	}
+)
+
+// CapabilityDefinition is the type we use to describe the conditions that have to be met
+// so that we can assume a certain capability on the installation or API side.
+type CapabilityDefinition struct {
+	Name        string
+	Description string
+	// RequiredReleasePerProvider holds the combination(s) of provider and
+	// release version which have to be fulfilled so we assume a capability.
+	RequiredReleasePerProvider []ReleaseProviderPair
+}
+
+// ReleaseProviderPair is a combination of a providr ('aws', 'azure', 'kvm) and
+// a release version number.
+type ReleaseProviderPair struct {
+	Provider       string
+	ReleaseVersion *semver.Version
+}
+
+// GetCapabilities returns the capabilities available in the current context
+func GetCapabilities(provider, releaseVersion string) ([]CapabilityDefinition, error) {
+	cap := []CapabilityDefinition{}
+
+	// iterate all capabilities and find the ones that apply
+	for _, capability := range AllCapabilityDefinitions {
+		hasCap, err := HasCapability(provider, releaseVersion, capability)
+		if err != nil {
+			return []CapabilityDefinition{}, microerror.Mask(err)
+		}
+		if hasCap {
+			cap = append(cap, capability)
+		}
+	}
+
+	return cap, nil
+}
+
+// HasCapability returns true if the current context (provider, release) provides
+// the given capabililty.
+func HasCapability(provider, releaseVersion string, capability CapabilityDefinition) (bool, error) {
+	ver, err := semver.NewVersion(releaseVersion)
+	if err != nil {
+		return false, microerror.Mask(err)
+	}
+
+	// check which release/provider pair matches ours
+	for _, releaseProviderPair := range capability.RequiredReleasePerProvider {
+		if provider == releaseProviderPair.Provider {
+			if !ver.LessThan(releaseProviderPair.ReleaseVersion) {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}

--- a/capabilities/capabilities.go
+++ b/capabilities/capabilities.go
@@ -68,7 +68,7 @@ type ReleaseProviderPair struct {
 
 // GetCapabilities returns the capabilities available in the current context
 func GetCapabilities(provider, releaseVersion string) ([]CapabilityDefinition, error) {
-	cap := []CapabilityDefinition{}
+	capabilities := []CapabilityDefinition{}
 
 	// iterate all capabilities and find the ones that apply
 	for _, capability := range AllCapabilityDefinitions {
@@ -77,11 +77,11 @@ func GetCapabilities(provider, releaseVersion string) ([]CapabilityDefinition, e
 			return []CapabilityDefinition{}, microerror.Mask(err)
 		}
 		if hasCap {
-			cap = append(cap, capability)
+			capabilities = append(capabilities, capability)
 		}
 	}
 
-	return cap, nil
+	return capabilities, nil
 }
 
 // HasCapability returns true if the current context (provider, release) provides

--- a/capabilities/capabilities_test.go
+++ b/capabilities/capabilities_test.go
@@ -1,0 +1,97 @@
+package capabilities
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+type testInput struct {
+	Provider       string
+	ReleaseVersion string
+}
+
+var capabilityTests = []struct {
+	in  testInput
+	out []CapabilityDefinition
+}{
+	{
+		testInput{
+			Provider:       "aws",
+			ReleaseVersion: "1.2.3",
+		},
+		[]CapabilityDefinition{},
+	},
+	{
+		testInput{
+			Provider:       "aws",
+			ReleaseVersion: "6.1.2",
+		},
+		[]CapabilityDefinition{AvailabilityZones},
+	},
+	{
+		testInput{
+			Provider:       "aws",
+			ReleaseVersion: "6.4.0",
+		},
+		[]CapabilityDefinition{Autoscaling, AvailabilityZones},
+	},
+	{
+		testInput{
+			Provider:       "aws",
+			ReleaseVersion: "9.0.0",
+		},
+		[]CapabilityDefinition{Autoscaling, AvailabilityZones, NodePools},
+	},
+	{
+		testInput{
+			Provider:       "aws",
+			ReleaseVersion: "9.1.2",
+		},
+		[]CapabilityDefinition{Autoscaling, AvailabilityZones, NodePools},
+	},
+	{
+		testInput{
+			Provider:       "kvm",
+			ReleaseVersion: "9.1.2",
+		},
+		[]CapabilityDefinition{},
+	},
+}
+
+var failingCapabilityTests = []struct {
+	in  testInput
+	out string
+}{
+	{
+		testInput{
+			Provider:       "aws",
+			ReleaseVersion: "1.2.3.4",
+		},
+		"Invalid Semantic Version",
+	},
+}
+
+func TestGetCapabilities(t *testing.T) {
+	for index, tt := range capabilityTests {
+		cap, err := GetCapabilities(tt.in.Provider, tt.in.ReleaseVersion)
+		if err != nil {
+			t.Errorf("Test %d: Error: %s", index, err)
+		}
+		if !cmp.Equal(cap, tt.out) {
+			t.Errorf("Test %d: Expected %#v but got %#v", index, tt.out, cap)
+		}
+	}
+}
+
+func TestFailingCapabilities(t *testing.T) {
+	for index, tt := range failingCapabilityTests {
+		_, err := GetCapabilities(tt.in.Provider, tt.in.ReleaseVersion)
+		if err == nil {
+			t.Errorf("Test %d: Expected error, got nil", index)
+		}
+		if err.Error() != tt.out {
+			t.Errorf("Test %d: Expected error '%s', got '%s'", index, tt.out, err.Error())
+		}
+	}
+}

--- a/commands/login/giantswarm_theme.go
+++ b/commands/login/giantswarm_theme.go
@@ -17,6 +17,7 @@ func loginGiantSwarm(args loginArguments) (loginResult, error) {
 	result := loginResult{
 		apiEndpoint:        args.apiEndpoint,
 		email:              args.email,
+		provider:           "",
 		loggedOutBefore:    false,
 		endpointSwitched:   false,
 		numEndpointsBefore: config.Config.NumEndpoints(),
@@ -65,13 +66,14 @@ func loginGiantSwarm(args loginArguments) (loginResult, error) {
 		fmt.Println(color.WhiteString("Fetching installation details"))
 	}
 
-	alias, err := getAlias(args.apiEndpoint, "giantswarm", result.token)
+	installationInfo, err := getInstallationInfo(args.apiEndpoint, "giantswarm", result.token)
 	if err != nil {
 		return result, microerror.Mask(err)
 	}
-	result.alias = alias
+	result.alias = installationInfo.InstallationName
+	result.provider = installationInfo.Provider
 
-	if err := config.Config.StoreEndpointAuth(args.apiEndpoint, result.alias, args.email, "giantswarm", result.token, ""); err != nil {
+	if err := config.Config.StoreEndpointAuth(args.apiEndpoint, result.alias, result.provider, args.email, "giantswarm", result.token, ""); err != nil {
 		return result, microerror.Mask(err)
 	}
 	if err := config.Config.SelectEndpoint(args.apiEndpoint); err != nil {

--- a/commands/login/sso.go
+++ b/commands/login/sso.go
@@ -37,7 +37,7 @@ func loginSSO(args loginArguments) (loginResult, error) {
 	}
 
 	// Check if the access token works by fetching the installation's name.
-	alias, err := getAlias(args.apiEndpoint, "Bearer", pkceResponse.AccessToken)
+	installationInfo, err := getInstallationInfo(args.apiEndpoint, "Bearer", pkceResponse.AccessToken)
 	if err != nil {
 		if args.verbose {
 			fmt.Println(color.WhiteString("Attempt to use new token against the API failed."))
@@ -60,7 +60,7 @@ func loginSSO(args loginArguments) (loginResult, error) {
 	}
 
 	// Store the token in the config file.
-	if err := config.Config.StoreEndpointAuth(args.apiEndpoint, alias, idToken.Email, "Bearer", pkceResponse.AccessToken, pkceResponse.RefreshToken); err != nil {
+	if err := config.Config.StoreEndpointAuth(args.apiEndpoint, installationInfo.InstallationName, installationInfo.Provider, idToken.Email, "Bearer", pkceResponse.AccessToken, pkceResponse.RefreshToken); err != nil {
 		if args.verbose {
 			fmt.Println(color.WhiteString("Attempt to store our authentication data with the endpoint in the configuration failed."))
 			fmt.Println(color.WhiteString("Error details: %s", err.Error()))
@@ -76,7 +76,8 @@ func loginSSO(args loginArguments) (loginResult, error) {
 		email:              idToken.Email,
 		endpointSwitched:   (config.Config.SelectedEndpoint != args.apiEndpoint),
 		loggedOutBefore:    false,
-		alias:              alias,
+		alias:              installationInfo.InstallationName,
+		provider:           installationInfo.Provider,
 		token:              pkceResponse.AccessToken,
 		numEndpointsBefore: numEndpointsBefore,
 		numEndpointsAfter:  config.Config.NumEndpoints(),

--- a/commands/scale/command_test.go
+++ b/commands/scale/command_test.go
@@ -1,0 +1,11 @@
+package scale
+
+import "testing"
+
+func TestCobraCommand(t *testing.T) {
+	Command.SetArgs([]string{"--help"})
+	err := Command.Execute()
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -171,7 +171,7 @@ type endpointConfig struct {
 
 // StoreEndpointAuth adds an endpoint to the configStruct.Endpoints field
 // (if not yet there). This should only be done after successful authentication.
-func (c *configStruct) StoreEndpointAuth(endpointURL string, alias string, email string, scheme string, token string, refreshToken string) error {
+func (c *configStruct) StoreEndpointAuth(endpointURL, alias, provider, email, scheme, token, refreshToken string) error {
 	ep := normalizeEndpoint(endpointURL)
 
 	if email == "" || token == "" {
@@ -201,9 +201,14 @@ func (c *configStruct) StoreEndpointAuth(endpointURL string, alias string, email
 		aliasBefore = c.endpoints[ep].Alias
 	}
 
+	if provider == "" && c.endpoints[ep] != nil {
+		provider = c.endpoints[ep].Provider
+	}
+
 	c.endpoints[ep] = &endpointConfig{
 		Alias:        aliasBefore,
 		Email:        email,
+		Provider:     provider,
 		RefreshToken: refreshToken,
 		Scheme:       scheme,
 		Token:        token,
@@ -394,6 +399,9 @@ func (c *configStruct) SetProvider(provider string) error {
 		return microerror.Mask(endpointProviderIsImmuttableError)
 	}
 
+	c.endpointsMutex.Lock()
+	defer c.endpointsMutex.Unlock()
+
 	c.endpoints[c.SelectedEndpoint].Provider = provider
 	c.Provider = provider
 	WriteToFile()
@@ -463,7 +471,7 @@ func (c *configStruct) AuthHeaderGetter(endpoint string, overridingToken string)
 				}
 
 				// Update the config file with the new access token.
-				if err := Config.StoreEndpointAuth(endpoint, endpointConfig.Alias, idToken.Email, "Bearer", refreshTokenResponse.AccessToken, refreshToken); err != nil {
+				if err := Config.StoreEndpointAuth(endpoint, endpointConfig.Alias, "", idToken.Email, "Bearer", refreshTokenResponse.AccessToken, refreshToken); err != nil {
 					return "", microerror.Maskf(err, "Error while attempting to store the token in the config file")
 				}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -70,7 +70,7 @@ func Test_Initialize_Empty(t *testing.T) {
 
 	// directly set some configuration
 	Config.LastVersionCheck = time.Time{}
-	err = Config.StoreEndpointAuth(testEndpointURL, testAlias, testEmail, testScheme, testToken, testRefreshToken)
+	err = Config.StoreEndpointAuth(testEndpointURL, testAlias, "", testEmail, testScheme, testToken, testRefreshToken)
 	if err != nil {
 		t.Error(err)
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -153,6 +153,7 @@ endpoints:
   https://myapi.domain.tld:
     email: email@example.com
     token: some-token
+    provider: testprovider
 selected_endpoint: https://myapi.domain.tld`
 	email := "email@example.com"
 	token := "some-token"
@@ -168,6 +169,9 @@ selected_endpoint: https://myapi.domain.tld`
 	}
 	if Config.Token != "some-token" {
 		t.Errorf("Expected token '%s', got '%s'", token, Config.Token)
+	}
+	if Config.Provider != "testprovider" {
+		t.Errorf("Expected provider testprovider, got '%s'", Config.Provider)
 	}
 
 	// test what happens after logout
@@ -276,4 +280,45 @@ selected_endpoint: https://other.endpoint`
 		t.Errorf("Expected endpointNotDefinedError, got '%s'", err)
 	}
 
+}
+
+func Test_SetProvider(t *testing.T) {
+	var testCases = []struct {
+		configYAML           string
+		expectedErrorMatcher func(error) bool
+	}{
+		{
+			// selected endpoint already has a provider set
+			configYAML: `endpoints:
+  https://myapi.domain.tld:
+    provider: foo
+selected_endpoint: https://myapi.domain.tld`,
+			expectedErrorMatcher: IsEndpointProviderIsImmuttableError,
+		},
+		{
+			// no provider selected
+			configYAML: `endpoints:
+  "https://myapi.domain.tld":
+    provider: ""
+selected_endpoint: ""`,
+			expectedErrorMatcher: IsNoEndpointSelectedError,
+		},
+	}
+
+	for index, tc := range testCases {
+		dir, err := tempConfig(tc.configYAML)
+		if err != nil {
+			t.Errorf("Error creating temporary config for test case %d: %q", index, err)
+		}
+		defer os.RemoveAll(dir)
+
+		t.Logf("Config: %#v", Config)
+
+		err = Config.SetProvider("aws")
+		if err == nil {
+			t.Errorf("Test case %d: Expected error, but got nil", index)
+		} else if tc.expectedErrorMatcher(err) == false {
+			t.Errorf("Test case %d: Unexpected error: %q", index, err)
+		}
+	}
 }

--- a/config/error.go
+++ b/config/error.go
@@ -12,6 +12,26 @@ func IsEndpointNotDefinedError(err error) bool {
 	return microerror.Cause(err) == endpointNotDefinedError
 }
 
+// noEndpointSelectedError means no endpoint is currently selected.
+var noEndpointSelectedError = &microerror.Error{
+	Kind: "noEndpointSelectedError",
+}
+
+// IsNoEndpointSelectedError asserts noEndpointSelectedError.
+func IsNoEndpointSelectedError(err error) bool {
+	return microerror.Cause(err) == noEndpointSelectedError
+}
+
+// endpointProviderIsImmuttableError means no endpoint is currently selected.
+var endpointProviderIsImmuttableError = &microerror.Error{
+	Kind: "endpointProviderIsImmuttableError",
+}
+
+// IsEndpointProviderIsImmuttableError asserts endpointProviderIsImmuttableError.
+func IsEndpointProviderIsImmuttableError(err error) bool {
+	return microerror.Cause(err) == endpointProviderIsImmuttableError
+}
+
 // aliasMustBeUniqueError should be used if the user tries to add an alias to
 // an endpoint, but the alias is already in use
 var aliasMustBeUniqueError = &microerror.Error{
@@ -24,7 +44,10 @@ func IsAliasMustBeUniqueError(err error) bool {
 }
 
 // credentialsRequiredError means an attempt to store incomplete credentials in the config
-var credentialsRequiredError = microerror.New("email, password, or token must not be empty")
+var credentialsRequiredError = &microerror.Error{
+	Kind: "credentialsRequiredError",
+	Desc: "email, password, or token must not be empty",
+}
 
 // IsCredentialsRequiredError asserts credentialsRequiredError.
 func IsCredentialsRequiredError(err error) bool {


### PR DESCRIPTION
This is supposed to do what https://github.com/giantswarm/gsctl/pull/356 already did, but based on a refactored gsctl code base.

Also fixes client initialization for the `refactor-command-tree` branch.