### PR TITLE
Add reusable EnsureProviderInConfig function in client

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -122,13 +122,20 @@ func NewV2(conf *Configuration) (*WrapperV2, error) {
 		Timeout:   conf.Timeout,
 	}
 
-	return &WrapperV2{
+	c := &WrapperV2{
 		conf:        conf,
 		gsclient:    gsclient.New(transport, strfmt.Default),
 		requestID:   randomRequestID(),
 		commandLine: getCommandLine(),
 		rawClient:   rawClient,
-	}, nil
+	}
+
+	err = c.ensureProviderInConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	return c, nil
 }
 
 // NewWithConfig creates a new client wrapper for a certain endpoint, optionally
@@ -295,9 +302,9 @@ func setParamsWithAuthorization(p *AuxiliaryParams, w *WrapperV2, params paramSe
 	return nil
 }
 
-// EnsureProviderInConfig ensures that the config file has a valid provider entry
+// ensureProviderInConfig ensures that the config file has a valid provider entry
 // for the configured endpoint.
-func (w *WrapperV2) EnsureProviderInConfig() error {
+func (w *WrapperV2) ensureProviderInConfig() error {
 	if config.Config.Provider == "" {
 		auxParams := w.DefaultAuxiliaryParams()
 		info, err := w.GetInfo(auxParams)

--- a/client/client.go
+++ b/client/client.go
@@ -295,6 +295,21 @@ func setParamsWithAuthorization(p *AuxiliaryParams, w *WrapperV2, params paramSe
 	return nil
 }
 
+// EnsureProviderInConfig ensures that the config file has a valid provider entry
+// for the configured endpoint.
+func (w *WrapperV2) EnsureProviderInConfig() error {
+	if config.Config.Provider == "" {
+		auxParams := w.DefaultAuxiliaryParams()
+		info, err := w.GetInfo(auxParams)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		config.Config.SetProvider(info.Payload.General.Provider)
+	}
+
+	return nil
+}
+
 // CreateAuthToken creates an auth token using the V2 client.
 func (w *WrapperV2) CreateAuthToken(email, password string, p *AuxiliaryParams) (*auth_tokens.CreateAuthTokenOK, error) {
 	params := auth_tokens.NewCreateAuthTokenParams().WithBody(&models.V4CreateAuthTokenRequest{

--- a/client/client.go
+++ b/client/client.go
@@ -132,7 +132,7 @@ func NewV2(conf *Configuration) (*WrapperV2, error) {
 
 	err = c.ensureProviderInConfig()
 	if err != nil {
-		return nil, err
+		return nil, microerror.Mask(err)
 	}
 
 	return c, nil

--- a/commands/scale/cluster/command.go
+++ b/commands/scale/cluster/command.go
@@ -173,12 +173,6 @@ func getClusterStatus(clusterID, activityName string) (*client.ClusterStatus, er
 	auxParams := clientV2.DefaultAuxiliaryParams()
 	auxParams.ActivityName = activityName
 
-	// Make sure we have provider info in the current endpoint
-	err = clientV2.EnsureProviderInConfig()
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
 	// perform API call
 	if flags.CmdVerbose {
 		fmt.Println(color.WhiteString("Fetching current cluster size"))

--- a/commands/scale/cluster/command.go
+++ b/commands/scale/cluster/command.go
@@ -174,16 +174,9 @@ func getClusterStatus(clusterID, activityName string) (*client.ClusterStatus, er
 	auxParams.ActivityName = activityName
 
 	// Make sure we have provider info in the current endpoint
-	if config.Config.Provider == "" {
-		if flags.CmdVerbose {
-			fmt.Println(color.WhiteString("Fetching provider information"))
-		}
-
-		info, err := clientV2.GetInfo(auxParams)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-		config.Config.SetProvider(info.Payload.General.Provider)
+	err = clientV2.EnsureProviderInConfig()
+	if err != nil {
+		return nil, microerror.Mask(err)
 	}
 
 	// perform API call


### PR DESCRIPTION
This adds a `EnsureProviderInConfig` function to the client package, as discussed in a hangout, to have it re-usable form other commands.