### PR TITLE
Handle malformed response error in 'show cluster' command

### DIFF
--- a/client/clienterror/matcher.go
+++ b/client/clienterror/matcher.go
@@ -1,0 +1,7 @@
+package clienterror
+
+// IsMalformedResponseError checks whether the error is
+// "Malformed response", which can mean several things.
+func IsMalformedResponseError(err error) bool {
+	return err.Error() == "Malformed response"
+}


### PR DESCRIPTION
This PR enables `gsctl show cluster` as implemented in the `support-v5` branch to work with the older API, not supporting v5 endpoints yet.