### PR TITLE
Add 'create nodepool' command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,10 +2,10 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.12.5
+      - image: circleci/golang:1.12.7
 
-    # We use 'medium+' because with 'medium' we saw tests fail due to memory problems.
-    resource_class: medium+
+    # We use 'large' because with 'medium' an 'medium#' we saw tests fail due to memory problems and too many threads.
+    resource_class: large
 
     working_directory: /go/src/github.com/giantswarm/gsctl
     steps:

--- a/client/client.go
+++ b/client/client.go
@@ -421,7 +421,7 @@ func (w *Wrapper) GetClusterV5(clusterID string, p *AuxiliaryParams) (*clusters.
 }
 
 // CreateNodePool creates a node pool.
-func (w *WrapperV2) CreateNodePool(clusterID string, addNodePoolRequest *models.V5AddNodePoolRequest, p *AuxiliaryParams) (*nodepools.AddNodePoolCreated, error) {
+func (w *Wrapper) CreateNodePool(clusterID string, addNodePoolRequest *models.V5AddNodePoolRequest, p *AuxiliaryParams) (*nodepools.AddNodePoolCreated, error) {
 	params := nodepools.NewAddNodePoolParams().WithBody(addNodePoolRequest).WithClusterID(clusterID)
 	err := setParamsWithAuthorization(p, w, params)
 	if err != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -420,6 +420,22 @@ func (w *WrapperV2) GetClusterV5(clusterID string, p *AuxiliaryParams) (*cluster
 	return response, nil
 }
 
+// CreateNodePool creates a node pool.
+func (w *WrapperV2) CreateNodePool(clusterID string, addNodePoolRequest *models.V5AddNodePoolRequest, p *AuxiliaryParams) (*nodepools.AddNodePoolCreated, error) {
+	params := nodepools.NewAddNodePoolParams().WithBody(addNodePoolRequest).WithClusterID(clusterID)
+	err := setParamsWithAuthorization(p, w, params)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	response, err := w.gsclient.Nodepools.AddNodePool(params, nil)
+	if err != nil {
+		return nil, clienterror.New(err)
+	}
+
+	return response, nil
+}
+
 // GetNodePool fetches a node pool.
 func (w *WrapperV2) GetNodePool(clusterID, nodePoolID string, p *AuxiliaryParams) (*nodepools.GetNodePoolOK, error) {
 	params := nodepools.NewGetNodePoolParams().WithClusterID(clusterID).WithNodepoolID(nodePoolID)

--- a/client/clienterror/clienterror.go
+++ b/client/clienterror/clienterror.go
@@ -257,6 +257,39 @@ func New(err error) *APIError {
 		}
 	}
 
+	// create node pool
+	if addNodePoolUnauthorizedErr, ok := err.(*nodepools.AddNodePoolUnauthorized); ok {
+		return &APIError{
+			HTTPStatusCode: http.StatusUnauthorized,
+			OriginalError:  addNodePoolUnauthorizedErr,
+			ErrorMessage:   "Unauthorized",
+			ErrorDetails:   "You don't have permission to add a node pool to this cluster.",
+		}
+	}
+	if addNodePoolBadRequestErr, ok := err.(*nodepools.AddNodePoolBadRequest); ok {
+		return &APIError{
+			HTTPStatusCode: http.StatusBadRequest,
+			OriginalError:  addNodePoolBadRequestErr,
+			ErrorMessage:   "Bad Request",
+			ErrorDetails:   addNodePoolBadRequestErr.Payload.Message,
+		}
+	}
+	if addNodePoolNotFoundErr, ok := err.(*nodepools.AddNodePoolNotFound); ok {
+		return &APIError{
+			HTTPStatusCode: http.StatusNotFound,
+			OriginalError:  addNodePoolNotFoundErr,
+			ErrorMessage:   "Cluster Not Found",
+			ErrorDetails:   "The cluster could not be found.",
+		}
+	}
+	if addNodePoolDefaultErr, ok := err.(*nodepools.AddNodePoolDefault); ok {
+		return &APIError{
+			HTTPStatusCode: addNodePoolDefaultErr.Code(),
+			OriginalError:  addNodePoolDefaultErr,
+			ErrorMessage:   addNodePoolDefaultErr.Error(),
+		}
+	}
+
 	// get node pool
 	if getNodePoolUnauthorizedErr, ok := err.(*nodepools.GetNodePoolUnauthorized); ok {
 		return &APIError{

--- a/client/clienterror/matcher.go
+++ b/client/clienterror/matcher.go
@@ -10,18 +10,27 @@ func IsMalformedResponseError(err error) bool {
 
 // IsBadRequestError checks whether the error
 // is an HTTP 400 error.
-func IsBadRequestError(err *APIError) bool {
-	return err.HTTPStatusCode == http.StatusBadRequest
+func IsBadRequestError(err error) bool {
+	if clientErr, ok := err.(*APIError); ok {
+		return clientErr.HTTPStatusCode == http.StatusBadRequest
+	}
+	return false
 }
 
 // IsAccessForbiddenError checks whether the error
 // is an HTTP 403 error.
-func IsAccessForbiddenError(err *APIError) bool {
-	return err.HTTPStatusCode == http.StatusForbidden
+func IsAccessForbiddenError(err error) bool {
+	if clientErr, ok := err.(*APIError); ok {
+		return clientErr.HTTPStatusCode == http.StatusForbidden
+	}
+	return false
 }
 
 // IsNotFoundError checks whether the error
 // is an HTTP 404 error.
-func IsNotFoundError(err *APIError) bool {
-	return err.HTTPStatusCode == http.StatusNotFound
+func IsNotFoundError(err error) bool {
+	if clientErr, ok := err.(*APIError); ok {
+		return clientErr.HTTPStatusCode == http.StatusNotFound
+	}
+	return false
 }

--- a/client/clienterror/matcher.go
+++ b/client/clienterror/matcher.go
@@ -1,7 +1,27 @@
 package clienterror
 
+import "net/http"
+
 // IsMalformedResponseError checks whether the error is
 // "Malformed response", which can mean several things.
 func IsMalformedResponseError(err error) bool {
 	return err.Error() == "Malformed response"
+}
+
+// IsBadRequestError checks whether the error
+// is an HTTP 400 error.
+func IsBadRequestError(err *APIError) bool {
+	return err.HTTPStatusCode == http.StatusBadRequest
+}
+
+// IsAccessForbiddenError checks whether the error
+// is an HTTP 403 error.
+func IsAccessForbiddenError(err *APIError) bool {
+	return err.HTTPStatusCode == http.StatusForbidden
+}
+
+// IsNotFoundError checks whether the error
+// is an HTTP 404 error.
+func IsNotFoundError(err *APIError) bool {
+	return err.HTTPStatusCode == http.StatusNotFound
 }

--- a/commands/create/cluster/command.go
+++ b/commands/create/cluster/command.go
@@ -66,7 +66,7 @@ func defaultArguments() arguments {
 		scheme:                  scheme,
 		token:                   token,
 		verbose:                 flags.CmdVerbose,
-		wokerAwsEc2InstanceType: cmdWorkerAwsEc2InstanceType,
+		wokerAwsEc2InstanceType: flags.CmdWorkerAwsEc2InstanceType,
 		wokerAzureVMSize:        cmdWorkerAzureVMSize,
 		workerMemorySizeGB:      flags.CmdWorkerMemorySizeGB,
 		workerNumCPUs:           flags.CmdWorkerNumCPUs,
@@ -145,8 +145,6 @@ Examples:
 	cmdClusterName string
 	// owner organization of the cluster as set via flag on execution
 	cmdOwner string
-	// AWS EC2 instance type to use, provided as a command line flag
-	cmdWorkerAwsEc2InstanceType string
 	// Azure VmSize to use, provided as a command line flag
 	cmdWorkerAzureVMSize string
 	// dry run command line flag
@@ -162,7 +160,7 @@ func init() {
 	Command.Flags().IntVarP(&flags.CmdNumWorkers, "num-workers", "", 0, "Shorthand to set --workers-min and --workers-max to the same value. Can't be used with -f|--file.")
 	Command.Flags().Int64VarP(&flags.CmdWorkersMin, "workers-min", "", 0, "Minimum number of worker nodes. Can't be used with -f|--file.")
 	Command.Flags().Int64VarP(&flags.CmdWorkersMax, "workers-max", "", 0, "Maximum number of worker nodes. Can't be used with -f|--file.")
-	Command.Flags().StringVarP(&cmdWorkerAwsEc2InstanceType, "aws-instance-type", "", "", "EC2 instance type to use for workers (AWS only), e. g. 'm3.large'")
+	Command.Flags().StringVarP(&flags.CmdWorkerAwsEc2InstanceType, "aws-instance-type", "", "", "EC2 instance type to use for workers (AWS only), e. g. 'm3.large'")
 	Command.Flags().StringVarP(&cmdWorkerAzureVMSize, "azure-vm-size", "", "", "VmSize to use for workers (Azure only), e. g. 'Standard_D2s_v3'")
 	Command.Flags().IntVarP(&flags.CmdWorkerNumCPUs, "num-cpus", "", 0, "Number of CPU cores per worker node. Can't be used with -f|--file.")
 	Command.Flags().Float32VarP(&flags.CmdWorkerMemorySizeGB, "memory-gb", "", 0, "RAM per worker node. Can't be used with -f|--file.")

--- a/commands/create/command.go
+++ b/commands/create/command.go
@@ -6,6 +6,7 @@ import (
 	"github.com/giantswarm/gsctl/commands/create/cluster"
 	"github.com/giantswarm/gsctl/commands/create/keypair"
 	"github.com/giantswarm/gsctl/commands/create/kubeconfig"
+	"github.com/giantswarm/gsctl/commands/create/nodepool"
 )
 
 var (
@@ -21,4 +22,5 @@ func init() {
 	Command.AddCommand(cluster.Command)
 	Command.AddCommand(keypair.Command)
 	Command.AddCommand(kubeconfig.Command)
+	Command.AddCommand(nodepool.Command)
 }

--- a/commands/create/nodepool/command.go
+++ b/commands/create/nodepool/command.go
@@ -21,7 +21,7 @@ import (
 var (
 	// Command is the cobra command for 'gsctl create nodepool'
 	Command = &cobra.Command{
-		Hidden:  false, // TODO: set to false to make this command visible once the release is out.
+		Hidden:  true, // TODO: set to false to make this command visible once the release is out.
 		Use:     "nodepool <cluster-id>",
 		Aliases: []string{"np"},
 		// Args: cobra.ExactArgs(1) guarantees that cobra will fail if no positional argument is given.

--- a/commands/create/nodepool/command.go
+++ b/commands/create/nodepool/command.go
@@ -127,6 +127,7 @@ type Arguments struct {
 	ScalingMax            int64
 	ScalingMin            int64
 	Scheme                string
+	UserProvidedToken     string
 	Verbose               bool
 }
 
@@ -147,7 +148,7 @@ func collectArguments(positionalArgs []string) (Arguments, error) {
 
 	zones := cmdAvailabilityZones
 	if zones != nil && len(zones) > 0 {
-		zones, err = expandZones(zones, endpoint, token)
+		zones, err = expandZones(zones, endpoint, flags.CmdToken)
 		if err != nil {
 			return Arguments{}, microerror.Mask(err)
 		}
@@ -170,6 +171,7 @@ func collectArguments(positionalArgs []string) (Arguments, error) {
 		ScalingMax:            flags.CmdWorkersMax,
 		ScalingMin:            flags.CmdWorkersMin,
 		Scheme:                scheme,
+		UserProvidedToken:     flags.CmdToken,
 		Verbose:               flags.CmdVerbose,
 	}, nil
 }
@@ -179,8 +181,8 @@ func collectArguments(positionalArgs []string) (Arguments, error) {
 //
 // ["a", "b"] -> ["eu-central-1a", "eu-central-1b"]
 //
-func expandZones(zones []string, endpoint, token string) ([]string, error) {
-	clientWrapper, err := client.NewWithConfig(endpoint, token)
+func expandZones(zones []string, endpoint, userProvidedToken string) ([]string, error) {
+	clientWrapper, err := client.NewWithConfig(endpoint, userProvidedToken)
 	if err != nil {
 		return []string{}, microerror.Mask(err)
 	}
@@ -289,7 +291,7 @@ func createNodePool(args Arguments) (*result, error) {
 		}
 	}
 
-	clientWrapper, err := client.NewWithConfig(args.APIEndpoint, args.AuthToken)
+	clientWrapper, err := client.NewWithConfig(args.APIEndpoint, args.UserProvidedToken)
 	if err != nil {
 		return r, microerror.Mask(err)
 	}

--- a/commands/create/nodepool/command.go
+++ b/commands/create/nodepool/command.go
@@ -144,13 +144,20 @@ func collectArguments(positionalArgs []string) (Arguments, error) {
 	token := config.Config.ChooseToken(endpoint, flags.CmdToken)
 	scheme := config.Config.ChooseScheme(endpoint, flags.CmdToken)
 
-	zones := cmdAvailabilityZones
 	var err error
+
+	zones := cmdAvailabilityZones
 	if zones != nil && len(zones) > 0 {
 		zones, err = expandZones(zones, endpoint, token)
 		if err != nil {
 			return Arguments{}, microerror.Mask(err)
 		}
+	}
+
+	if flags.CmdWorkersMin > 0 && flags.CmdWorkersMax == 0 {
+		flags.CmdWorkersMax = flags.CmdWorkersMin
+	} else if flags.CmdWorkersMax > 0 && flags.CmdWorkersMin == 0 {
+		flags.CmdWorkersMin = flags.CmdWorkersMax
 	}
 
 	return Arguments{

--- a/commands/create/nodepool/command.go
+++ b/commands/create/nodepool/command.go
@@ -303,16 +303,14 @@ func createNodePool(args Arguments) (*result, error) {
 
 	if err != nil {
 		// return specific error types for the cases we care about most.
-		if clientErr, ok := err.(*clienterror.APIError); ok {
-			if clienterror.IsAccessForbiddenError(clientErr) {
-				return nil, microerror.Mask(errors.AccessForbiddenError)
-			}
-			if clienterror.IsNotFoundError(clientErr) {
-				return nil, microerror.Mask(errors.ClusterNotFoundError)
-			}
-			if clienterror.IsBadRequestError(clientErr) {
-				return nil, microerror.Maskf(errors.BadRequestError, clientErr.ErrorDetails)
-			}
+		if clienterror.IsAccessForbiddenError(err) {
+			return nil, microerror.Mask(errors.AccessForbiddenError)
+		}
+		if clienterror.IsNotFoundError(err) {
+			return nil, microerror.Mask(errors.ClusterNotFoundError)
+		}
+		if clienterror.IsBadRequestError(err) {
+			return nil, microerror.Maskf(errors.BadRequestError, err.Error())
 		}
 
 		return r, microerror.Mask(err)

--- a/commands/create/nodepool/command.go
+++ b/commands/create/nodepool/command.go
@@ -183,6 +183,24 @@ func printValidation(cmd *cobra.Command, positionalArgs []string) {
 	}
 
 	errors.HandleCommonErrors(err)
+
+	headline := ""
+	subtext := ""
+
+	switch {
+	case errors.IsConflictingFlagsError(err):
+		headline = "Conflicting flags used"
+		subtext = "The flags --availability-zones and --num-availability-zones must not be used together."
+	default:
+		headline = err.Error()
+	}
+
+	// print output
+	fmt.Println(color.RedString(headline))
+	if subtext != "" {
+		fmt.Println(subtext)
+	}
+	os.Exit(1)
 }
 
 // createNodePool is the business function sending our creation request to the API

--- a/commands/create/nodepool/command.go
+++ b/commands/create/nodepool/command.go
@@ -324,7 +324,7 @@ func createNodePool(args Arguments) (*result, error) {
 }
 
 func printResult(cmd *cobra.Command, positionalArgs []string) {
-	var r result
+	var r *result
 
 	args, err := collectArguments(positionalArgs)
 	if err == nil {
@@ -349,6 +349,15 @@ func printResult(cmd *cobra.Command, positionalArgs []string) {
 		if subtext != "" {
 			fmt.Println(subtext)
 		}
+		os.Exit(1)
+	}
+
+	if r == nil {
+		// This is unlikely, but hey.
+		fmt.Println(color.RedString("No response returned"))
+		fmt.Println("The API call to create a node pooll apparently has been successful, however")
+		fmt.Println("no useful response has been returned. Please report this problem to the")
+		fmt.Println("Giant Swarm support team. Thank you!")
 		os.Exit(1)
 	}
 

--- a/commands/create/nodepool/command.go
+++ b/commands/create/nodepool/command.go
@@ -1,0 +1,153 @@
+// Package nodepool implements the "show nodepool" command.
+package nodepool
+
+import (
+	"github.com/giantswarm/gscliauth/config"
+	"github.com/giantswarm/gsctl/commands/errors"
+	"github.com/giantswarm/gsctl/flags"
+	"github.com/giantswarm/microerror"
+	"github.com/spf13/cobra"
+)
+
+var (
+	// Command is the cobra command for 'gsctl create nodepool'
+	Command = &cobra.Command{
+		Hidden:  false, // TODO: set to true before merging into master!
+		Use:     "nodepool <cluster-id>",
+		Aliases: []string{"np"},
+		// Args: cobra.ExactArgs(1) guarantees that cobra will fail if no positional argument is given.
+		Args:  cobra.ExactArgs(1),
+		Short: "Create a node pool",
+		Long: `Add a new node pool to a cluster.
+
+This command allows to create a new node pool within a cluster. Node pools
+are groups of wortker nodes sharing a common configuration. Create different
+node pools to serve workloads with different resource requirements, different
+availability zone spreading etc. Node pools are also scaled independently.
+
+Note that some attributes of node pools cannot be changed later. These are:
+
+- ID - will be generated on creation
+- Availability zone assignment
+- Instance type used
+
+When creating a node pool, all arguments (except for the cluster ID) are
+optional. Where an argument is not given, a default will be applied as
+follows:
+
+- Name: will be "Unnamed node pool <n>".
+- Availability zones: the node pool will use 1 zone selected randomly.
+- Instance type: the default instance type of the installation will be
+  used. Check 'gsctl info' to find out what that is.
+- Scaling settings: the minimum and maximum size will be set to 3,
+  meaning that autoscaling is disabled.
+
+Examples:
+
+  The simplest invocation creates a node pool with default attributes
+  in the cluster specified.
+
+    gsctl create nodepool f01r4
+
+  We recommend to set a descriptive name, to tell the node pool apart
+  from others.
+
+    gsctl create nodepool f01r4  --name "Batch jobs"
+
+  Assigning the node pool to availabilty zones can be done in several
+  ways. If you only want to ensure that several zones are used, specify
+  a number liker like this:
+
+    gsctl create nodepool f01r4 --num-availability-zones 2
+
+  To set one or several specific zones to use, give a list of zone names
+  or letters.
+
+    gsctl create nodepool f01r4 --availability-zones b,c,d
+
+  Here is how you specify the instance type to use:
+
+    gsctl create nodepool f01r4 --aws-instance-type m4.2xlarge
+
+  The initial node pool size is set by adjusting the lower and upper
+  size limit like this:
+
+    gsctl create nodepool f01r4 --nodes-min 3 --nodes-max 10
+`,
+
+		// PreRun checks a few general things, like authentication.
+		PreRun: printValidation,
+
+		// Run calls the business function and prints results and errors.
+		Run: printResult,
+	}
+
+	cmdAwsEc2InstanceType   string
+	cmdName                 string
+	cmdNumAvailabilityZones int
+	cmdAvailabilityZones    []string
+)
+
+const (
+	activityName = "create-nodepool"
+)
+
+func init() {
+	Command.Flags().StringVarP(&cmdName, "name", "n", "", "name or purpose description of the node pool")
+	Command.Flags().IntVarP(&cmdNumAvailabilityZones, "num-availability-zones", "", 0, "Number of availability zones to use. Default is 1.")
+	Command.Flags().StringSliceVarP(&cmdAvailabilityZones, "availability-zones", "", []string{}, "List of availability zones to use, instead of setting a number. Use comma to separate values.")
+	Command.Flags().StringVarP(&cmdAwsEc2InstanceType, "aws-instance-type", "", "", "EC2 instance type to use for workers, e. g. 'm5.2xlarge'")
+	// TODO: size min/max flags
+}
+
+type arguments struct {
+	apiEndpoint           string
+	authToken             string
+	availabilityZonesList []string
+	availabilityZonesNum  int
+	clusterID             string
+	instanceType          string
+	name                  string
+	scheme                string
+	verbose               bool
+}
+
+func defaultArguments(positionalArgs []string) arguments {
+	endpoint := config.Config.ChooseEndpoint(flags.CmdAPIEndpoint)
+	token := config.Config.ChooseToken(endpoint, flags.CmdToken)
+	scheme := config.Config.ChooseScheme(endpoint, flags.CmdToken)
+
+	return arguments{
+		apiEndpoint: endpoint,
+		authToken:   token,
+		scheme:      scheme,
+		clusterID:   positionalArgs[0],
+		verbose:     flags.CmdVerbose,
+		name:        cmdName,
+	}
+}
+
+func verifyPreconditions(args arguments, positionalArgs []string) error {
+	parsedArgs := defaultArguments(positionalArgs)
+	if config.Config.Token == "" && parsedArgs.authToken == "" {
+		return microerror.Mask(errors.NotLoggedInError)
+	}
+
+	if parsedArgs.clusterID == "" {
+		return microerror.Mask(errors.ClusterIDMissingError)
+	}
+
+	if len(parsedArgs.availabilityZonesList) > 0 && parsedArgs.availabilityZonesNum > 0 {
+		return microerror.Maskf(errors.ConflictingFlagsError, "the flags --availability-zones and --num-availability-zones cannot be combined.")
+	}
+
+	return nil
+}
+
+func printValidation(cmd *cobra.Command, positionalArgs []string) {
+
+}
+
+func printResult(cmd *cobra.Command, positionalArgs []string) {
+
+}

--- a/commands/create/nodepool/command.go
+++ b/commands/create/nodepool/command.go
@@ -208,7 +208,36 @@ func printValidation(cmd *cobra.Command, positionalArgs []string) {
 func createNodePool(args Arguments) (result, error) {
 	r := result{}
 
-	requestBody := &models.V5AddNodePoolRequest{}
+	requestBody := &models.V5AddNodePoolRequest{
+		Name: args.Name,
+	}
+	if args.InstanceType != "" {
+		requestBody.NodeSpec = &models.V5AddNodePoolRequestNodeSpec{
+			Aws: &models.V5AddNodePoolRequestNodeSpecAws{
+				InstanceType: args.InstanceType,
+			},
+		}
+	}
+	if args.AvailabilityZonesList != nil && len(args.AvailabilityZonesList) > 0 {
+		requestBody.AvailabilityZones = &models.V5AddNodePoolRequestAvailabilityZones{
+			Zones: args.AvailabilityZonesList,
+		}
+	} else if args.AvailabilityZonesNum != 0 {
+		requestBody.AvailabilityZones = &models.V5AddNodePoolRequestAvailabilityZones{
+			Number: int64(args.AvailabilityZonesNum),
+		}
+	}
+	if args.ScalingMin != 0 || args.ScalingMax != 0 {
+		requestBody.Scaling = &models.V5AddNodePoolRequestScaling{
+			Min: args.ScalingMin,
+			Max: args.ScalingMax,
+		}
+	}
+
+	if args.Verbose {
+		fmt.Println(color.WhiteString("Submitting node pool creation reqwuest with the following details:"))
+		fmt.Println(color.WhiteString("%+v\n", requestBody))
+	}
 
 	clientWrapper, err := client.NewWithConfig(args.APIEndpoint, args.AuthToken)
 	if err != nil {

--- a/commands/create/nodepool/command.go
+++ b/commands/create/nodepool/command.go
@@ -19,7 +19,7 @@ import (
 var (
 	// Command is the cobra command for 'gsctl create nodepool'
 	Command = &cobra.Command{
-		Hidden:  false, // TODO: set to true before merging into master!
+		Hidden:  false, // TODO: set to false to make this command visible once the release is out.
 		Use:     "nodepool <cluster-id>",
 		Aliases: []string{"np"},
 		// Args: cobra.ExactArgs(1) guarantees that cobra will fail if no positional argument is given.

--- a/commands/create/nodepool/command_test.go
+++ b/commands/create/nodepool/command_test.go
@@ -1,0 +1,1 @@
+package nodepool

--- a/commands/create/nodepool/command_test.go
+++ b/commands/create/nodepool/command_test.go
@@ -13,11 +13,6 @@ import (
 	"github.com/giantswarm/gsctl/testutils"
 )
 
-// TODO:
-// cases which should succeed:
-//   - setting only scaling min or only max should result in proper setting
-//   - set AZ list to letters like "A,B,C"
-
 // TestCollectArgs tests whether collectArguments produces the expected results.
 func TestCollectArgs(t *testing.T) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -118,6 +113,44 @@ func TestCollectArgs(t *testing.T) {
 				ClusterID:             "a-cluster-id",
 				Scheme:                "giantswarm",
 				AvailabilityZonesList: []string{"myzonea", "myzoneb", "myzonec"},
+			},
+		},
+		// Only setting the --nodes-min, but not --nodes-max flag.
+		{
+			[]string{"another-cluster-id"},
+			func() {
+				initFlags()
+				Command.ParseFlags([]string{
+					"another-cluster-id",
+					"--nodes-min=5",
+				})
+			},
+			Arguments{
+				APIEndpoint: mockServer.URL,
+				AuthToken:   "some-token",
+				ClusterID:   "another-cluster-id",
+				ScalingMax:  5,
+				ScalingMin:  5,
+				Scheme:      "giantswarm",
+			},
+		},
+		// Only setting the --nodes-max, but not --nodes-min flag.
+		{
+			[]string{"another-cluster-id"},
+			func() {
+				initFlags()
+				Command.ParseFlags([]string{
+					"another-cluster-id",
+					"--nodes-max=5",
+				})
+			},
+			Arguments{
+				APIEndpoint: mockServer.URL,
+				AuthToken:   "some-token",
+				ClusterID:   "another-cluster-id",
+				ScalingMax:  5,
+				ScalingMin:  5,
+				Scheme:      "giantswarm",
 			},
 		},
 	}

--- a/commands/create/nodepool/command_test.go
+++ b/commands/create/nodepool/command_test.go
@@ -15,10 +15,9 @@ import (
 
 // TODO:
 // cases which should succeed:
-//   - minimal creation
 //   - setting only scaling min or only max should result in proper setting
 
-// TestCollectArgs tests the collectArguments function.
+// TestCollectArgs tests whether collectArguments produces the expected results.
 func TestCollectArgs(t *testing.T) {
 	var testCases = []struct {
 		// The positional arguments we pass.
@@ -97,6 +96,7 @@ func TestSuccess(t *testing.T) {
 		args         Arguments
 		responseBody string
 	}{
+		// Minimal node pool creation.
 		{
 			Arguments{
 				ClusterID: "cluster-id",

--- a/commands/create/nodepool/command_test.go
+++ b/commands/create/nodepool/command_test.go
@@ -112,6 +112,48 @@ func TestSuccess(t *testing.T) {
 				"subnet": "10.1.0.0/24"
 			}`,
 		},
+		// Creation with availability zones list.
+		{
+			Arguments{
+				ClusterID:             "cluster-id",
+				AuthToken:             "token",
+				Name:                  "my node pool",
+				ScalingMin:            4,
+				ScalingMax:            10,
+				InstanceType:          "my-big-type",
+				AvailabilityZonesList: []string{"my-region-1a", "my-region-1c"},
+			},
+			`{
+				"id": "m0ckr",
+				"name": "my node pool",
+				"availability_zones": ["my-region-1a", "my-region-1c"],
+				"scaling": {"min": 4, "max": 10},
+				"node_spec": {"aws": {"instance_type": "my-big-type"}, "volume_sizes_gb": {"docker": 100, "kubelet": 100}},
+				"status": {"nodes": 0, "nodes_ready": 0},
+				"subnet": "10.1.0.0/24"
+			}`,
+		},
+		// Creation with availability zones number.
+		{
+			Arguments{
+				ClusterID:            "cluster-id",
+				AuthToken:            "token",
+				Name:                 "my node pool",
+				ScalingMin:           2,
+				ScalingMax:           50,
+				InstanceType:         "my-big-type",
+				AvailabilityZonesNum: 3,
+			},
+			`{
+				"id": "m0ckr",
+				"name": "my node pool",
+				"availability_zones": ["my-region-1a", "my-region-1b", "my-region-1c"],
+				"scaling": {"min": 4, "max": 10},
+				"node_spec": {"aws": {"instance_type": "my-big-type"}, "volume_sizes_gb": {"docker": 100, "kubelet": 100}},
+				"status": {"nodes": 0, "nodes_ready": 0},
+				"subnet": "10.1.0.0/24"
+			}`,
+		},
 	}
 
 	fs := afero.NewMemMapFs()

--- a/commands/create/nodepool/command_test.go
+++ b/commands/create/nodepool/command_test.go
@@ -1,1 +1,216 @@
 package nodepool
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/spf13/afero"
+
+	"github.com/giantswarm/gsctl/commands/errors"
+	"github.com/giantswarm/gsctl/testutils"
+)
+
+// TODO:
+// cases which should succeed:
+//   - minimal creation
+//   - setting only scaling min or only max should result in proper setting
+
+// TestCollectArgs tests the collectArguments function.
+func TestCollectArgs(t *testing.T) {
+	var testCases = []struct {
+		// The positional arguments we pass.
+		positionalArguments []string
+		// How we execute the command.
+		commandExecution func()
+		// What we expect as arguments.
+		resultingArgs Arguments
+	}{
+		{
+			[]string{"cluster-id"},
+			func() {
+				Command.ParseFlags([]string{"cluster-id", "--name", "my-name"})
+			},
+			Arguments{
+				APIEndpoint: "https://endpoint",
+				AuthToken:   "some-token",
+				ClusterID:   "cluster-id",
+				Name:        "my-name",
+				Scheme:      "giantswarm",
+			},
+		},
+		{
+			[]string{"cluster-id"},
+			func() {
+				Command.ParseFlags([]string{
+					"cluster-id",
+					"--num-availability-zones=3",
+					"--aws-instance-type=instance-type",
+					"--nodes-min=5",
+					"--nodes-max=10",
+				})
+			},
+			Arguments{
+				APIEndpoint:          "https://endpoint",
+				AuthToken:            "some-token",
+				ClusterID:            "cluster-id",
+				Name:                 "my-name",
+				Scheme:               "giantswarm",
+				AvailabilityZonesNum: 3,
+				InstanceType:         "instance-type",
+				ScalingMin:           5,
+				ScalingMax:           10,
+			},
+		},
+	}
+
+	yamlText := `last_version_check: 0001-01-01T00:00:00Z
+updated: 2017-09-29T11:23:15+02:00
+endpoints:
+  https://endpoint:
+    email: email@example.com
+    token: some-token
+selected_endpoint: https://endpoint`
+
+	fs := afero.NewMemMapFs()
+	_, err := testutils.TempConfig(fs, yamlText)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			tc.commandExecution()
+			args := collectArguments(tc.positionalArguments)
+			if diff := cmp.Diff(tc.resultingArgs, args); diff != "" {
+				t.Errorf("Case %d - Resulting args unequal. (-expected +got):\n%s", i, diff)
+			}
+		})
+	}
+}
+
+// TestSuccess tests node pool creation with cases that are expected to succeed.
+func TestSuccess(t *testing.T) {
+	var testCases = []struct {
+		args         Arguments
+		responseBody string
+	}{
+		{
+			Arguments{
+				ClusterID: "cluster-id",
+				AuthToken: "token",
+			},
+			`{
+				"id": "m0ckr",
+				"name": "Unnamed node pool 1",
+				"availability_zones": ["eu-central-1a"],
+				"scaling": {"min": 3, "max": 3},
+				"node_spec": {"aws": {"instance_type": "m5.large"}, "volume_sizes_gb": {"docker": 100, "kubelet": 100}},
+				"status": {"nodes": 0, "nodes_ready": 0},
+				"subnet": "10.1.0.0/24"
+			}`,
+		},
+	}
+
+	fs := afero.NewMemMapFs()
+	_, err := testutils.TempConfig(fs, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			// ste up mock server
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if r.Method == "POST" {
+					switch uri := r.URL.Path; uri {
+					case "/v5/clusters/cluster-id/nodepools/":
+						w.WriteHeader(http.StatusCreated)
+						w.Write([]byte(tc.responseBody))
+					default:
+						t.Errorf("Unsupported route %s called in mock server", r.URL.Path)
+						w.WriteHeader(http.StatusNotFound)
+						w.Write([]byte(`{"code": "RESOURCE_NOT_FOUND", "message": "Status for this cluster is not yet available."}`))
+					}
+				}
+			}))
+			defer mockServer.Close()
+
+			tc.args.APIEndpoint = mockServer.URL
+
+			err := verifyPreconditions(tc.args)
+			if err != nil {
+				t.Fatalf("Case %d - Unxpected error '%s'", i, err)
+			}
+
+			r, err := createNodePool(tc.args)
+			if err != nil {
+				t.Fatalf("Case %d - Unxpected error '%s'", i, err)
+			}
+
+			if r.nodePoolID != "m0ckr" {
+				t.Errorf("Case %d - Expected ID %q, got %q", i, "m0ckr", r.nodePoolID)
+			}
+		})
+	}
+}
+
+// TestVerifyPreconditions tests cases where validating preconditions fails.
+func TestVerifyPreconditions(t *testing.T) {
+	var testCases = []struct {
+		args         Arguments
+		errorMatcher func(error) bool
+	}{
+		// Cluster ID is missing.
+		{
+			Arguments{
+				AuthToken:   "token",
+				APIEndpoint: "https://mock-url",
+				ClusterID:   "",
+			},
+			errors.IsClusterIDMissingError,
+		},
+		// Availability zones flags are conflicting.
+		{
+			Arguments{
+				AuthToken:             "token",
+				APIEndpoint:           "https://mock-url",
+				AvailabilityZonesList: []string{"fooa", "foob"},
+				AvailabilityZonesNum:  3,
+				ClusterID:             "cluster-id",
+			},
+			errors.IsConflictingFlagsError,
+		},
+		// Scaling min and max are not plausible.
+		{
+			Arguments{
+				AuthToken:   "token",
+				APIEndpoint: "https://mock-url",
+				ClusterID:   "cluster-id",
+				ScalingMax:  3,
+				ScalingMin:  5,
+			},
+			errors.IsWorkersMinMaxInvalid,
+		},
+	}
+
+	fs := afero.NewMemMapFs()
+	_, err := testutils.TempConfig(fs, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			err := verifyPreconditions(tc.args)
+			if err == nil {
+				t.Errorf("Case %d - Expected error, got nil", i)
+			} else if !tc.errorMatcher(err) {
+				t.Errorf("Case %d - Error did not match expectec type. Got '%s'", i, err)
+			}
+		})
+	}
+}

--- a/commands/login/command_test.go
+++ b/commands/login/command_test.go
@@ -18,7 +18,8 @@ import (
 var regularInfoResponse = []byte(`{
 	"general": {
 		"installation_name": "codename",
-		"provider": "aws"
+		"provider": "aws",
+		"datacenter": "eu-central-foo"
 	},
 	"workers": {
 		"count_per_cluster": {

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -53,9 +53,12 @@ var (
 	// CmdWorkerStorageSizeGB represents the local storage per worker node in GB per worker as required via flag.
 	CmdWorkerStorageSizeGB float32
 
-	// CmdWorkersMin is the minimum number of workers created for the cluster.
+	// CmdWorkersMin is the minimum number of workers created for the cluster or node pool.
 	CmdWorkersMin int64
 
-	// CmdWorkersMax is the minimum number of workers created for the cluster.
+	// CmdWorkersMax is the minimum number of workers created for the cluster or node pool.
 	CmdWorkersMax int64
+
+	// CmdWorkerAwsEc2InstanceType is the instance type name for nodes in AWS.
+	CmdWorkerAwsEc2InstanceType string
 )


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6447

This PR adds the `gsctl create nodepool` command.

### Preview

```
Add a new node pool to a cluster.

This command allows to create a new node pool within a cluster. Node pools
are groups of wortker nodes sharing a common configuration. Create different
node pools to serve workloads with different resource requirements, different
availability zone spreading etc. Node pools are also scaled independently.

Note that some attributes of node pools cannot be changed later. These are:

- ID - will be generated on creation
- Availability zone assignment
- Instance type used

When creating a node pool, all arguments (except for the cluster ID) are
optional. Where an argument is not given, a default will be applied as
follows:

- Name: will be "Unnamed node pool <n>".
- Availability zones: the node pool will use 1 zone selected randomly.
- Instance type: the default instance type of the installation will be
  used. Check 'gsctl info' to find out what that is.
- Scaling settings: the minimum and maximum size will be set to 3,
  meaning that autoscaling is disabled.

Examples:

  The simplest invocation creates a node pool with default attributes
  in the cluster specified.

    gsctl create nodepool f01r4

  We recommend to set a descriptive name, to tell the node pool apart
  from others.

    gsctl create nodepool f01r4  --name "Batch jobs"

  Assigning the node pool to availabilty zones can be done in several
  ways. If you only want to ensure that several zones are used, specify
  a number liker like this:

    gsctl create nodepool f01r4 --num-availability-zones 2

  To set one or several specific zones to use, give a list of zone names
  or letters.

    gsctl create nodepool f01r4 --availability-zones b,c,d

  Here is how you specify the instance type to use:

    gsctl create nodepool f01r4 --aws-instance-type m4.2xlarge

  The initial node pool size is set by adjusting the lower and upper
  size limit like this:

    gsctl create nodepool f01r4 --nodes-min 3 --nodes-max 10

Usage:
  gsctl create nodepool <cluster-id> [flags]

Aliases:
  nodepool, np

Flags:
      --availability-zones strings   List of availability zones to use, instead of setting a number. Use comma to separate values.
      --aws-instance-type string     EC2 instance type to use for workers, e. g. 'm5.2xlarge'
  -h, --help                         help for nodepool
  -n, --name string                  name or purpose description of the node pool
      --nodes-max int                Maximum number of worker nodes for the node pool.
      --nodes-min int                Minimum number of worker nodes for the node pool.
      --num-availability-zones int   Number of availability zones to use. Default is 1.

Global Flags:
      --auth-token string   Authorization token to use
      --config-dir string   Configuration directory path to use (default "/Users/marian/.config/gsctl")
  -e, --endpoint string     The API endpoint to use
  -v, --verbose             Print more information
```