### PR TITLE
Rename clientV2 variables to clientWrapper

### DIFF
--- a/commands/create/cluster/command.go
+++ b/commands/create/cluster/command.go
@@ -537,15 +537,15 @@ func addCluster(args arguments) (creationResult, error) {
 	if !args.dryRun {
 		fmt.Printf("Requesting new cluster for organization '%s'\n", color.CyanString(result.definition.Owner))
 
-		clientV2, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
+		clientWrapper, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
 		if err != nil {
 			return result, microerror.Mask(err)
 		}
 
-		auxParams := clientV2.DefaultAuxiliaryParams()
+		auxParams := clientWrapper.DefaultAuxiliaryParams()
 		auxParams.ActivityName = createClusterActivityName
 		// perform API call
-		response, err := clientV2.CreateCluster(addClusterBody, auxParams)
+		response, err := clientWrapper.CreateCluster(addClusterBody, auxParams)
 		if err != nil {
 			return result, microerror.Mask(err)
 		}

--- a/commands/create/keypair/command.go
+++ b/commands/create/keypair/command.go
@@ -231,15 +231,15 @@ func createKeypair(args commandArguments) (createKeypairResult, error) {
 		CertificateOrganizations: args.certificateOrganizations,
 	}
 
-	clientV2, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
+	clientWrapper, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
 	if err != nil {
 		return result, microerror.Mask(err)
 	}
 
-	auxParams := clientV2.DefaultAuxiliaryParams()
+	auxParams := clientWrapper.DefaultAuxiliaryParams()
 	auxParams.ActivityName = activityName
 
-	response, err := clientV2.CreateKeyPair(args.clusterID, addKeyPairBody, auxParams)
+	response, err := clientWrapper.CreateKeyPair(args.clusterID, addKeyPairBody, auxParams)
 	if err != nil {
 		// create specific error types for cases we care about
 		if clientErr, ok := err.(*clienterror.APIError); ok {

--- a/commands/create/kubeconfig/command.go
+++ b/commands/create/kubeconfig/command.go
@@ -349,16 +349,16 @@ func createKubeconfigRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 func createKubeconfig(ctx context.Context, args createKubeconfigArguments) (createKubeconfigResult, error) {
 	result := createKubeconfigResult{}
 
-	clientV2, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
+	clientWrapper, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
 	if err != nil {
 		return result, microerror.Mask(err)
 	}
 
-	auxParams := clientV2.DefaultAuxiliaryParams()
+	auxParams := clientWrapper.DefaultAuxiliaryParams()
 	auxParams.ActivityName = createKubeconfigActivityName
 
 	// get cluster details
-	clusterDetailsResponse, err := clientV2.GetClusterV4(args.clusterID, auxParams)
+	clusterDetailsResponse, err := clientWrapper.GetClusterV4(args.clusterID, auxParams)
 	if err != nil {
 		if clientErr, ok := err.(*clienterror.APIError); ok {
 			return result, microerror.Maskf(clientErr,
@@ -377,7 +377,7 @@ func createKubeconfig(ctx context.Context, args createKubeconfigArguments) (crea
 		CertificateOrganizations: args.certOrgs,
 	}
 
-	response, err := clientV2.CreateKeyPair(args.clusterID, addKeyPairBody, auxParams)
+	response, err := clientWrapper.CreateKeyPair(args.clusterID, addKeyPairBody, auxParams)
 	if err != nil {
 		// create specific error types for cases we care about
 		if clientErr, ok := err.(*clienterror.APIError); ok {

--- a/commands/delete/cluster/command.go
+++ b/commands/delete/cluster/command.go
@@ -198,16 +198,16 @@ func deleteCluster(args deleteClusterArguments) (bool, error) {
 		}
 	}
 
-	clientV2, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
+	clientWrapper, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
 	if err != nil {
 		return false, microerror.Mask(err)
 	}
 
-	auxParams := clientV2.DefaultAuxiliaryParams()
+	auxParams := clientWrapper.DefaultAuxiliaryParams()
 	auxParams.ActivityName = deleteClusterActivityName
 
 	// perform API call
-	_, err = clientV2.DeleteCluster(clusterID, auxParams)
+	_, err = clientWrapper.DeleteCluster(clusterID, auxParams)
 	if err != nil {
 		// create specific error types for cases we care about
 		if clientErr, ok := err.(*clienterror.APIError); ok {

--- a/commands/info/command.go
+++ b/commands/info/command.go
@@ -192,15 +192,15 @@ func info(args infoArguments) (infoResult, error) {
 
 	// If an endpoint and a token is defined, we pull info from the API, too.
 	if args.apiEndpoint != "" && args.token != "" {
-		clientV2, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
+		clientWrapper, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
 		if err != nil {
 			return result, microerror.Mask(err)
 		}
 
-		auxParams := clientV2.DefaultAuxiliaryParams()
+		auxParams := clientWrapper.DefaultAuxiliaryParams()
 		auxParams.ActivityName = infoActivityName
 
-		response, err := clientV2.GetInfo(auxParams)
+		response, err := clientWrapper.GetInfo(auxParams)
 		if err != nil {
 			return result, microerror.Mask(err)
 		}

--- a/commands/list/clusters/command.go
+++ b/commands/list/clusters/command.go
@@ -104,15 +104,15 @@ func printResult(cmd *cobra.Command, cmdLineArgs []string) {
 
 // clustersTable returns a table of clusters the user has access to
 func clustersTable(args listClustersArguments) (string, error) {
-	clientV2, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
+	clientWrapper, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
 	if err != nil {
 		return "", microerror.Mask(err)
 	}
 
-	auxParams := clientV2.DefaultAuxiliaryParams()
+	auxParams := clientWrapper.DefaultAuxiliaryParams()
 	auxParams.ActivityName = listClustersActivityName
 
-	response, err := clientV2.GetClusters(auxParams)
+	response, err := clientWrapper.GetClusters(auxParams)
 	if err != nil {
 		if clientErr, ok := err.(*clienterror.APIError); ok {
 			switch clientErr.HTTPStatusCode {

--- a/commands/list/keypairs/command.go
+++ b/commands/list/keypairs/command.go
@@ -101,14 +101,14 @@ func listKeypairsValidate(args *listKeypairsArguments) error {
 		return microerror.Mask(errors.NotLoggedInError)
 	}
 
-	clientV2, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
+	clientWrapper, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
 	if err != nil {
 		return microerror.Mask(err)
 	}
 
 	if args.clusterID == "" {
 		// use default cluster if possible
-		clusterID, _ := clientV2.GetDefaultCluster(nil)
+		clusterID, _ := clientWrapper.GetDefaultCluster(nil)
 		if clusterID != "" {
 			flags.CmdClusterID = clusterID
 		} else {
@@ -195,15 +195,15 @@ func printResult(cmd *cobra.Command, extraArgs []string) {
 func listKeypairs(args listKeypairsArguments) (listKeypairsResult, error) {
 	result := listKeypairsResult{}
 
-	clientV2, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
+	clientWrapper, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
 	if err != nil {
 		return result, microerror.Mask(err)
 	}
 
-	auxParams := clientV2.DefaultAuxiliaryParams()
+	auxParams := clientWrapper.DefaultAuxiliaryParams()
 	auxParams.ActivityName = listKeypairsActivityName
 
-	response, err := clientV2.GetKeyPairs(args.clusterID, auxParams)
+	response, err := clientWrapper.GetKeyPairs(args.clusterID, auxParams)
 	if err != nil {
 		if clientErr, ok := err.(*clienterror.APIError); ok {
 			if clientErr.HTTPStatusCode >= http.StatusInternalServerError {

--- a/commands/list/nodepools/command.go
+++ b/commands/list/nodepools/command.go
@@ -110,15 +110,15 @@ func printValidation(cmd *cobra.Command, positionalArgs []string) {
 // fetchNodePools collects all information we would want to display
 // on the node pools of a cluster.
 func fetchNodePools(args arguments) ([]*resultRow, error) {
-	clientV2, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
+	clientWrapper, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
 
-	auxParams := clientV2.DefaultAuxiliaryParams()
+	auxParams := clientWrapper.DefaultAuxiliaryParams()
 	auxParams.ActivityName = activityName
 
-	response, err := clientV2.GetNodePools(args.clusterID, auxParams)
+	response, err := clientWrapper.GetNodePools(args.clusterID, auxParams)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/commands/list/organizations/command.go
+++ b/commands/list/organizations/command.go
@@ -99,15 +99,15 @@ func printResult(cmd *cobra.Command, extraArgs []string) {
 // orgsTable fetches the organizations the user is a member of
 // and returns a table in string form.
 func orgsTable(args listOrgsArguments) (string, error) {
-	clientV2, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
+	clientWrapper, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
 	if err != nil {
 		return "", microerror.Mask(err)
 	}
 
-	auxParams := clientV2.DefaultAuxiliaryParams()
+	auxParams := clientWrapper.DefaultAuxiliaryParams()
 	auxParams.ActivityName = listOrgsActivityName
 
-	response, err := clientV2.GetOrganizations(auxParams)
+	response, err := clientWrapper.GetOrganizations(auxParams)
 	if err != nil {
 		if clientErr, ok := err.(*clienterror.APIError); ok {
 			if clientErr.HTTPStatusCode == http.StatusUnauthorized {

--- a/commands/list/releases/command.go
+++ b/commands/list/releases/command.go
@@ -213,15 +213,15 @@ func printResult(cmd *cobra.Command, extraArgs []string) {
 
 // listReleases fetches releases and returns them as a structured result.
 func listReleases(args listReleasesArguments) ([]*models.V4ReleaseListItem, error) {
-	clientV2, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
+	clientWrapper, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
 
-	auxParams := clientV2.DefaultAuxiliaryParams()
+	auxParams := clientWrapper.DefaultAuxiliaryParams()
 	auxParams.ActivityName = listReleasesActivityName
 
-	response, err := clientV2.GetReleases(auxParams)
+	response, err := clientWrapper.GetReleases(auxParams)
 	if err != nil {
 		// create specific error types for cases we care about
 		if clientErr, ok := err.(*clienterror.APIError); ok {

--- a/commands/login/command.go
+++ b/commands/login/command.go
@@ -265,15 +265,15 @@ func getInstallationInfo(apiEndpoint string, scheme string, accessToken string) 
 		UserAgent:        config.UserAgent(),
 		AuthHeaderGetter: authHeaderGetter,
 	}
-	clientV2, err := client.NewV2(clientConfig)
+	clientWrapper, err := client.NewV2(clientConfig)
 	if err != nil {
 		return nil, microerror.Maskf(errors.CouldNotCreateClientError, err.Error())
 	}
 
 	// Fetch installation name as alias.
-	auxParams := clientV2.DefaultAuxiliaryParams()
+	auxParams := clientWrapper.DefaultAuxiliaryParams()
 	auxParams.ActivityName = loginActivityName
-	infoResponse, err := clientV2.GetInfo(auxParams)
+	infoResponse, err := clientWrapper.GetInfo(auxParams)
 	if err != nil {
 		return nil, err
 	}

--- a/commands/login/giantswarm_theme.go
+++ b/commands/login/giantswarm_theme.go
@@ -28,12 +28,12 @@ func loginGiantSwarm(args loginArguments) (loginResult, error) {
 		result.endpointSwitched = true
 	}
 
-	clientV2, err := client.NewWithConfig(flags.CmdAPIEndpoint, "")
+	clientWrapper, err := client.NewWithConfig(flags.CmdAPIEndpoint, "")
 	if err != nil {
 		return result, microerror.Mask(err)
 	}
 
-	ap := clientV2.DefaultAuxiliaryParams()
+	ap := clientWrapper.DefaultAuxiliaryParams()
 	ap.ActivityName = loginActivityName
 
 	// log out if logged in
@@ -44,14 +44,14 @@ func loginGiantSwarm(args loginArguments) (loginResult, error) {
 
 		result.loggedOutBefore = true
 		// we deliberately ignore the logout result here
-		clientV2.DeleteAuthToken(config.Config.Token, ap)
+		clientWrapper.DeleteAuthToken(config.Config.Token, ap)
 	}
 
 	if args.verbose {
 		fmt.Println(color.WhiteString("Submitting API call to create an authentication token with email '%s'", args.email))
 	}
 
-	response, err := clientV2.CreateAuthToken(args.email, args.password, ap)
+	response, err := clientWrapper.CreateAuthToken(args.email, args.password, ap)
 	if err != nil {
 		return result, err
 	}

--- a/commands/logout/command.go
+++ b/commands/logout/command.go
@@ -96,14 +96,14 @@ func logout(args logoutArguments) error {
 		return nil
 	}
 
-	clientV2, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
+	clientWrapper, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
 	if err != nil {
 		return microerror.Mask(err)
 	}
 
-	ap := clientV2.DefaultAuxiliaryParams()
+	ap := clientWrapper.DefaultAuxiliaryParams()
 	ap.ActivityName = logoutActivityName
 
-	_, err = clientV2.DeleteAuthToken(args.token, ap)
+	_, err = clientWrapper.DeleteAuthToken(args.token, ap)
 	return microerror.Mask(err)
 }

--- a/commands/scale/cluster/command.go
+++ b/commands/scale/cluster/command.go
@@ -165,12 +165,12 @@ func defaultArguments(ctx context.Context, cmd *cobra.Command, clusterID string,
 
 // getClusterStatus returns the status for one cluster.
 func getClusterStatus(clusterID, activityName string) (*client.ClusterStatus, error) {
-	clientV2, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
+	clientWrapper, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
 
-	auxParams := clientV2.DefaultAuxiliaryParams()
+	auxParams := clientWrapper.DefaultAuxiliaryParams()
 	auxParams.ActivityName = activityName
 
 	// Make sure we have provider info in the current endpoint
@@ -179,7 +179,7 @@ func getClusterStatus(clusterID, activityName string) (*client.ClusterStatus, er
 			fmt.Println(color.WhiteString("Fetching provider information"))
 		}
 
-		info, err := clientV2.GetInfo(auxParams)
+		info, err := clientWrapper.GetInfo(auxParams)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -190,7 +190,7 @@ func getClusterStatus(clusterID, activityName string) (*client.ClusterStatus, er
 	if flags.CmdVerbose {
 		fmt.Println(color.WhiteString("Fetching current cluster size"))
 	}
-	status, err := clientV2.GetClusterStatus(clusterID, auxParams)
+	status, err := clientWrapper.GetClusterStatus(clusterID, auxParams)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
@@ -213,15 +213,15 @@ func scaleCluster(args scaleClusterArguments) (*models.V4ClusterDetailsResponse,
 		fmt.Println(color.WhiteString("Sending API request to modify cluster"))
 	}
 
-	clientV2, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
+	clientWrapper, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
 
-	auxParams := clientV2.DefaultAuxiliaryParams()
+	auxParams := clientWrapper.DefaultAuxiliaryParams()
 	auxParams.ActivityName = scaleClusterActivityName
 
-	response, err := clientV2.ModifyCluster(args.clusterID, reqBody, auxParams)
+	response, err := clientWrapper.ModifyCluster(args.clusterID, reqBody, auxParams)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
@@ -244,16 +244,16 @@ func printResult(cmd *cobra.Command, cmdLineArgs []string) {
 	var currentWorkers int64
 	var releaseVersion string
 	{
-		clientV2, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
+		clientWrapper, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
 		if err != nil {
 			fmt.Println(color.RedString(err.Error()))
 			os.Exit(1)
 		}
 
-		auxParams := clientV2.DefaultAuxiliaryParams()
+		auxParams := clientWrapper.DefaultAuxiliaryParams()
 		auxParams.ActivityName = scaleClusterActivityName
 
-		response, err := clientV2.GetClusterV4(clusterID, auxParams)
+		response, err := clientWrapper.GetClusterV4(clusterID, auxParams)
 		if err != nil {
 			errors.HandleCommonErrors(err)
 			client.HandleErrors(err)

--- a/commands/show/cluster/command.go
+++ b/commands/show/cluster/command.go
@@ -101,16 +101,16 @@ func verifyShowClusterPreconditions(args showClusterArguments, cmdLineArgs []str
 
 // getClusterDetailsV4 returns details for one cluster.
 func getClusterDetailsV4(clusterID string) (*models.V4ClusterDetailsResponse, error) {
-	clientV2, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
+	clientWrapper, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
 
 	// perform API call
-	auxParams := clientV2.DefaultAuxiliaryParams()
+	auxParams := clientWrapper.DefaultAuxiliaryParams()
 	auxParams.ActivityName = activityName
 
-	response, err := clientV2.GetClusterV4(clusterID, auxParams)
+	response, err := clientWrapper.GetClusterV4(clusterID, auxParams)
 	if err != nil {
 		if clientErr, ok := err.(*clienterror.APIError); ok {
 			switch clientErr.HTTPStatusCode {
@@ -133,16 +133,16 @@ func getClusterDetailsV4(clusterID string) (*models.V4ClusterDetailsResponse, er
 
 // getClusterDetailsV5 returns details for one cluster, supporting node pools.
 func getClusterDetailsV5(clusterID string) (*models.V5ClusterDetailsResponse, error) {
-	clientV2, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
+	clientWrapper, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
 
 	// perform API call
-	auxParams := clientV2.DefaultAuxiliaryParams()
+	auxParams := clientWrapper.DefaultAuxiliaryParams()
 	auxParams.ActivityName = activityName
 
-	response, err := clientV2.GetClusterV5(clusterID, auxParams)
+	response, err := clientWrapper.GetClusterV5(clusterID, auxParams)
 	if err != nil {
 		if clientErr, ok := err.(*clienterror.APIError); ok {
 			switch clientErr.HTTPStatusCode {
@@ -164,15 +164,15 @@ func getClusterDetailsV5(clusterID string) (*models.V5ClusterDetailsResponse, er
 }
 
 func getOrgCredentials(orgName, credentialID string) (*models.V4GetCredentialResponse, error) {
-	clientV2, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
+	clientWrapper, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
 
-	auxParams := clientV2.DefaultAuxiliaryParams()
+	auxParams := clientWrapper.DefaultAuxiliaryParams()
 	auxParams.ActivityName = activityName
 
-	response, err := clientV2.GetCredential(orgName, credentialID, auxParams)
+	response, err := clientWrapper.GetCredential(orgName, credentialID, auxParams)
 	if err != nil {
 		if clientErr, ok := err.(*clienterror.APIError); ok {
 			switch clientErr.HTTPStatusCode {
@@ -219,15 +219,15 @@ func getClusterDetails(args showClusterArguments) (
 	clusterDetailsV5, v5Err := getClusterDetailsV5(args.clusterID)
 	if v5Err == nil {
 		// fetch node pools
-		clientV2, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
+		clientWrapper, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
 		if err != nil {
 			return nil, nil, nil, nil, nil, microerror.Mask(err)
 		}
 
 		// perform API call
-		auxParams := clientV2.DefaultAuxiliaryParams()
+		auxParams := clientWrapper.DefaultAuxiliaryParams()
 		auxParams.ActivityName = activityName
-		response, err := clientV2.GetNodePools(args.clusterID, auxParams)
+		response, err := clientWrapper.GetNodePools(args.clusterID, auxParams)
 		if err != nil {
 			return nil, nil, nil, nil, nil, microerror.Mask(err)
 		}
@@ -255,7 +255,7 @@ func getClusterDetails(args showClusterArguments) (
 			return nil, nil, nil, nil, nil, microerror.Mask(clusterDetailsV4Err)
 		}
 
-		clientV2, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
+		clientWrapper, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
 		if err != nil {
 			return nil, nil, nil, nil, nil, microerror.Mask(err)
 		}
@@ -263,10 +263,10 @@ func getClusterDetails(args showClusterArguments) (
 		if args.verbose {
 			fmt.Println(color.WhiteString("Fetching status for v4 cluster."))
 		}
-		auxParams := clientV2.DefaultAuxiliaryParams()
+		auxParams := clientWrapper.DefaultAuxiliaryParams()
 		auxParams.ActivityName = activityName
 		var clusterStatusErr error
-		clusterStatus, clusterStatusErr = clientV2.GetClusterStatus(args.clusterID, auxParams)
+		clusterStatus, clusterStatusErr = clientWrapper.GetClusterStatus(args.clusterID, auxParams)
 		if clusterStatusErr != nil {
 			// Return an error if it is something else than 404 Not Found,
 			// as 404s are expected during cluster creation.

--- a/commands/show/nodepool/command.go
+++ b/commands/show/nodepool/command.go
@@ -111,18 +111,18 @@ func printValidation(cmd *cobra.Command, positionalArgs []string) {
 // fetchNodePool collects all information we would want to display
 // on a node pools of a cluster.
 func fetchNodePool(args arguments) (*result, error) {
-	clientV2, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
+	clientWrapper, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
 
-	auxParams := clientV2.DefaultAuxiliaryParams()
+	auxParams := clientWrapper.DefaultAuxiliaryParams()
 	auxParams.ActivityName = activityName
 
 	// create combined output data structure.
 	res := &result{}
 
-	response, err := clientV2.GetNodePool(args.clusterID, args.nodePoolID, auxParams)
+	response, err := clientWrapper.GetNodePool(args.clusterID, args.nodePoolID, auxParams)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/commands/show/release/command.go
+++ b/commands/show/release/command.go
@@ -92,16 +92,16 @@ func verifyShowReleasePreconditions(args showReleaseArguments, cmdLineArgs []str
 
 // getReleaseDetails fetches release details from the API
 func getReleaseDetails(releaseVersion, scheme, token, endpoint string) (*models.V4ReleaseListItem, error) {
-	clientV2, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
+	clientWrapper, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
 
 	// perform API call
-	auxParams := clientV2.DefaultAuxiliaryParams()
+	auxParams := clientWrapper.DefaultAuxiliaryParams()
 	auxParams.ActivityName = showReleaseActivityName
 
-	response, err := clientV2.GetReleases(auxParams)
+	response, err := clientWrapper.GetReleases(auxParams)
 	if err != nil {
 		// create specific error types for cases we care about
 		if clientErr, ok := err.(*clienterror.APIError); ok {

--- a/commands/update/organization/setcredentials/command.go
+++ b/commands/update/organization/setcredentials/command.go
@@ -179,15 +179,15 @@ func verifyPreconditions(args cmdArguments) error {
 		fmt.Println(color.WhiteString("Determining which provider this installation uses"))
 	}
 
-	clientV2, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
+	clientWrapper, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
 	if err != nil {
 		return microerror.Mask(err)
 	}
 
-	auxParams := clientV2.DefaultAuxiliaryParams()
+	auxParams := clientWrapper.DefaultAuxiliaryParams()
 	auxParams.ActivityName = activityName
 
-	response, err := clientV2.GetInfo(auxParams)
+	response, err := clientWrapper.GetInfo(auxParams)
 	if err != nil {
 		if clientErr, ok := err.(*clienterror.APIError); ok {
 			if clientErr.HTTPStatusCode == http.StatusUnauthorized {
@@ -245,7 +245,7 @@ func verifyPreconditions(args cmdArguments) error {
 	if args.verbose {
 		fmt.Println(color.WhiteString("Verify organization membership"))
 	}
-	orgsResponse, err := clientV2.GetOrganizations(auxParams)
+	orgsResponse, err := clientWrapper.GetOrganizations(auxParams)
 	{
 		if err != nil {
 			if clientErr, ok := err.(*clienterror.APIError); ok {
@@ -333,15 +333,15 @@ func setOrgCredentials(args cmdArguments) (*setOrgCredentialsResult, error) {
 		fmt.Println(color.WhiteString("Sending API request to set credentials"))
 	}
 
-	clientV2, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
+	clientWrapper, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
 
-	auxParams := clientV2.DefaultAuxiliaryParams()
+	auxParams := clientWrapper.DefaultAuxiliaryParams()
 	auxParams.ActivityName = activityName
 
-	response, err := clientV2.SetCredentials(args.organizationID, requestBody, auxParams)
+	response, err := clientWrapper.SetCredentials(args.organizationID, requestBody, auxParams)
 	if err != nil {
 		if clientErr, ok := err.(*clienterror.APIError); ok {
 			if clientErr.HTTPStatusCode == http.StatusConflict {

--- a/commands/upgrade/cluster/command.go
+++ b/commands/upgrade/cluster/command.go
@@ -201,17 +201,17 @@ func upgradeCluster(args upgradeClusterArguments) (upgradeClusterResult, error) 
 	result := upgradeClusterResult{}
 	var details *models.V4ClusterDetailsResponse
 
-	clientV2, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
+	clientWrapper, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
 	if err != nil {
 		return result, microerror.Mask(err)
 	}
 
-	auxParams := clientV2.DefaultAuxiliaryParams()
+	auxParams := clientWrapper.DefaultAuxiliaryParams()
 	auxParams.ActivityName = upgradeClusterActivityName
 
 	// fetch current cluster details
 	{
-		response, err := clientV2.GetClusterV4(args.clusterID, auxParams)
+		response, err := clientWrapper.GetClusterV4(args.clusterID, auxParams)
 		if err != nil {
 			return result, microerror.Mask(err)
 		}
@@ -219,7 +219,7 @@ func upgradeCluster(args upgradeClusterArguments) (upgradeClusterResult, error) 
 		details = response.Payload
 	}
 
-	releasesResponse, err := clientV2.GetReleases(auxParams)
+	releasesResponse, err := clientWrapper.GetReleases(auxParams)
 	if err != nil {
 		return result, microerror.Mask(err)
 	}
@@ -295,7 +295,7 @@ func upgradeCluster(args upgradeClusterArguments) (upgradeClusterResult, error) 
 	}
 
 	// perform API call
-	_, err = clientV2.ModifyCluster(args.clusterID, reqBody, auxParams)
+	_, err = clientWrapper.ModifyCluster(args.clusterID, reqBody, auxParams)
 	if err != nil {
 		return result, microerror.Maskf(errors.CouldNotUpgradeClusterError, err.Error())
 	}


### PR DESCRIPTION
Along the lines of https://github.com/giantswarm/gsctl/pull/387 this PR removes the V2 naming from all variables representing the client wrapper.