### PR TITLE
Add 'show nodepool' command

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -420,6 +420,22 @@ func (w *WrapperV2) GetClusterV5(clusterID string, p *AuxiliaryParams) (*cluster
 	return response, nil
 }
 
+// GetNodePool fetches a node pool.
+func (w *WrapperV2) GetNodePool(clusterID, nodePoolID string, p *AuxiliaryParams) (*nodepools.GetNodePoolOK, error) {
+	params := nodepools.NewGetNodePoolParams().WithClusterID(clusterID).WithNodepoolID(nodePoolID)
+	err := setParamsWithAuthorization(p, w, params)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	response, err := w.gsclient.Nodepools.GetNodePool(params, nil)
+	if err != nil {
+		return nil, clienterror.New(err)
+	}
+
+	return response, nil
+}
+
 // GetNodePools fetches a list of node pools.
 func (w *WrapperV2) GetNodePools(clusterID string, p *AuxiliaryParams) (*nodepools.GetNodePoolsOK, error) {
 	params := nodepools.NewGetNodePoolsParams().WithClusterID(clusterID)

--- a/client/clienterror/clienterror.go
+++ b/client/clienterror/clienterror.go
@@ -257,6 +257,24 @@ func New(err error) *APIError {
 		}
 	}
 
+	// get node pool
+	if getNodePoolUnauthorizedErr, ok := err.(*nodepools.GetNodePoolUnauthorized); ok {
+		return &APIError{
+			HTTPStatusCode: http.StatusUnauthorized,
+			OriginalError:  getNodePoolUnauthorizedErr,
+			ErrorMessage:   "Unauthorized",
+			ErrorDetails:   "You don't have permission to access this node pool.",
+		}
+	}
+	if getNodePoolNotFoundErr, ok := err.(*nodepools.GetNodePoolNotFound); ok {
+		return &APIError{
+			HTTPStatusCode: http.StatusNotFound,
+			OriginalError:  getNodePoolNotFoundErr,
+			ErrorMessage:   "Not found",
+			ErrorDetails:   "The node pool could not be found.",
+		}
+	}
+
 	// get node pools
 	if getNodePoolsUnauthorizedErr, ok := err.(*nodepools.GetNodePoolsUnauthorized); ok {
 		return &APIError{

--- a/commands/create/keypair/command.go
+++ b/commands/create/keypair/command.go
@@ -18,6 +18,7 @@ import (
 	"github.com/giantswarm/gsctl/commands/errors"
 	"github.com/giantswarm/gsctl/config"
 	"github.com/giantswarm/gsctl/flags"
+	"github.com/giantswarm/gsctl/formatting"
 	"github.com/giantswarm/gsctl/util"
 )
 
@@ -206,7 +207,7 @@ func printResult(cmd *cobra.Command, cmdLineArgs []string) {
 
 	// Success output
 	msg := fmt.Sprintf("New key pair created with ID %s and expiry of %v",
-		util.Truncate(util.CleanKeypairID(result.id), 10, true),
+		util.Truncate(formatting.CleanKeypairID(result.id), 10, true),
 		util.DurationPhrase(int(result.ttlHours)))
 	fmt.Println(color.GreenString(msg))
 

--- a/commands/create/kubeconfig/command.go
+++ b/commands/create/kubeconfig/command.go
@@ -24,6 +24,7 @@ import (
 	"github.com/giantswarm/gsctl/config"
 	"github.com/giantswarm/gsctl/confirm"
 	"github.com/giantswarm/gsctl/flags"
+	"github.com/giantswarm/gsctl/formatting"
 	"github.com/giantswarm/gsctl/util"
 )
 
@@ -316,7 +317,7 @@ func createKubeconfigRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 	// Success output
 
 	msg := fmt.Sprintf("New key pair created with ID %s and expiry of %v",
-		util.Truncate(util.CleanKeypairID(result.id), 10, true),
+		util.Truncate(formatting.CleanKeypairID(result.id), 10, true),
 		util.DurationPhrase(int(result.ttlHours)))
 	fmt.Println(color.GreenString(msg))
 

--- a/commands/errors/errors.go
+++ b/commands/errors/errors.go
@@ -92,6 +92,16 @@ func IsClusterIDMissingError(err error) bool {
 	return microerror.Cause(err) == ClusterIDMissingError
 }
 
+// NodePoolIDMissingError means a required node pool ID has not been given as input
+var NodePoolIDMissingError = &microerror.Error{
+	Kind: "NodePoolIDMissingError",
+}
+
+// IsNodePoolIDMissingError asserts NodePoolIDMissingError.
+func IsNodePoolIDMissingError(err error) bool {
+	return microerror.Cause(err) == NodePoolIDMissingError
+}
+
 // ClusterNotFoundError means that a given cluster does not exist
 var ClusterNotFoundError = &microerror.Error{
 	Kind: "ClusterNotFoundError",

--- a/commands/errors/handling.go
+++ b/commands/errors/handling.go
@@ -55,6 +55,9 @@ func HandleCommonErrors(err error) {
 		case IsClusterIDMissingError(err):
 			headline = "No cluster ID specified."
 			subtext = "Please specify a cluster ID. Use --help for details."
+		case IsNodePoolIDMissingError(err):
+			headline = "No node pool ID specified."
+			subtext = "Please specify a node pool ID. Use --help for details."
 		case IsCouldNotCreateClientError(err):
 			headline = "Failed to create API client."
 			subtext = fmt.Sprintf("Details: %s", err.Error())

--- a/commands/list/keypairs/command.go
+++ b/commands/list/keypairs/command.go
@@ -20,6 +20,7 @@ import (
 	"github.com/giantswarm/gsctl/commands/errors"
 	"github.com/giantswarm/gsctl/config"
 	"github.com/giantswarm/gsctl/flags"
+	"github.com/giantswarm/gsctl/formatting"
 	"github.com/giantswarm/gsctl/util"
 )
 
@@ -178,7 +179,7 @@ func printResult(cmd *cobra.Command, extraArgs []string) {
 			row := []string{
 				util.ShortDate(createdTime),
 				expires,
-				util.Truncate(util.CleanKeypairID(keypair.ID), 10, !args.full),
+				util.Truncate(formatting.CleanKeypairID(keypair.ID), 10, !args.full),
 				keypair.Description,
 				util.Truncate(keypair.CommonName, 24, !args.full),
 				keypair.CertificateOrganizations,

--- a/commands/list/nodepools/command.go
+++ b/commands/list/nodepools/command.go
@@ -19,6 +19,7 @@ import (
 	"github.com/giantswarm/gsctl/commands/errors"
 	"github.com/giantswarm/gsctl/config"
 	"github.com/giantswarm/gsctl/flags"
+	"github.com/giantswarm/gsctl/formatting"
 	"github.com/giantswarm/gsctl/nodespec"
 )
 
@@ -187,7 +188,7 @@ func printResult(cmd *cobra.Command, positionalArgs []string) {
 		table = append(table, strings.Join([]string{
 			row.nodePool.ID,
 			row.nodePool.Name,
-			formatAvailabilityZones(row.nodePool.AvailabilityZones),
+			formatting.AvailabilityZonesList(row.nodePool.AvailabilityZones),
 			row.nodePool.NodeSpec.Aws.InstanceType,
 			strconv.FormatInt(row.nodePool.Scaling.Min, 10) + "/" + strconv.FormatInt(row.nodePool.Scaling.Max, 10),
 			strconv.FormatInt(row.nodePool.Status.Nodes, 10),
@@ -198,21 +199,6 @@ func printResult(cmd *cobra.Command, positionalArgs []string) {
 	}
 
 	fmt.Println(columnize.SimpleFormat(table))
-}
-
-// formatAvailabilityZones returns the list of availability zones
-// as one string consisting of uppercase letters only, e. g. "A,B,C".
-func formatAvailabilityZones(az []string) string {
-	shortened := []string{}
-
-	for _, az := range az {
-		// last character of each item
-		shortened = append(shortened, az[len(az)-1:])
-	}
-
-	sort.Strings(shortened)
-
-	return strings.ToUpper(strings.Join(shortened, ","))
 }
 
 func formatNodesReady(nodes, nodesReady int64) string {

--- a/commands/list/nodepools/command_test.go
+++ b/commands/list/nodepools/command_test.go
@@ -25,7 +25,7 @@ func Test_ListNodePools(t *testing.T) {
 					{"id": "a6bf4", "name": "New node pool", "availability_zones": ["eu-west-1c"], "scaling": {"min": 3, "max": 3}, "node_spec": {"aws": {"instance_type": "m5.2xlarge"}, "volume_sizes_gb": {"docker": 100, "kubelet": 100}}, "status": {"nodes": 0, "nodes_ready": 0}}
 				]`))
 			default:
-				t.Errorf("Unsupported route %scalled in mock server", r.URL.Path)
+				t.Errorf("Unsupported route %s called in mock server", r.URL.Path)
 				w.WriteHeader(http.StatusNotFound)
 				w.Write([]byte(`{"code": "RESOURCE_NOT_FOUND", "message": "Status for this cluster is not yet available."}`))
 			}

--- a/commands/show/command.go
+++ b/commands/show/command.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/giantswarm/gsctl/commands/show/cluster"
+	"github.com/giantswarm/gsctl/commands/show/nodepool"
 	"github.com/giantswarm/gsctl/commands/show/release"
 )
 
@@ -18,5 +19,6 @@ var (
 
 func init() {
 	Command.AddCommand(cluster.ShowClusterCommand)
+	Command.AddCommand(nodepool.ShowNodepoolCommand)
 	Command.AddCommand(release.ShowReleaseCommand)
 }

--- a/commands/show/nodepool/command.go
+++ b/commands/show/nodepool/command.go
@@ -22,9 +22,10 @@ import (
 var (
 	// ShowNodepoolCommand is the cobra command for 'gsctl show nodepool'
 	ShowNodepoolCommand = &cobra.Command{
-		Hidden:  true,
-		Use:     "nodepool <cluster-id>/<nodepool-id>",
-		Aliases: []string{"np"},
+		DisableFlagsInUseLine: true,
+		Hidden:                true,
+		Use:                   "nodepool <cluster-id>/<nodepool-id>",
+		Aliases:               []string{"np"},
 		// Args: cobra.ExactArgs(1) guarantees that cobra will fail if no positional argument is given.
 		Args:  cobra.ExactArgs(1),
 		Short: "Show node pool details",

--- a/commands/show/nodepool/command.go
+++ b/commands/show/nodepool/command.go
@@ -1,0 +1,176 @@
+// Package nodepool implements the 'show nodepool' command.
+package nodepool
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/fatih/color"
+	"github.com/giantswarm/columnize"
+	"github.com/giantswarm/gsclientgen/models"
+	"github.com/giantswarm/microerror"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/gsctl/client"
+	"github.com/giantswarm/gsctl/commands/errors"
+	"github.com/giantswarm/gsctl/config"
+	"github.com/giantswarm/gsctl/flags"
+	"github.com/giantswarm/gsctl/formatting"
+	"github.com/giantswarm/gsctl/nodespec"
+)
+
+var (
+	// ShowNodepoolCommand is the cobra command for 'gsctl show nodepool'
+	ShowNodepoolCommand = &cobra.Command{
+		Use:     "nodepool <cluster-id>/<nodepool-id>",
+		Aliases: []string{"np"},
+		// Args: cobra.ExactArgs(1) guarantees that cobra will fail if no positional argument is given.
+		Args:  cobra.ExactArgs(1),
+		Short: "Show node pool details",
+		Long: `Display details of a node pool.
+
+Examples:
+
+  gsctl show nodepool f01r4/75rh1
+`,
+
+		// PreRun checks a few general things, like authentication.
+		PreRun: printValidation,
+
+		// Run calls the business function and prints results and errors.
+		Run: printResult,
+	}
+)
+
+const (
+	activityName = "show-nodepool"
+)
+
+type arguments struct {
+	apiEndpoint string
+	authToken   string
+	scheme      string
+	clusterID   string
+	nodePoolID  string
+}
+
+// result represents all information we want to collect about one node pool.
+type result struct {
+	// nodePool contains all the node pool details as returned from the API.
+	nodePool *models.V5GetNodePoolResponse
+	// instanceTypeDetails contains details on the instance type.
+	instanceTypeDetails *nodespec.InstanceType
+	sumCPUs             int64
+	sumMemory           float64
+}
+
+func defaultArguments(positionalArgs []string) arguments {
+	endpoint := config.Config.ChooseEndpoint(flags.CmdAPIEndpoint)
+	token := config.Config.ChooseToken(endpoint, flags.CmdToken)
+	scheme := config.Config.ChooseScheme(endpoint, flags.CmdToken)
+
+	parts := strings.Split(positionalArgs[0], "/")
+
+	return arguments{
+		apiEndpoint: endpoint,
+		authToken:   token,
+		scheme:      scheme,
+		clusterID:   parts[0],
+		nodePoolID:  parts[1],
+	}
+}
+
+func verifyPreconditions(args arguments, positionalArgs []string) error {
+	parsedArgs := defaultArguments(positionalArgs)
+	if config.Config.Token == "" && parsedArgs.authToken == "" {
+		return microerror.Mask(errors.NotLoggedInError)
+	}
+
+	if parsedArgs.clusterID == "" {
+		return microerror.Mask(errors.ClusterIDMissingError)
+	}
+	if parsedArgs.nodePoolID == "" {
+		return microerror.Mask(errors.NodePoolIDMissingError)
+	}
+
+	return nil
+}
+
+func printValidation(cmd *cobra.Command, positionalArgs []string) {
+	args := defaultArguments(positionalArgs)
+	err := verifyPreconditions(args, positionalArgs)
+	if err == nil {
+		return
+	}
+
+	errors.HandleCommonErrors(err)
+}
+
+// fetchNodePool collects all information we would want to display
+// on a node pools of a cluster.
+func fetchNodePool(args arguments) (*result, error) {
+	clientV2, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	auxParams := clientV2.DefaultAuxiliaryParams()
+	auxParams.ActivityName = activityName
+
+	// create combined output data structure.
+	res := &result{}
+
+	response, err := clientV2.GetNodePool(args.clusterID, args.nodePoolID, auxParams)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	res.nodePool = response.Payload
+
+	awsInfo, err := nodespec.NewAWS()
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	res.instanceTypeDetails, err = awsInfo.GetInstanceTypeDetails(res.nodePool.NodeSpec.Aws.InstanceType)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	res.sumCPUs = res.nodePool.Status.NodesReady * int64(res.instanceTypeDetails.CPUCores)
+	res.sumMemory = float64(res.nodePool.Status.NodesReady) * float64(res.instanceTypeDetails.MemorySizeGB)
+
+	return res, nil
+
+}
+
+func printResult(cmd *cobra.Command, positionalArgs []string) {
+	args := defaultArguments(positionalArgs)
+	data, err := fetchNodePool(args)
+	if err != nil {
+		errors.HandleCommonErrors(err)
+	}
+
+	table := []string{}
+
+	table = append(table, color.YellowString("ID:")+"|"+data.nodePool.ID)
+	table = append(table, color.YellowString("Name:")+"|"+data.nodePool.Name)
+	table = append(table, color.YellowString("Node instance type:")+fmt.Sprintf("|%s - %d GB RAM, %d CPUs each",
+		data.nodePool.NodeSpec.Aws.InstanceType, data.instanceTypeDetails.MemorySizeGB, data.instanceTypeDetails.CPUCores))
+	table = append(table, color.YellowString("Availability zones:")+"|"+formatting.AvailabilityZonesList(data.nodePool.AvailabilityZones))
+	table = append(table, color.YellowString("Node scaling:")+"|"+formatNodeScaling(data.nodePool.Scaling))
+	table = append(table, color.YellowString("Nodes desired:")+fmt.Sprintf("|%d", data.nodePool.Status.Nodes))
+	table = append(table, color.YellowString("Nodes in state Ready:")+fmt.Sprintf("|%d", data.nodePool.Status.NodesReady))
+	table = append(table, color.YellowString("CPUs:")+fmt.Sprintf("|%d", data.nodePool.Status.NodesReady*int64(data.instanceTypeDetails.CPUCores)))
+	table = append(table, color.YellowString("RAM:")+fmt.Sprintf("|%d GB", data.nodePool.Status.NodesReady*int64(data.instanceTypeDetails.MemorySizeGB)))
+
+	fmt.Println(columnize.SimpleFormat(table))
+}
+
+func formatNodeScaling(scaling *models.V5GetNodePoolResponseScaling) string {
+	if scaling.Min == scaling.Max {
+		return fmt.Sprintf("Pinned to %d", scaling.Min)
+	}
+
+	return fmt.Sprintf("Autoscaling between %d and %d", scaling.Min, scaling.Max)
+}

--- a/commands/show/nodepool/command.go
+++ b/commands/show/nodepool/command.go
@@ -22,6 +22,7 @@ import (
 var (
 	// ShowNodepoolCommand is the cobra command for 'gsctl show nodepool'
 	ShowNodepoolCommand = &cobra.Command{
+		Hidden:  true,
 		Use:     "nodepool <cluster-id>/<nodepool-id>",
 		Aliases: []string{"np"},
 		// Args: cobra.ExactArgs(1) guarantees that cobra will fail if no positional argument is given.

--- a/commands/show/nodepool/command_test.go
+++ b/commands/show/nodepool/command_test.go
@@ -1,0 +1,71 @@
+package nodepool
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/spf13/afero"
+
+	"github.com/giantswarm/gsctl/config"
+	"github.com/giantswarm/gsctl/flags"
+	"github.com/giantswarm/gsctl/testutils"
+)
+
+func Test_ShowNodePool(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == "GET" {
+			switch uri := r.URL.Path; uri {
+			case "/v5/clusters/cluster-id/nodepools/nodepool-id/":
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{
+					"id": "nodepool-id",
+					"name": "Application servers",
+					"availability_zones": ["eu-west-1a", "eu-west-1c"],
+					"scaling": {"min": 3, "max": 10},
+					"node_spec": {"aws": {"instance_type": "c5.large"}, "volume_sizes_gb": {"docker": 100, "kubelet": 100}},
+					"status": {"nodes": 3, "nodes_ready": 3}
+				}`))
+			default:
+				t.Errorf("Unsupported route %s called in mock server", r.URL.Path)
+				w.WriteHeader(http.StatusNotFound)
+				w.Write([]byte(`{"code": "RESOURCE_NOT_FOUND", "message": "Status for this cluster is not yet available."}`))
+			}
+		}
+	}))
+	defer mockServer.Close()
+
+	// temp config
+	fs := afero.NewMemMapFs()
+	configDir := testutils.TempDir(fs)
+	config.Initialize(fs, configDir)
+
+	positionalArgs := []string{"cluster-id/nodepool-id"}
+
+	flags.CmdAPIEndpoint = mockServer.URL
+	flags.CmdToken = "my-token"
+	args := defaultArguments(positionalArgs)
+
+	err := verifyPreconditions(args, positionalArgs)
+	if err != nil {
+		t.Error(err)
+	}
+
+	result, err := fetchNodePool(args)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if result.nodePool.ID != "nodepool-id" {
+		t.Errorf("Got unexpected node pool ID %s", result.nodePool.ID)
+	}
+
+	if result.sumCPUs != 6 {
+		t.Errorf("Got unexpected number of CPUs: %d", result.sumCPUs)
+	}
+	if result.sumMemory != 12.0 {
+		t.Errorf("Got unexpected sum of RAM: %f GB", result.sumMemory)
+	}
+
+}

--- a/formatting/availability_zones.go
+++ b/formatting/availability_zones.go
@@ -1,0 +1,22 @@
+package formatting
+
+import (
+	"sort"
+	"strings"
+)
+
+// AvailabilityZonesList returns the list of availability zones
+// as one string consisting of uppercase letters only, separated by comma.
+// Example: "A,B,C".
+func AvailabilityZonesList(az []string) string {
+	shortened := []string{}
+
+	for _, az := range az {
+		// last character of each item
+		shortened = append(shortened, az[len(az)-1:])
+	}
+
+	sort.Strings(shortened)
+
+	return strings.ToUpper(strings.Join(shortened, ","))
+}

--- a/formatting/availability_zones_test.go
+++ b/formatting/availability_zones_test.go
@@ -1,0 +1,20 @@
+package formatting
+
+import "testing"
+
+var flagtests = []struct {
+	in  []string
+	out string
+}{
+	{[]string{"foo1-c"}, "C"},
+	{[]string{"foo1-b", "foo1-a"}, "A,B"},
+}
+
+func TestAvailabilityZonesList(t *testing.T) {
+	for _, tt := range flagtests {
+		s := AvailabilityZonesList(tt.in)
+		if s != tt.out {
+			t.Errorf("got %q, want %q", s, tt.out)
+		}
+	}
+}

--- a/formatting/availability_zones_test.go
+++ b/formatting/availability_zones_test.go
@@ -1,20 +1,25 @@
 package formatting
 
-import "testing"
-
-var flagtests = []struct {
-	in  []string
-	out string
-}{
-	{[]string{"foo1-c"}, "C"},
-	{[]string{"foo1-b", "foo1-a"}, "A,B"},
-}
+import (
+	"strconv"
+	"testing"
+)
 
 func TestAvailabilityZonesList(t *testing.T) {
-	for _, tt := range flagtests {
-		s := AvailabilityZonesList(tt.in)
-		if s != tt.out {
-			t.Errorf("got %q, want %q", s, tt.out)
-		}
+	var testCases = []struct {
+		in  []string
+		out string
+	}{
+		{[]string{"foo1-c"}, "C"},
+		{[]string{"foo1-b", "foo1-a"}, "A,B"},
+	}
+
+	for i, tt := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			s := AvailabilityZonesList(tt.in)
+			if s != tt.out {
+				t.Errorf("got %q, want %q", s, tt.out)
+			}
+		})
 	}
 }

--- a/formatting/availability_zones_test.go
+++ b/formatting/availability_zones_test.go
@@ -14,11 +14,11 @@ func TestAvailabilityZonesList(t *testing.T) {
 		{[]string{"foo1-b", "foo1-a"}, "A,B"},
 	}
 
-	for i, tt := range testCases {
+	for i, tc := range testCases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			s := AvailabilityZonesList(tt.in)
-			if s != tt.out {
-				t.Errorf("got %q, want %q", s, tt.out)
+			s := AvailabilityZonesList(tc.in)
+			if s != tc.out {
+				t.Errorf("got %q, want %q", s, tc.out)
 			}
 		})
 	}

--- a/formatting/key_pair_id.go
+++ b/formatting/key_pair_id.go
@@ -1,0 +1,8 @@
+package formatting
+
+import "strings"
+
+// CleanKeypairID returns a cleaned version of the KeyPair ID
+func CleanKeypairID(str string) string {
+	return strings.Replace(str, ":", "", -1)
+}

--- a/formatting/key_pair_id_test.go
+++ b/formatting/key_pair_id_test.go
@@ -1,21 +1,26 @@
 package formatting
 
-import "testing"
+import (
+	"strconv"
+	"testing"
+)
 
 type KeypairIDTest struct {
 	input  string
 	output string
 }
 
-var keypairIDTests = []KeypairIDTest{
-	{"a1:b2:c3:d4:e5:f6:g7:00", "a1b2c3d4e5f6g700"},
-}
-
 func TestCleanKeypairID(t *testing.T) {
-	for i, test := range keypairIDTests {
-		out := CleanKeypairID(test.input)
-		if out != test.output {
-			t.Errorf("#%d: CleanKeypairID(%s) = '%s'; want '%s'", i, test.input, out, test.output)
-		}
+	testCases := []KeypairIDTest{
+		{"a1:b2:c3:d4:e5:f6:g7:00", "a1b2c3d4e5f6g700"},
+	}
+
+	for i, test := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			out := CleanKeypairID(test.input)
+			if out != test.output {
+				t.Errorf("#%d: CleanKeypairID(%s) = '%s'; want '%s'", i, test.input, out, test.output)
+			}
+		})
 	}
 }

--- a/formatting/key_pair_id_test.go
+++ b/formatting/key_pair_id_test.go
@@ -13,11 +13,11 @@ func TestCleanKeypairID(t *testing.T) {
 		{"a1:b2:c3:d4:e5:f6:g7:00", "a1b2c3d4e5f6g700"},
 	}
 
-	for i, test := range testCases {
+	for i, tc := range testCases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			out := CleanKeypairID(test.input)
-			if out != test.output {
-				t.Errorf("#%d: CleanKeypairID(%s) = '%s'; want '%s'", i, test.input, out, test.output)
+			out := CleanKeypairID(tc.input)
+			if out != tc.output {
+				t.Errorf("#%d: CleanKeypairID(%s) = '%s'; want '%s'", i, tc.input, out, tc.output)
 			}
 		})
 	}

--- a/formatting/key_pair_id_test.go
+++ b/formatting/key_pair_id_test.go
@@ -5,13 +5,11 @@ import (
 	"testing"
 )
 
-type KeypairIDTest struct {
-	input  string
-	output string
-}
-
 func TestCleanKeypairID(t *testing.T) {
-	testCases := []KeypairIDTest{
+	testCases := []struct {
+		input  string
+		output string
+	}{
 		{"a1:b2:c3:d4:e5:f6:g7:00", "a1b2c3d4e5f6g700"},
 	}
 

--- a/formatting/key_pair_id_test.go
+++ b/formatting/key_pair_id_test.go
@@ -1,0 +1,21 @@
+package formatting
+
+import "testing"
+
+type KeypairIDTest struct {
+	input  string
+	output string
+}
+
+var keypairIDTests = []KeypairIDTest{
+	{"a1:b2:c3:d4:e5:f6:g7:00", "a1b2c3d4e5f6g700"},
+}
+
+func TestCleanKeypairID(t *testing.T) {
+	for i, test := range keypairIDTests {
+		out := CleanKeypairID(test.input)
+		if out != test.output {
+			t.Errorf("#%d: CleanKeypairID(%s) = '%s'; want '%s'", i, test.input, out, test.output)
+		}
+	}
+}

--- a/util/certs.go
+++ b/util/certs.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/spf13/afero"
+
+	"github.com/giantswarm/gsctl/formatting"
 )
 
 func writeCredentialFile(fs afero.Fs, certsDirPath, fileName, certificateData string) string {
@@ -36,7 +38,7 @@ func StoreCaCertificate(fs afero.Fs, certsDirPath, clusterID, data string) strin
 //
 // The file will have the name format `<clusterID>-<keypair-id>-client.crt`
 func StoreClientCertificate(fs afero.Fs, certsDirPath, clusterID, keyPairID, data string) string {
-	fileName := clusterID + "-" + CleanKeypairID(keyPairID)[:10] + "-client.crt"
+	fileName := clusterID + "-" + formatting.CleanKeypairID(keyPairID)[:10] + "-client.crt"
 	return writeCredentialFile(fs, certsDirPath, fileName, data)
 }
 
@@ -44,6 +46,6 @@ func StoreClientCertificate(fs afero.Fs, certsDirPath, clusterID, keyPairID, dat
 //
 // The file will have the name format `<clusterID>-<keypair-id>-client.key`
 func StoreClientKey(fs afero.Fs, certsDirPath, clusterID, keyPairID, data string) string {
-	fileName := clusterID + "-" + CleanKeypairID(keyPairID)[:10] + "-client.key"
+	fileName := clusterID + "-" + formatting.CleanKeypairID(keyPairID)[:10] + "-client.key"
 	return writeCredentialFile(fs, certsDirPath, fileName, data)
 }

--- a/util/truncate.go
+++ b/util/truncate.go
@@ -1,16 +1,9 @@
 package util
 
-import "strings"
-
 // Truncate takes a string and truncates it (if doTruncate is true)
 func Truncate(str string, length int, doTruncate bool) string {
 	if !doTruncate || len(str) < length {
 		return str
 	}
 	return str[:(length-1)] + "…"
-}
-
-// CleanKeypairID returns a cleaned version of the KeyPair ID
-func CleanKeypairID(str string) string {
-	return strings.Replace(str, ":", "", -1)
 }

--- a/util/truncate_test.go
+++ b/util/truncate_test.go
@@ -8,19 +8,10 @@ type TruncateTest struct {
 	output string
 }
 
-type KeypairIDTest struct {
-	input  string
-	output string
-}
-
 var truncateTests = []TruncateTest{
 	{"This is a longer string", 10, "This is a…"},
 	{"Cut after a blank character", 19, "Cut after a blank …"},
 	{"This won't be touched", 30, "This won't be touched"},
-}
-
-var keypairIDTests = []KeypairIDTest{
-	{"a1:b2:c3:d4:e5:f6:g7:00", "a1b2c3d4e5f6g700"},
 }
 
 func TestTruncate(t *testing.T) {
@@ -28,15 +19,6 @@ func TestTruncate(t *testing.T) {
 		out := Truncate(test.input, test.length, true)
 		if out != test.output {
 			t.Errorf("#%d: TestTruncate(%s, %d) = '%s'; want '%s'", i, test.input, test.length, out, test.output)
-		}
-	}
-}
-
-func TestCleanKeypairID(t *testing.T) {
-	for i, test := range keypairIDTests {
-		out := CleanKeypairID(test.input)
-		if out != test.output {
-			t.Errorf("#%d: CleanKeypairID(%s) = '%s'; want '%s'", i, test.input, out, test.output)
 		}
 	}
 }


### PR DESCRIPTION
To be merged into https://github.com/giantswarm/gsctl/pull/372

Part of https://github.com/giantswarm/giantswarm/issues/6447

This PR adds the `gsctl show nodepool <cluster-id>/<nodepool-id>` command.

### Preview

```nohighlight
$ gsctl show nodepool m0ckd/a7rc4
ID:                    a7rc4
Name:                  Batch number crunching
Node instance type:    p3.8xlarge - 244 GB RAM, 32 CPUs each
Availability zones:    D
Node scaling:          Autoscaling between 2 and 5
Nodes desired:         4
Nodes in state Ready:  4
CPUs:                  128
RAM:                   976 GB
```