### PR TITLE
Fix syntax for bash completion in usage

### DIFF
--- a/commands/completion.go
+++ b/commands/completion.go
@@ -49,7 +49,7 @@ To enable bash completion for gsctl:
 
 1. Edit your ~/.bash_profile and add a line like this:
 
-   source $(gsctl completion bash --stdout)
+   source <(gsctl completion bash --stdout)
 
 2. Start a new terminal session
 `,


### PR DESCRIPTION
For https://github.com/giantswarm/gsctl/issues/160

This fixes a usage info in the `gsctl completion` command.