### PR TITLE
Fix ldflags and improve info command to show more build info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 PROJECT=gsctl
 ORGANISATION=giantswarm
 BIN=$(PROJECT)
-GOVERSION := 1.12.5
+GOVERSION := 1.12.7
 BUILDDATE := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
-COMMIT := $(shell git rev-parse HEAD | cut -c1-10)
-VERSION := $(shell (test -f VERSION && cat VERSION) || echo "git-${COMMIT}")
+COMMITHASH := $(shell git rev-parse HEAD)
+VERSION := $(shell (test -f VERSION && cat VERSION) || echo "")
 SOURCE=$(shell find . -name '*.go')
 USERID=$(shell id -u)
 GROUPID=$(shell id -g)
@@ -41,6 +41,7 @@ crosscompile: prebuild build/bin/$(BIN)-darwin-amd64 build/bin/$(BIN)-linux-amd6
 build/bin/$(BIN)-darwin-amd64: $(SOURCE)
 	@mkdir -p build/bin
 	@mkdir -p go-build-cache
+	@echo "Commit hash: $(COMMITHASH)"
 	docker run --rm \
 		-v $(shell pwd):/go/src/github.com/$(ORGANISATION)/$(PROJECT) \
 		-v $(shell pwd)/go-build-cache:/.cache \
@@ -48,7 +49,7 @@ build/bin/$(BIN)-darwin-amd64: $(SOURCE)
 		-w /go/src/github.com/$(ORGANISATION)/$(PROJECT) \
 		--user ${USERID}:${GROUPID} \
 		golang:$(GOVERSION)-alpine go build -a -installsuffix cgo -o build/bin/$(BIN)-darwin-amd64 \
-		-ldflags "-X 'github.com/giantswarm/gscliauth/config.Version=$(VERSION)' -X 'github.com/giantswarm/gscliauth/config.BuildDate=$(BUILDDATE)' -X 'github.com/giantswarm/gscliauth/config.Commit=$(COMMIT)'"
+		-ldflags="-X github.com/giantswarm/gsctl/buildinfo.Version=$(VERSION) -X github.com/giantswarm/gsctl/buildinfo.BuildDate=$(BUILDDATE) -X github.com/giantswarm/gsctl/buildinfo.Commit=$(COMMITHASH)"
 	rm -rf go-build-cache
 
 # platform-specific build for linux-amd64
@@ -63,7 +64,7 @@ build/bin/$(BIN)-linux-amd64: $(SOURCE)
 		-w /go/src/github.com/$(ORGANISATION)/$(PROJECT) \
 		--user ${USERID}:${GROUPID} \
 		golang:$(GOVERSION)-stretch go build -a -installsuffix cgo -o build/bin/$(BIN)-linux-amd64 \
-		-ldflags "-X 'github.com/giantswarm/gscliauth/config.Version=$(VERSION)' -X 'github.com/giantswarm/gscliauth/config.BuildDate=$(BUILDDATE)' -X 'github.com/giantswarm/gscliauth/config.Commit=$(COMMIT)'"
+		-ldflags="-X github.com/giantswarm/gsctl/buildinfo.Version=$(VERSION) -X github.com/giantswarm/gsctl/buildinfo.BuildDate=$(BUILDDATE) -X github.com/giantswarm/gsctl/buildinfo.Commit=$(COMMITHASH)"
 	rm -rf go-build-cache
 
 # platform-specific build
@@ -77,7 +78,7 @@ build/bin/$(BIN)-windows-386: $(SOURCE)
 		-w /go/src/github.com/$(ORGANISATION)/$(PROJECT) \
 		--user ${USERID}:${GROUPID} \
 		golang:$(GOVERSION)-alpine go build -a -installsuffix cgo -o build/bin/$(BIN)-windows-386 \
-		-ldflags "-X 'github.com/giantswarm/gscliauth/config.Version=$(VERSION)' -X 'github.com/giantswarm/gscliauth/config.BuildDate=$(BUILDDATE)' -X 'github.com/giantswarm/gscliauth/config.Commit=$(COMMIT)'"
+		-ldflags="-X github.com/giantswarm/gsctl/buildinfo.Version=$(VERSION) -X github.com/giantswarm/gsctl/buildinfo.BuildDate=$(BUILDDATE) -X github.com/giantswarm/gsctl/buildinfo.Commit=$(COMMITHASH)"
 	rm -rf go-build-cache
 
 # platform-specific build
@@ -91,7 +92,7 @@ build/bin/$(BIN)-windows-amd64: $(SOURCE)
 		-w /go/src/github.com/$(ORGANISATION)/$(PROJECT) \
 		--user ${USERID}:${GROUPID} \
 		golang:$(GOVERSION)-alpine go build -a -installsuffix cgo -o build/bin/$(BIN)-windows-amd64 \
-		-ldflags "-X 'github.com/giantswarm/gscliauth/config.Version=$(VERSION)' -X 'github.com/giantswarm/gscliauth/config.BuildDate=$(BUILDDATE)' -X 'github.com/giantswarm/gscliauth/config.Commit=$(COMMIT)'"
+		-ldflags "-X 'github.com/giantswarm/gscliauth/config.Version=$(VERSION)' -X 'github.com/giantswarm/gscliauth/config.BuildDate=$(BUILDDATE)' -X 'github.com/giantswarm/gscliauth/config.Commit=$(COMMITHASH)'"
 	rm -rf go-build-cache
 
 gotest:

--- a/buildinfo/buildinfo.go
+++ b/buildinfo/buildinfo.go
@@ -1,0 +1,14 @@
+// Package buildinfo defines variables which are set by the Go linker on build time using ldflags.
+package buildinfo
+
+// Placeholder is the text we use to pre-set our variables.
+const Placeholder = "Not set - please use a binary release or use 'make' to build gsctl."
+
+var (
+	// BuildDate is a string representing when the binary is built.
+	BuildDate = Placeholder
+	// Commit is the commit SHA hash representing the state of the repository.
+	Commit = Placeholder
+	// Version is the semantic version number of the build.
+	Version = Placeholder
+)

--- a/commands/info/command.go
+++ b/commands/info/command.go
@@ -11,6 +11,7 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/spf13/cobra"
 
+	"github.com/giantswarm/gsctl/buildinfo"
 	"github.com/giantswarm/gsctl/client"
 	"github.com/giantswarm/gsctl/commands/errors"
 	"github.com/giantswarm/gsctl/flags"
@@ -58,6 +59,7 @@ func collectArguments() Arguments {
 type infoResult struct {
 	apiEndpoint      string
 	apiEndpointAlias string
+	commitHash       string
 	email            string
 	token            string
 	version          string
@@ -90,8 +92,24 @@ func printInfo(cmd *cobra.Command, args []string) {
 
 	output := []string{}
 
-	output = append(output, color.YellowString("%s version:", config.ProgramName)+"|"+color.CyanString(result.version))
-	output = append(output, color.YellowString("%s build:", config.ProgramName)+"|"+color.CyanString(result.buildDate))
+	if result.commitHash != buildinfo.Placeholder {
+		output = append(output, color.YellowString("%s commit hash:", config.ProgramName)+"|"+color.CyanString(result.commitHash)+" - https://github.com/giantswarm/gsctl/commit/"+result.commitHash)
+	} else {
+		output = append(output, color.YellowString("%s commit hash:", config.ProgramName)+"|n/a")
+	}
+
+	if result.version != buildinfo.Placeholder {
+		output = append(output, color.YellowString("%s version:", config.ProgramName)+"|"+color.CyanString(result.version))
+	} else {
+		output = append(output, color.YellowString("%s version:", config.ProgramName)+"|n/a")
+	}
+
+	if result.buildDate != buildinfo.Placeholder {
+		output = append(output, color.YellowString("%s build:", config.ProgramName)+"|"+color.CyanString(result.buildDate))
+	} else {
+		output = append(output, color.YellowString("%s build:", config.ProgramName)+"|"+color.RedString(result.buildDate))
+	}
+
 	output = append(output, color.YellowString("Config path:")+"|"+color.CyanString(result.configFilePath))
 
 	// kubectl configuration paths
@@ -174,8 +192,9 @@ func info(args Arguments) (infoResult, error) {
 
 	result.email = config.Config.Email
 	result.token = config.Config.ChooseToken(result.apiEndpoint, args.token)
-	result.version = config.Version
-	result.buildDate = config.BuildDate
+	result.version = buildinfo.Version
+	result.buildDate = buildinfo.BuildDate
+	result.commitHash = buildinfo.Commit
 
 	if config.Config.EndpointConfig(result.apiEndpoint) != nil {
 		result.apiEndpointAlias = config.Config.EndpointConfig(result.apiEndpoint).Alias


### PR DESCRIPTION
This PR solves the problem that the `-ldflags` for `go build` (see Makefile) were not setting the version and build date strings to be shown in `gsctl info` properly.

In addition, this adds a new row for the git commit hash to the `gsctl info` output, which shows the URL of the Github page for the commit details. Also the placeholder content shown is changed.

Unrelated: bump from Go 1.12.5 to 1.12.7

### Expected output from a release:

```
$ gsctl info
gsctl commit hash:    5a61dc71253c00472ca6c9dd7f1af0785ca0a577 - https://github.com/giantswarm/gsctl/commit/5a61dc71253c00472ca6c9dd7f1af0785ca0a577
gsctl version:        1.2.3
gsctl build:          2019-08-07T09:54:37Z
Config path:          /Users/marian/.config/gsctl/config.yaml
kubectl config path:  /Users/marian/.kube/config
...
```

### From a binary created using `go build`:

```
$ ./gsctl info                                                                                                                                                                                         2925ms  Mi  7 Aug 11:50:04 2019
gsctl commit hash:    n/a
gsctl version:        n/a
gsctl build:          Not set - please use a binary release or use 'make' to build gsctl.
Config path:          /Users/marian/.config/gsctl/config.yaml
kubectl config path:  /Users/marian/.kube/config
...
```