### PR TITLE
Remove v2 naming quirks in client package

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -62,8 +62,8 @@ type Configuration struct {
 	ActivityName string
 }
 
-// WrapperV2 is the structure holding representing our latest API client.
-type WrapperV2 struct {
+// Wrapper is the structure holding representing our latest API client.
+type Wrapper struct {
 	// conf is the Configuration used when creating this.
 	conf *Configuration
 
@@ -122,7 +122,7 @@ func NewV2(conf *Configuration) (*WrapperV2, error) {
 		Timeout:   conf.Timeout,
 	}
 
-	return &WrapperV2{
+	return &Wrapper{
 		conf:        conf,
 		gsclient:    gsclient.New(transport, strfmt.Default),
 		requestID:   randomRequestID(),
@@ -133,7 +133,7 @@ func NewV2(conf *Configuration) (*WrapperV2, error) {
 
 // NewWithConfig creates a new client wrapper for a certain endpoint, optionally
 // using a certain auth token.
-func NewWithConfig(endpointString, token string) (*WrapperV2, error) {
+func NewWithConfig(endpointString, token string) (*Wrapper, error) {
 	endpoint := config.Config.ChooseEndpoint(endpointString)
 	ClientConfig := &Configuration{
 		AuthHeaderGetter: config.Config.AuthHeaderGetter(endpoint, token),
@@ -215,7 +215,7 @@ type AuxiliaryParams struct {
 
 // DefaultAuxiliaryParams returns a partially pre-populated AuxiliaryParams
 // object.
-func (w *WrapperV2) DefaultAuxiliaryParams() *AuxiliaryParams {
+func (w *Wrapper) DefaultAuxiliaryParams() *AuxiliaryParams {
 	return &AuxiliaryParams{
 		CommandLine: getCommandLine(),
 		RequestID:   randomRequestID(),
@@ -242,7 +242,7 @@ type paramSetterWithAuthorization interface {
 // setParams takes parameters from an AuxiliaryParams input, and from the
 // client wrapper (or rather it's config) and sets request parameters
 // accordingly, independent of type.
-func setParams(p *AuxiliaryParams, w *WrapperV2, params paramSetter) {
+func setParams(p *AuxiliaryParams, w *Wrapper, params paramSetter) {
 	// first take client-level config params
 	if w != nil && w.conf != nil {
 		if w.conf.Timeout > 0 {
@@ -278,7 +278,7 @@ func setParams(p *AuxiliaryParams, w *WrapperV2, params paramSetter) {
 
 // setParamsWithAuthorization does the same as setParams, but also sets
 // an Autorization header if configured.
-func setParamsWithAuthorization(p *AuxiliaryParams, w *WrapperV2, params paramSetterWithAuthorization) error {
+func setParamsWithAuthorization(p *AuxiliaryParams, w *Wrapper, params paramSetterWithAuthorization) error {
 	if w != nil && w.conf != nil {
 		authHeader, err := w.conf.AuthHeaderGetter()
 		if err != nil {
@@ -296,7 +296,7 @@ func setParamsWithAuthorization(p *AuxiliaryParams, w *WrapperV2, params paramSe
 }
 
 // CreateAuthToken creates an auth token using the V2 client.
-func (w *WrapperV2) CreateAuthToken(email, password string, p *AuxiliaryParams) (*auth_tokens.CreateAuthTokenOK, error) {
+func (w *Wrapper) CreateAuthToken(email, password string, p *AuxiliaryParams) (*auth_tokens.CreateAuthTokenOK, error) {
 	params := auth_tokens.NewCreateAuthTokenParams().WithBody(&models.V4CreateAuthTokenRequest{
 		Email:          email,
 		PasswordBase64: base64.StdEncoding.EncodeToString([]byte(password)),
@@ -312,7 +312,7 @@ func (w *WrapperV2) CreateAuthToken(email, password string, p *AuxiliaryParams) 
 }
 
 // DeleteAuthToken calls the API's deleteAuthToken operation using the V2 client.
-func (w *WrapperV2) DeleteAuthToken(authToken string, p *AuxiliaryParams) (*auth_tokens.DeleteAuthTokenOK, error) {
+func (w *Wrapper) DeleteAuthToken(authToken string, p *AuxiliaryParams) (*auth_tokens.DeleteAuthTokenOK, error) {
 	params := auth_tokens.NewDeleteAuthTokenParams().WithAuthorization("giantswarm " + authToken)
 	setParams(p, w, params)
 
@@ -325,7 +325,7 @@ func (w *WrapperV2) DeleteAuthToken(authToken string, p *AuxiliaryParams) (*auth
 }
 
 // CreateCluster creates cluster using the V2 client.
-func (w *WrapperV2) CreateCluster(addClusterRequest *models.V4AddClusterRequest, p *AuxiliaryParams) (*clusters.AddClusterCreated, error) {
+func (w *Wrapper) CreateCluster(addClusterRequest *models.V4AddClusterRequest, p *AuxiliaryParams) (*clusters.AddClusterCreated, error) {
 	params := clusters.NewAddClusterParams().WithBody(addClusterRequest)
 	err := setParamsWithAuthorization(p, w, params)
 	if err != nil {
@@ -341,7 +341,7 @@ func (w *WrapperV2) CreateCluster(addClusterRequest *models.V4AddClusterRequest,
 }
 
 // ModifyCluster modifies a cluster using the V2 client.
-func (w *WrapperV2) ModifyCluster(clusterID string, body *models.V4ModifyClusterRequest, p *AuxiliaryParams) (*clusters.ModifyClusterOK, error) {
+func (w *Wrapper) ModifyCluster(clusterID string, body *models.V4ModifyClusterRequest, p *AuxiliaryParams) (*clusters.ModifyClusterOK, error) {
 	params := clusters.NewModifyClusterParams().WithClusterID(clusterID).WithBody(body)
 	err := setParamsWithAuthorization(p, w, params)
 	if err != nil {
@@ -357,7 +357,7 @@ func (w *WrapperV2) ModifyCluster(clusterID string, body *models.V4ModifyCluster
 }
 
 // DeleteCluster deletes a cluster using the V2 client.
-func (w *WrapperV2) DeleteCluster(clusterID string, p *AuxiliaryParams) (*clusters.DeleteClusterAccepted, error) {
+func (w *Wrapper) DeleteCluster(clusterID string, p *AuxiliaryParams) (*clusters.DeleteClusterAccepted, error) {
 	params := clusters.NewDeleteClusterParams().WithClusterID(clusterID)
 	err := setParamsWithAuthorization(p, w, params)
 	if err != nil {
@@ -373,7 +373,7 @@ func (w *WrapperV2) DeleteCluster(clusterID string, p *AuxiliaryParams) (*cluste
 }
 
 // GetClusters fetches a list of clusters using the V2 client.
-func (w *WrapperV2) GetClusters(p *AuxiliaryParams) (*clusters.GetClustersOK, error) {
+func (w *Wrapper) GetClusters(p *AuxiliaryParams) (*clusters.GetClustersOK, error) {
 	params := clusters.NewGetClustersParams()
 	err := setParamsWithAuthorization(p, w, params)
 	if err != nil {
@@ -389,7 +389,7 @@ func (w *WrapperV2) GetClusters(p *AuxiliaryParams) (*clusters.GetClustersOK, er
 }
 
 // GetClusterV4 fetches details on a V4 cluster.
-func (w *WrapperV2) GetClusterV4(clusterID string, p *AuxiliaryParams) (*clusters.GetClusterOK, error) {
+func (w *Wrapper) GetClusterV4(clusterID string, p *AuxiliaryParams) (*clusters.GetClusterOK, error) {
 	params := clusters.NewGetClusterParams().WithClusterID(clusterID)
 	err := setParamsWithAuthorization(p, w, params)
 	if err != nil {
@@ -405,7 +405,7 @@ func (w *WrapperV2) GetClusterV4(clusterID string, p *AuxiliaryParams) (*cluster
 }
 
 // GetClusterV5 fetches details on a V5 cluster.
-func (w *WrapperV2) GetClusterV5(clusterID string, p *AuxiliaryParams) (*clusters.GetClusterV5OK, error) {
+func (w *Wrapper) GetClusterV5(clusterID string, p *AuxiliaryParams) (*clusters.GetClusterV5OK, error) {
 	params := clusters.NewGetClusterV5Params().WithClusterID(clusterID)
 	err := setParamsWithAuthorization(p, w, params)
 	if err != nil {
@@ -421,7 +421,7 @@ func (w *WrapperV2) GetClusterV5(clusterID string, p *AuxiliaryParams) (*cluster
 }
 
 // GetNodePool fetches a node pool.
-func (w *WrapperV2) GetNodePool(clusterID, nodePoolID string, p *AuxiliaryParams) (*nodepools.GetNodePoolOK, error) {
+func (w *Wrapper) GetNodePool(clusterID, nodePoolID string, p *AuxiliaryParams) (*nodepools.GetNodePoolOK, error) {
 	params := nodepools.NewGetNodePoolParams().WithClusterID(clusterID).WithNodepoolID(nodePoolID)
 	err := setParamsWithAuthorization(p, w, params)
 	if err != nil {
@@ -437,7 +437,7 @@ func (w *WrapperV2) GetNodePool(clusterID, nodePoolID string, p *AuxiliaryParams
 }
 
 // GetNodePools fetches a list of node pools.
-func (w *WrapperV2) GetNodePools(clusterID string, p *AuxiliaryParams) (*nodepools.GetNodePoolsOK, error) {
+func (w *Wrapper) GetNodePools(clusterID string, p *AuxiliaryParams) (*nodepools.GetNodePoolsOK, error) {
 	params := nodepools.NewGetNodePoolsParams().WithClusterID(clusterID)
 	err := setParamsWithAuthorization(p, w, params)
 	if err != nil {
@@ -454,7 +454,7 @@ func (w *WrapperV2) GetNodePools(clusterID string, p *AuxiliaryParams) (*nodepoo
 
 // GetDefaultCluster determines which is the default cluster.
 // If only one cluster exists, the default cluster is the only cluster.
-func (w *WrapperV2) GetDefaultCluster(p *AuxiliaryParams) (string, error) {
+func (w *Wrapper) GetDefaultCluster(p *AuxiliaryParams) (string, error) {
 	params := clusters.NewGetClustersParams()
 	err := setParamsWithAuthorization(p, w, params)
 	if err != nil {
@@ -474,7 +474,7 @@ func (w *WrapperV2) GetDefaultCluster(p *AuxiliaryParams) (string, error) {
 }
 
 // CreateKeyPair calls the addKeyPair API operation using the V2 client.
-func (w *WrapperV2) CreateKeyPair(clusterID string, addKeyPairRequest *models.V4AddKeyPairRequest, p *AuxiliaryParams) (*key_pairs.AddKeyPairOK, error) {
+func (w *Wrapper) CreateKeyPair(clusterID string, addKeyPairRequest *models.V4AddKeyPairRequest, p *AuxiliaryParams) (*key_pairs.AddKeyPairOK, error) {
 	params := key_pairs.NewAddKeyPairParams().WithClusterID(clusterID).WithBody(addKeyPairRequest)
 	err := setParamsWithAuthorization(p, w, params)
 	if err != nil {
@@ -490,7 +490,7 @@ func (w *WrapperV2) CreateKeyPair(clusterID string, addKeyPairRequest *models.V4
 }
 
 // GetKeyPairs calls the API to fetch key pairs using the V2 client.
-func (w *WrapperV2) GetKeyPairs(clusterID string, p *AuxiliaryParams) (*key_pairs.GetKeyPairsOK, error) {
+func (w *Wrapper) GetKeyPairs(clusterID string, p *AuxiliaryParams) (*key_pairs.GetKeyPairsOK, error) {
 	params := key_pairs.NewGetKeyPairsParams().WithClusterID(clusterID)
 	err := setParamsWithAuthorization(p, w, params)
 	if err != nil {
@@ -506,7 +506,7 @@ func (w *WrapperV2) GetKeyPairs(clusterID string, p *AuxiliaryParams) (*key_pair
 }
 
 // GetInfo calls the API's getInfo operation using the V2 client.
-func (w *WrapperV2) GetInfo(p *AuxiliaryParams) (*info.GetInfoOK, error) {
+func (w *Wrapper) GetInfo(p *AuxiliaryParams) (*info.GetInfoOK, error) {
 	params := info.NewGetInfoParams()
 	err := setParamsWithAuthorization(p, w, params)
 	if err != nil {
@@ -522,7 +522,7 @@ func (w *WrapperV2) GetInfo(p *AuxiliaryParams) (*info.GetInfoOK, error) {
 }
 
 // GetReleases calls the API's getReleases operation using the V2 client.
-func (w *WrapperV2) GetReleases(p *AuxiliaryParams) (*releases.GetReleasesOK, error) {
+func (w *Wrapper) GetReleases(p *AuxiliaryParams) (*releases.GetReleasesOK, error) {
 	params := releases.NewGetReleasesParams()
 	err := setParamsWithAuthorization(p, w, params)
 	if err != nil {
@@ -538,7 +538,7 @@ func (w *WrapperV2) GetReleases(p *AuxiliaryParams) (*releases.GetReleasesOK, er
 }
 
 // GetOrganizations calls the API's getOrganizations operation using the new client.
-func (w *WrapperV2) GetOrganizations(p *AuxiliaryParams) (*organizations.GetOrganizationsOK, error) {
+func (w *Wrapper) GetOrganizations(p *AuxiliaryParams) (*organizations.GetOrganizationsOK, error) {
 	params := organizations.NewGetOrganizationsParams()
 	err := setParamsWithAuthorization(p, w, params)
 	if err != nil {
@@ -554,7 +554,7 @@ func (w *WrapperV2) GetOrganizations(p *AuxiliaryParams) (*organizations.GetOrga
 }
 
 // GetCredential calls the API's getCredential operation using the V2 client.
-func (w *WrapperV2) GetCredential(organizationID string, credentialID string, p *AuxiliaryParams) (*organizations.GetCredentialOK, error) {
+func (w *Wrapper) GetCredential(organizationID string, credentialID string, p *AuxiliaryParams) (*organizations.GetCredentialOK, error) {
 	params := organizations.NewGetCredentialParams().WithOrganizationID(organizationID).WithCredentialID(credentialID)
 	err := setParamsWithAuthorization(p, w, params)
 	if err != nil {
@@ -570,7 +570,7 @@ func (w *WrapperV2) GetCredential(organizationID string, credentialID string, p 
 }
 
 // SetCredentials calls the API's addCredentials operation of an organization.
-func (w *WrapperV2) SetCredentials(organizationID string, addCredentialsRequest *models.V4AddCredentialsRequest, p *AuxiliaryParams) (*organizations.AddCredentialsCreated, error) {
+func (w *Wrapper) SetCredentials(organizationID string, addCredentialsRequest *models.V4AddCredentialsRequest, p *AuxiliaryParams) (*organizations.AddCredentialsCreated, error) {
 	params := organizations.NewAddCredentialsParams().WithOrganizationID(organizationID).WithBody(addCredentialsRequest)
 	err := setParamsWithAuthorization(p, w, params)
 	if err != nil {
@@ -586,7 +586,7 @@ func (w *WrapperV2) SetCredentials(organizationID string, addCredentialsRequest 
 }
 
 // GetClusterStatus fetches details on a cluster using the V2 client.
-func (w *WrapperV2) GetClusterStatus(clusterID string, p *AuxiliaryParams) (*ClusterStatus, error) {
+func (w *Wrapper) GetClusterStatus(clusterID string, p *AuxiliaryParams) (*ClusterStatus, error) {
 	params := clusters.NewGetClusterStatusParams().WithClusterID(clusterID)
 	err := setParamsWithAuthorization(p, w, params)
 	if err != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -87,8 +87,8 @@ type ClusterStatus struct {
 	Cluster *v1alpha1.StatusCluster `json:"cluster,omitempty"`
 }
 
-// NewV2 creates a client based on the latest gsclientgen version.
-func NewV2(conf *Configuration) (*WrapperV2, error) {
+// New creates a client based on the latest gsclientgen version.
+func New(conf *Configuration) (*Wrapper, error) {
 	if conf.AuthHeaderGetter == nil {
 		conf.AuthHeaderGetter = func() (string, error) { return "", nil }
 	}
@@ -142,7 +142,7 @@ func NewWithConfig(endpointString, token string) (*Wrapper, error) {
 		UserAgent:        config.UserAgent(),
 	}
 
-	return NewV2(ClientConfig)
+	return New(ClientConfig)
 }
 
 type roundTripperWithUserAgent struct {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -51,7 +51,7 @@ func TestV2NoConnection(t *testing.T) {
 		Endpoint: "http://127.0.0.1:55555",
 	}
 
-	gsClient, err := NewV2(config)
+	gsClient, err := New(config)
 	if err != nil {
 		t.Error(err)
 	}
@@ -94,7 +94,7 @@ func TestV2HostnameUnresolvable(t *testing.T) { // Our test server.
 		Endpoint: "http://non.existing.host.name",
 	}
 
-	gsClient, err := NewV2(config)
+	gsClient, err := New(config)
 	if err != nil {
 		t.Error(err)
 	}
@@ -142,7 +142,7 @@ func TestV2Timeout(t *testing.T) {
 		Endpoint: ts.URL,
 		Timeout:  500 * time.Millisecond,
 	}
-	gsClient, err := NewV2(clientConfig)
+	gsClient, err := New(clientConfig)
 	if err != nil {
 		t.Error(err)
 	}
@@ -182,7 +182,7 @@ func TestV2UserAgent(t *testing.T) {
 
 	clientConfig.Endpoint = ts.URL
 
-	gsClient, err := NewV2(clientConfig)
+	gsClient, err := New(clientConfig)
 	if err != nil {
 		t.Error(err)
 	}
@@ -201,7 +201,7 @@ func TestV2Forbidden(t *testing.T) { // Our test server.
 	}))
 	defer ts.Close()
 
-	gsClient, err := NewV2(&Configuration{Endpoint: ts.URL})
+	gsClient, err := New(&Configuration{Endpoint: ts.URL})
 	if err != nil {
 		t.Error(err)
 	}
@@ -234,7 +234,7 @@ func TestV2Unauthorized(t *testing.T) { // Our test server.
 	}))
 	defer ts.Close()
 
-	gsClient, err := NewV2(&Configuration{Endpoint: ts.URL})
+	gsClient, err := New(&Configuration{Endpoint: ts.URL})
 	if err != nil {
 		t.Error(err)
 	}
@@ -281,7 +281,7 @@ func TestV2AuxiliaryParams(t *testing.T) { // Our test server.
 		Endpoint: ts.URL,
 	}
 
-	gsClient, err := NewV2(config)
+	gsClient, err := New(config)
 	if err != nil {
 		t.Error(err)
 	}
@@ -308,7 +308,7 @@ func TestV2CreateAuthToken(t *testing.T) { // Our test server.
 		Endpoint: ts.URL,
 	}
 
-	gsClient, err := NewV2(config)
+	gsClient, err := New(config)
 	if err != nil {
 		t.Error(err)
 	}
@@ -340,7 +340,7 @@ func TestV2DeleteAuthToken(t *testing.T) { // Our test server.
 		Endpoint: ts.URL,
 	}
 
-	gsClient, err := NewV2(config)
+	gsClient, err := New(config)
 	if err != nil {
 		t.Error(err)
 	}
@@ -396,7 +396,7 @@ func TestGetClusterStatus(t *testing.T) {
 		Endpoint: ts.URL,
 	}
 
-	gsClient, err := NewV2(config)
+	gsClient, err := New(config)
 	if err != nil {
 		t.Error(err)
 	}
@@ -427,7 +427,7 @@ func TestGetClusterStatusEmpty(t *testing.T) {
 		Endpoint: ts.URL,
 	}
 
-	gsClient, err := NewV2(config)
+	gsClient, err := New(config)
 	if err != nil {
 		t.Error(err)
 	}
@@ -497,7 +497,7 @@ func TestMalformedResponse(t *testing.T) {
 		Endpoint: mockServer.URL,
 	}
 
-	gsClient, err := NewV2(config)
+	gsClient, err := New(config)
 	if err != nil {
 		t.Error(err)
 	}

--- a/commands/login/command.go
+++ b/commands/login/command.go
@@ -265,7 +265,7 @@ func getInstallationInfo(apiEndpoint string, scheme string, accessToken string) 
 		UserAgent:        config.UserAgent(),
 		AuthHeaderGetter: authHeaderGetter,
 	}
-	clientV2, err := client.NewV2(clientConfig)
+	clientV2, err := client.New(clientConfig)
 	if err != nil {
 		return nil, microerror.Maskf(errors.CouldNotCreateClientError, err.Error())
 	}


### PR DESCRIPTION
This PR removes an outdated naming suffix "V2" stemming from a time where we had two different clients and V2 marked the new one.