### PR TITLE
Align numeric columns to the right

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -77,12 +77,12 @@
   revision = "5294df621fba91f5e5b45730904a377623752242"
 
 [[projects]]
-  branch = "right-alignment"
+  branch = "master"
   digest = "1:10073b2acb12a3325039f2ac5cfd50039584ad5913ed7147a391f3f6d9005ef1"
   name = "github.com/giantswarm/columnize"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "eb87b5036530adbfa273551408069fd53b047814"
+  revision = "cc99d98ffb296b079c11bc555aa8f55842601b7b"
 
 [[projects]]
   branch = "node-pools"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -77,12 +77,12 @@
   revision = "5294df621fba91f5e5b45730904a377623752242"
 
 [[projects]]
-  digest = "1:8f95a926443ce0713334413d2c0307bf4d7c79cc01746b08f6ec999bbc2d6cdc"
+  branch = "right-alignment"
+  digest = "1:10073b2acb12a3325039f2ac5cfd50039584ad5913ed7147a391f3f6d9005ef1"
   name = "github.com/giantswarm/columnize"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "677ded9e47e75ca49bd2541794a7281a49a2f17b"
-  version = "v2.0.2"
+  revision = "eb87b5036530adbfa273551408069fd53b047814"
 
 [[projects]]
   branch = "node-pools"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -36,7 +36,7 @@
 
 [[constraint]]
   name = "github.com/giantswarm/columnize"
-  version = "=2.0.2"
+  branch = "right-alignment"
 
 [[constraint]]
   branch = "node-pools"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -36,7 +36,7 @@
 
 [[constraint]]
   name = "github.com/giantswarm/columnize"
-  branch = "right-alignment"
+  branch = "master"
 
 [[constraint]]
   branch = "node-pools"

--- a/commands/list/nodepools/command.go
+++ b/commands/list/nodepools/command.go
@@ -197,7 +197,20 @@ func printResult(cmd *cobra.Command, positionalArgs []string) {
 		}, "|"))
 	}
 
-	fmt.Println(columnize.SimpleFormat(table))
+	colConfig := columnize.DefaultConfig()
+	colConfig.ColumnSpec = []*columnize.ColumnSpecification{
+		&columnize.ColumnSpecification{Alignment: columnize.AlignLeft},
+		&columnize.ColumnSpecification{Alignment: columnize.AlignLeft},
+		&columnize.ColumnSpecification{Alignment: columnize.AlignLeft},
+		&columnize.ColumnSpecification{Alignment: columnize.AlignLeft},
+		&columnize.ColumnSpecification{Alignment: columnize.AlignLeft},
+		&columnize.ColumnSpecification{Alignment: columnize.AlignRight},
+		&columnize.ColumnSpecification{Alignment: columnize.AlignRight},
+		&columnize.ColumnSpecification{Alignment: columnize.AlignRight},
+		&columnize.ColumnSpecification{Alignment: columnize.AlignRight},
+	}
+
+	fmt.Println(columnize.Format(table, colConfig))
 }
 
 // formatAvailabilityZones returns the list of availability zones


### PR DESCRIPTION
This PR changes the table output of `gsctl list nodepools` to right-align the numeric columns.

### Preview

![image](https://user-images.githubusercontent.com/273727/61327909-46aefd00-a81a-11e9-93fc-4a7bc69a2a9c.png)
