### PR TITLE
Add 'list nodepools' command

### DIFF
--- a/commands/list/command.go
+++ b/commands/list/command.go
@@ -7,6 +7,7 @@ import (
 	"github.com/giantswarm/gsctl/commands/list/clusters"
 	"github.com/giantswarm/gsctl/commands/list/endpoints"
 	"github.com/giantswarm/gsctl/commands/list/keypairs"
+	"github.com/giantswarm/gsctl/commands/list/nodepools"
 	"github.com/giantswarm/gsctl/commands/list/organizations"
 	"github.com/giantswarm/gsctl/commands/list/releases"
 )
@@ -15,8 +16,8 @@ var (
 	// Command is the command to list things.
 	Command = &cobra.Command{
 		Use:   "list",
-		Short: "List things, like organizations, clusters, key pairs",
-		Long:  `Prints a list of the things you have access to`,
+		Short: "List things, like organizations, clusters, node pools, key pairs",
+		Long:  `Prints a list of the things you have access to.`,
 	}
 )
 
@@ -24,6 +25,7 @@ func init() {
 	Command.AddCommand(clusters.Command)
 	Command.AddCommand(endpoints.Command)
 	Command.AddCommand(keypairs.Command)
+	Command.AddCommand(nodepools.Command)
 	Command.AddCommand(organizations.Command)
 	Command.AddCommand(releases.Command)
 }

--- a/commands/list/nodepools/command.go
+++ b/commands/list/nodepools/command.go
@@ -1,0 +1,119 @@
+// Package nodepools implements the 'list organizations' sub-command.
+package nodepools
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/fatih/color"
+	"github.com/giantswarm/gsclientgen/client/nodepools"
+	"github.com/giantswarm/microerror"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/gsctl/client"
+	"github.com/giantswarm/gsctl/client/clienterror"
+	"github.com/giantswarm/gsctl/commands/errors"
+	"github.com/giantswarm/gsctl/config"
+	"github.com/giantswarm/gsctl/flags"
+)
+
+var (
+	// Command performs the "list organizations" function
+	Command = &cobra.Command{
+		Use:     "nodepools <cluster-id>",
+		Aliases: []string{"nps", "np"},
+
+		// Args: cobra.ExactArgs(1) guarantees that cobra will fail if no positional argument is given.
+		Args:  cobra.ExactArgs(1),
+		Short: "List node pools",
+		Long: `Prints a list of the node pools of a cluster.
+
+The result will be a table of all node pools of a specific cluster with some details.
+
+To see all available details for a cluster, use 'gsctl show nodepool <cluster-id>/<nodepool-id>'.
+
+To list all clusters you have access to, use 'gsctl list clusters'.`,
+		PreRun: printValidation,
+		Run:    printResult,
+	}
+)
+
+const activityName = "list-nodepools"
+
+type arguments struct {
+	apiEndpoint string
+	authToken   string
+	scheme      string
+	clusterID   string
+}
+
+// defaultArgs creates arguments based on command line flags and config.
+func defaultArgs(cmdLineArgs []string) arguments {
+	endpoint := config.Config.ChooseEndpoint(flags.CmdAPIEndpoint)
+	token := config.Config.ChooseToken(endpoint, flags.CmdToken)
+	scheme := config.Config.ChooseScheme(endpoint, flags.CmdToken)
+
+	return arguments{
+		apiEndpoint: endpoint,
+		authToken:   token,
+		scheme:      scheme,
+		clusterID:   cmdLineArgs[0],
+	}
+}
+
+func verifyPreconditions(args arguments, positionalArgs []string) error {
+	if config.Config.Token == "" && args.authToken == "" {
+		return microerror.Mask(errors.NotLoggedInError)
+	}
+
+	return nil
+}
+
+func printValidation(cmd *cobra.Command, positionalArgs []string) {
+	args := defaultArgs(positionalArgs)
+	err := verifyPreconditions(args, positionalArgs)
+	if err == nil {
+		return
+	}
+
+	errors.HandleCommonErrors(err)
+}
+
+func printResult(cmd *cobra.Command, positionalArgs []string) {
+	args := defaultArgs(positionalArgs)
+	nodePools, err := fetchNodePools(args)
+	if err != nil {
+		errors.HandleCommonErrors(err)
+		client.HandleErrors(err)
+
+		if clientErr, ok := err.(*clienterror.APIError); ok {
+			fmt.Println(color.RedString(clientErr.ErrorMessage))
+			if clientErr.ErrorDetails != "" {
+				fmt.Println(clientErr.ErrorDetails)
+			}
+		} else {
+			fmt.Println(color.RedString("Error: %s", err.Error()))
+		}
+		os.Exit(1)
+	}
+
+	fmt.Printf("Node pools: %#v\n", nodePools)
+}
+
+func fetchNodePools(args arguments) (*nodepools.GetNodePoolsOK, error) {
+	clientV2, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	auxParams := clientV2.DefaultAuxiliaryParams()
+	auxParams.ActivityName = activityName
+
+	response, err := clientV2.GetNodePools(args.clusterID, auxParams)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return response, nil
+
+}

--- a/commands/list/nodepools/command.go
+++ b/commands/list/nodepools/command.go
@@ -1,4 +1,4 @@
-// Package nodepools implements the 'list organizations' sub-command.
+// Package nodepools implements the 'list nodepools' sub-command.
 package nodepools
 
 import (
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-	// Command performs the "list organizations" function
+	// Command performs the "list nodepools" function
 	Command = &cobra.Command{
 		Use:     "nodepools <cluster-id>",
 		Aliases: []string{"nps", "np"},

--- a/commands/list/nodepools/command.go
+++ b/commands/list/nodepools/command.go
@@ -33,7 +33,18 @@ var (
 		Short: "List node pools",
 		Long: `Prints a list of the node pools of a cluster.
 
-The result will be a table of all node pools of a specific cluster with some details.
+The result will be a table of all node pools of a specific cluster with the following details in
+columns:
+
+	ID:             Node pool identifier (unique within the cluster)
+	NAME:           Name specified for the node pool, usually indicating the purpose
+	AZ:             Availability zone letters used by the node pool, separated by comma
+	INSTANCE TYPE:  EC2 instance type used for worker nodes
+	NODES MIN/MAX:  The minimum and maximum number of worker nodes in this pool
+	NODES DESIRED:  Current desired number of nodes as determined by the autoscaler
+	NODES READY:    Number of nodes that are in the Ready state in kubernetes
+	CPUS:           Sum of CPU cores in nodes that are in state Ready
+	RAM (GB):       Sum of memory in GB of all nodes that are in state Ready
 
 To see all available details for a cluster, use 'gsctl show nodepool <cluster-id>/<nodepool-id>'.
 

--- a/commands/list/nodepools/command.go
+++ b/commands/list/nodepools/command.go
@@ -95,6 +95,29 @@ func printValidation(cmd *cobra.Command, positionalArgs []string) {
 	errors.HandleCommonErrors(err)
 }
 
+func fetchNodePools(args arguments) (models.V5GetNodePoolsResponse, error) {
+	clientV2, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	auxParams := clientV2.DefaultAuxiliaryParams()
+	auxParams.ActivityName = activityName
+
+	response, err := clientV2.GetNodePools(args.clusterID, auxParams)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	// sort node pools by ID
+	sort.Slice(response.Payload[:], func(i, j int) bool {
+		return response.Payload[i].ID < response.Payload[j].ID
+	})
+
+	return response.Payload, nil
+
+}
+
 func printResult(cmd *cobra.Command, positionalArgs []string) {
 	args := defaultArgs(positionalArgs)
 	nodePools, err := fetchNodePools(args)
@@ -157,29 +180,6 @@ func printResult(cmd *cobra.Command, positionalArgs []string) {
 	}
 
 	fmt.Println(columnize.SimpleFormat(table))
-}
-
-func fetchNodePools(args arguments) (models.V5GetNodePoolsResponse, error) {
-	clientV2, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	auxParams := clientV2.DefaultAuxiliaryParams()
-	auxParams.ActivityName = activityName
-
-	response, err := clientV2.GetNodePools(args.clusterID, auxParams)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	// sort node pools by ID
-	sort.Slice(response.Payload[:], func(i, j int) bool {
-		return response.Payload[i].ID < response.Payload[j].ID
-	})
-
-	return response.Payload, nil
-
 }
 
 // formatAvailabilityZones returns the list of availability zones

--- a/commands/list/nodepools/command_test.go
+++ b/commands/list/nodepools/command_test.go
@@ -1,1 +1,3 @@
 package nodepools
+
+// TODO: Write unit tests

--- a/commands/list/nodepools/command_test.go
+++ b/commands/list/nodepools/command_test.go
@@ -1,3 +1,63 @@
 package nodepools
 
-// TODO: Write unit tests
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/spf13/afero"
+
+	"github.com/giantswarm/gsctl/config"
+	"github.com/giantswarm/gsctl/flags"
+	"github.com/giantswarm/gsctl/testutils"
+)
+
+func Test_ListNodePools(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == "GET" {
+			switch uri := r.URL.Path; uri {
+			case "/v5/clusters/cluster-id/nodepools/":
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`[
+					{"id": "a7rc4", "name": "Batch number crunching", "availability_zones": ["eu-west-1d"], "scaling": {"min": 2, "max": 5}, "node_spec": {"aws": {"instance_type": "p3.8xlarge"}, "volume_sizes_gb": {"docker": 100, "kubelet": 100}}, "status": {"nodes": 4, "nodes_ready": 4}},
+					{"id": "6feel", "name": "Application servers", "availability_zones": ["eu-west-1a", "eu-west-1b", "eu-west-1c"], "scaling": {"min": 3, "max": 15}, "node_spec": {"aws": {"instance_type": "p3.2xlarge"}, "volume_sizes_gb": {"docker": 100, "kubelet": 100}}, "status": {"nodes": 10, "nodes_ready": 9}},
+					{"id": "a6bf4", "name": "New node pool", "availability_zones": ["eu-west-1c"], "scaling": {"min": 3, "max": 3}, "node_spec": {"aws": {"instance_type": "m5.2xlarge"}, "volume_sizes_gb": {"docker": 100, "kubelet": 100}}, "status": {"nodes": 0, "nodes_ready": 0}}
+				]`))
+			default:
+				t.Errorf("Unsupported route %scalled in mock server", r.URL.Path)
+				w.WriteHeader(http.StatusNotFound)
+				w.Write([]byte(`{"code": "RESOURCE_NOT_FOUND", "message": "Status for this cluster is not yet available."}`))
+			}
+		}
+	}))
+	defer mockServer.Close()
+
+	// temp config
+	fs := afero.NewMemMapFs()
+	configDir := testutils.TempDir(fs)
+	config.Initialize(fs, configDir)
+
+	positionalArgs := []string{"cluster-id"}
+
+	flags.CmdAPIEndpoint = mockServer.URL
+	flags.CmdToken = "my-token"
+	args := defaultArgs(positionalArgs)
+
+	err := verifyPreconditions(args, positionalArgs)
+	if err != nil {
+		t.Error(err)
+	}
+
+	nodePools, err := fetchNodePools(args)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(nodePools) != 2 {
+		t.Errorf("Expected length 2, got %d", len(nodePools))
+	}
+
+	// execute the command
+	printResult(Command, positionalArgs)
+}

--- a/commands/list/nodepools/command_test.go
+++ b/commands/list/nodepools/command_test.go
@@ -54,7 +54,7 @@ func Test_ListNodePools(t *testing.T) {
 		t.Error(err)
 	}
 
-	if len(nodePools) != 2 {
+	if len(nodePools) != 3 {
 		t.Errorf("Expected length 2, got %d", len(nodePools))
 	}
 

--- a/commands/list/nodepools/command_test.go
+++ b/commands/list/nodepools/command_test.go
@@ -1,0 +1,1 @@
+package nodepools

--- a/commands/list/nodepools/command_test.go
+++ b/commands/list/nodepools/command_test.go
@@ -49,15 +49,20 @@ func Test_ListNodePools(t *testing.T) {
 		t.Error(err)
 	}
 
-	nodePools, err := fetchNodePools(args)
+	results, err := fetchNodePools(args)
 	if err != nil {
 		t.Error(err)
 	}
 
-	if len(nodePools) != 3 {
-		t.Errorf("Expected length 2, got %d", len(nodePools))
+	if len(results) != 3 {
+		t.Errorf("Expected length 3, got %d", len(results))
 	}
 
-	// execute the command
-	printResult(Command, positionalArgs)
+	if results[0].nodePool.ID != "6feel" {
+		t.Errorf("Expected NP ID 6feel in the front, got %s", results[0].nodePool.ID)
+	}
+
+	if results[2].sumCPUs != 128 {
+		t.Errorf("Expected 128 CPUs in the third row, got %d", results[2].sumCPUs)
+	}
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6447, to be merged into https://github.com/giantswarm/gsctl/pull/372

This PR adds the new `gsctl list nodepools <cluster-id>` command to list node pools of a cluster.

## Preview

```nohighlight
ID     NAME                    AZ     INSTANCE TYPE  NODES MIN/MAX  NODES DESIRED  NODES READY  CPUS  RAM (GB)
6feel  Application servers     A,B,C  p3.2xlarge     3/15           10             9            72    549.0
a7rc4  Batch number crunching  D      p3.8xlarge     2/5            4              4            128   976.0
```

Screenshot

![image](https://user-images.githubusercontent.com/273727/61206323-91cdf080-a6f2-11e9-9b11-b526c1aaf670.png)

