### PR TITLE
Fix auth scheme via client initialization

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -222,6 +222,11 @@ func (w *Wrapper) DefaultAuxiliaryParams() *AuxiliaryParams {
 	}
 }
 
+// GetConfiguration returns the client wrapper's configuration, e. g. for debugging purposes.
+func (w *Wrapper) GetConfiguration() *Configuration {
+	return w.conf
+}
+
 // paramSetter is the interface we use to abstract away the differences between
 // request parameter types.
 type paramSetter interface {

--- a/commands/create/cluster/command.go
+++ b/commands/create/cluster/command.go
@@ -38,6 +38,7 @@ type Arguments struct {
 	releaseVersion          string
 	scheme                  string
 	token                   string
+	userProvidedToken       string
 	verbose                 bool
 	wokerAwsEc2InstanceType string
 	wokerAzureVMSize        string
@@ -65,6 +66,7 @@ func collectArguments() Arguments {
 		releaseVersion:          flags.CmdRelease,
 		scheme:                  scheme,
 		token:                   token,
+		userProvidedToken:       flags.CmdToken,
 		verbose:                 flags.CmdVerbose,
 		wokerAwsEc2InstanceType: cmdWorkerAwsEc2InstanceType,
 		wokerAzureVMSize:        cmdWorkerAzureVMSize,
@@ -534,7 +536,7 @@ func addCluster(args Arguments) (creationResult, error) {
 	if !args.dryRun {
 		fmt.Printf("Requesting new cluster for organization '%s'\n", color.CyanString(result.definition.Owner))
 
-		clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.token)
+		clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.userProvidedToken)
 		if err != nil {
 			return result, microerror.Mask(err)
 		}

--- a/commands/create/cluster/command_test.go
+++ b/commands/create/cluster/command_test.go
@@ -232,6 +232,7 @@ func Test_CreateClusterSuccessfully(t *testing.T) {
 		defer mockServer.Close()
 
 		testCase.inputArgs.apiEndpoint = mockServer.URL
+		testCase.inputArgs.userProvidedToken = testCase.inputArgs.token
 
 		err := validatePreConditions(*testCase.inputArgs)
 		if err != nil {

--- a/commands/create/keypair/command.go
+++ b/commands/create/keypair/command.go
@@ -49,6 +49,7 @@ type Arguments struct {
 	fileSystem               afero.Fs
 	scheme                   string
 	ttlHours                 int32
+	userProvidedToken        string
 }
 
 // collectArguments puts together arguments for our business function
@@ -82,6 +83,7 @@ func collectArguments() (Arguments, error) {
 		fileSystem:               config.FileSystem,
 		scheme:                   scheme,
 		ttlHours:                 int32(ttl.Hours()),
+		userProvidedToken:        flags.CmdToken,
 	}, nil
 }
 
@@ -232,7 +234,7 @@ func createKeypair(args Arguments) (createKeypairResult, error) {
 		CertificateOrganizations: args.certificateOrganizations,
 	}
 
-	clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.authToken)
+	clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.userProvidedToken)
 	if err != nil {
 		return result, microerror.Mask(err)
 	}

--- a/commands/create/kubeconfig/command.go
+++ b/commands/create/kubeconfig/command.go
@@ -94,6 +94,7 @@ type Arguments struct {
 	scheme            string
 	selfContainedPath string
 	ttlHours          int32
+	userProvidedToken string
 }
 
 // collectArguments gathers arguments based on command line
@@ -135,6 +136,7 @@ func collectArguments() (Arguments, error) {
 		scheme:            scheme,
 		selfContainedPath: cmdKubeconfigSelfContained,
 		ttlHours:          int32(ttl.Hours()),
+		userProvidedToken: flags.CmdToken,
 	}, nil
 }
 
@@ -349,7 +351,7 @@ func createKubeconfigRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 func createKubeconfig(ctx context.Context, args Arguments) (createKubeconfigResult, error) {
 	result := createKubeconfigResult{}
 
-	clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.authToken)
+	clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.userProvidedToken)
 	if err != nil {
 		return result, microerror.Mask(err)
 	}

--- a/commands/delete/cluster/command.go
+++ b/commands/delete/cluster/command.go
@@ -32,7 +32,8 @@ type Arguments struct {
 	// auth scheme
 	scheme string
 	// auth token
-	token string
+	token             string
+	userProvidedToken string
 	// verbosity
 	verbose bool
 }
@@ -48,13 +49,14 @@ func collectArguments(positionalArgs []string) Arguments {
 	}
 
 	return Arguments{
-		apiEndpoint:     endpoint,
-		clusterID:       clusterID,
-		force:           flags.CmdForce,
-		legacyClusterID: flags.CmdClusterID,
-		scheme:          scheme,
-		token:           token,
-		verbose:         flags.CmdVerbose,
+		apiEndpoint:       endpoint,
+		clusterID:         clusterID,
+		force:             flags.CmdForce,
+		legacyClusterID:   flags.CmdClusterID,
+		scheme:            scheme,
+		token:             token,
+		userProvidedToken: flags.CmdToken,
+		verbose:           flags.CmdVerbose,
 	}
 }
 
@@ -200,7 +202,7 @@ func deleteCluster(args Arguments) (bool, error) {
 		}
 	}
 
-	clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.token)
+	clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.userProvidedToken)
 	if err != nil {
 		return false, microerror.Mask(err)
 	}

--- a/commands/info/command.go
+++ b/commands/info/command.go
@@ -33,10 +33,11 @@ var (
 
 // Arguments represents the arguments we can make use of in this command
 type Arguments struct {
-	scheme      string
-	token       string
-	verbose     bool
-	apiEndpoint string
+	apiEndpoint       string
+	scheme            string
+	token             string
+	userProvidedToken string
+	verbose           bool
 }
 
 // collectArguments returns an Arguments object populated by the user's
@@ -47,10 +48,11 @@ func collectArguments() Arguments {
 	scheme := config.Config.ChooseScheme(endpoint, flags.CmdToken)
 
 	return Arguments{
-		scheme:      scheme,
-		token:       token,
-		verbose:     flags.CmdVerbose,
-		apiEndpoint: endpoint,
+		apiEndpoint:       endpoint,
+		scheme:            scheme,
+		token:             token,
+		userProvidedToken: flags.CmdToken,
+		verbose:           flags.CmdVerbose,
 	}
 }
 
@@ -173,7 +175,7 @@ func info(args Arguments) (infoResult, error) {
 	}
 
 	result.email = config.Config.Email
-	result.token = config.Config.ChooseToken(result.apiEndpoint, args.token)
+	result.token = config.Config.ChooseToken(result.apiEndpoint, args.userProvidedToken)
 	result.version = config.Version
 	result.buildDate = config.BuildDate
 
@@ -192,7 +194,7 @@ func info(args Arguments) (infoResult, error) {
 
 	// If an endpoint and a token is defined, we pull info from the API, too.
 	if args.apiEndpoint != "" && args.token != "" {
-		clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.token)
+		clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.userProvidedToken)
 		if err != nil {
 			return result, microerror.Mask(err)
 		}

--- a/commands/info/command_test.go
+++ b/commands/info/command_test.go
@@ -59,6 +59,7 @@ func Test_InfoWithTempDirAndToken(t *testing.T) {
 
 	args := collectArguments()
 	args.token = "fake token"
+	args.userProvidedToken = args.token
 	args.apiEndpoint = ""
 
 	infoResult, err := info(args)

--- a/commands/list/clusters/command.go
+++ b/commands/list/clusters/command.go
@@ -38,9 +38,10 @@ const (
 )
 
 type Arguments struct {
-	apiEndpoint string
-	authToken   string
-	scheme      string
+	apiEndpoint       string
+	authToken         string
+	scheme            string
+	userProvidedToken string
 }
 
 func collectArguments() Arguments {
@@ -49,9 +50,10 @@ func collectArguments() Arguments {
 	scheme := config.Config.ChooseScheme(endpoint, flags.CmdToken)
 
 	return Arguments{
-		apiEndpoint: endpoint,
-		authToken:   token,
-		scheme:      scheme,
+		apiEndpoint:       endpoint,
+		authToken:         token,
+		scheme:            scheme,
+		userProvidedToken: flags.CmdToken,
 	}
 }
 
@@ -104,7 +106,7 @@ func printResult(cmd *cobra.Command, cmdLineArgs []string) {
 
 // clustersTable returns a table of clusters the user has access to
 func clustersTable(args Arguments) (string, error) {
-	clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.authToken)
+	clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.userProvidedToken)
 	if err != nil {
 		return "", microerror.Mask(err)
 	}

--- a/commands/list/endpoints/command.go
+++ b/commands/list/endpoints/command.go
@@ -27,6 +27,7 @@ var (
 
 // Arguments are the arguments we pass to the actual functions
 // listing endpoints and printing endpoints lists
+// TODO: apiEndpoint is the only argument used. The rest can be removed.
 type Arguments struct {
 	apiEndpoint string
 	scheme      string

--- a/commands/list/keypairs/command.go
+++ b/commands/list/keypairs/command.go
@@ -43,11 +43,12 @@ var (
 // Arguments are the actual arguments used to call the
 // listKeypairs() function.
 type Arguments struct {
-	apiEndpoint string
-	clusterID   string
-	full        bool
-	token       string
-	scheme      string
+	apiEndpoint       string
+	clusterID         string
+	full              bool
+	token             string
+	userProvidedToken string
+	scheme            string
 }
 
 // collectArguments returns a new Arguments struct
@@ -58,11 +59,12 @@ func collectArguments() Arguments {
 	scheme := config.Config.ChooseScheme(endpoint, flags.CmdToken)
 
 	return Arguments{
-		apiEndpoint: endpoint,
-		clusterID:   flags.CmdClusterID,
-		full:        flags.CmdFull,
-		token:       token,
-		scheme:      scheme,
+		apiEndpoint:       endpoint,
+		clusterID:         flags.CmdClusterID,
+		full:              flags.CmdFull,
+		token:             token,
+		userProvidedToken: flags.CmdToken,
+		scheme:            scheme,
 	}
 }
 
@@ -101,7 +103,7 @@ func listKeypairsValidate(args *Arguments) error {
 		return microerror.Mask(errors.NotLoggedInError)
 	}
 
-	clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.token)
+	clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.userProvidedToken)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/commands/list/keypairs/command.go
+++ b/commands/list/keypairs/command.go
@@ -197,7 +197,7 @@ func printResult(cmd *cobra.Command, extraArgs []string) {
 func listKeypairs(args Arguments) (listKeypairsResult, error) {
 	result := listKeypairsResult{}
 
-	clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.token)
+	clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.userProvidedToken)
 	if err != nil {
 		return result, microerror.Mask(err)
 	}

--- a/commands/list/nodepools/command.go
+++ b/commands/list/nodepools/command.go
@@ -59,10 +59,11 @@ To list all clusters you have access to, use 'gsctl list clusters'.`,
 const activityName = "list-nodepools"
 
 type Arguments struct {
-	apiEndpoint string
-	authToken   string
-	scheme      string
-	clusterID   string
+	apiEndpoint       string
+	authToken         string
+	clusterID         string
+	scheme            string
+	userProvidedToken string
 }
 
 // resultRow represents one nope pool row as returned by fetchNodePools.
@@ -82,10 +83,11 @@ func collectArguments(cmdLineArgs []string) Arguments {
 	scheme := config.Config.ChooseScheme(endpoint, flags.CmdToken)
 
 	return Arguments{
-		apiEndpoint: endpoint,
-		authToken:   token,
-		scheme:      scheme,
-		clusterID:   cmdLineArgs[0],
+		apiEndpoint:       endpoint,
+		authToken:         token,
+		clusterID:         cmdLineArgs[0],
+		scheme:            scheme,
+		userProvidedToken: flags.CmdToken,
 	}
 }
 
@@ -110,7 +112,7 @@ func printValidation(cmd *cobra.Command, positionalArgs []string) {
 // fetchNodePools collects all information we would want to display
 // on the node pools of a cluster.
 func fetchNodePools(args Arguments) ([]*resultRow, error) {
-	clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.authToken)
+	clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.userProvidedToken)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/commands/list/organizations/command.go
+++ b/commands/list/organizations/command.go
@@ -35,9 +35,10 @@ const (
 )
 
 type Arguments struct {
-	apiEndpoint string
-	authToken   string
-	scheme      string
+	apiEndpoint       string
+	authToken         string
+	scheme            string
+	userProvidedToken string
 }
 
 // collectArguments creates arguments based on command line flags and config
@@ -47,9 +48,10 @@ func collectArguments() Arguments {
 	scheme := config.Config.ChooseScheme(endpoint, flags.CmdToken)
 
 	return Arguments{
-		apiEndpoint: endpoint,
-		authToken:   token,
-		scheme:      scheme,
+		apiEndpoint:       endpoint,
+		authToken:         token,
+		scheme:            scheme,
+		userProvidedToken: flags.CmdToken,
 	}
 }
 
@@ -99,7 +101,7 @@ func printResult(cmd *cobra.Command, extraArgs []string) {
 // orgsTable fetches the organizations the user is a member of
 // and returns a table in string form.
 func orgsTable(args Arguments) (string, error) {
-	clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.authToken)
+	clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.userProvidedToken)
 
 	if err != nil {
 		return "", microerror.Mask(err)

--- a/commands/list/releases/command.go
+++ b/commands/list/releases/command.go
@@ -43,9 +43,10 @@ A release is a software bundle that constitutes a cluster. It is identified by i
 // Arguments are the actual arguments used to call the
 // listReleases() function.
 type Arguments struct {
-	apiEndpoint string
-	token       string
-	scheme      string
+	apiEndpoint       string
+	token             string
+	scheme            string
+	userProvidedToken string
 }
 
 // collectArguments returns a new Arguments struct
@@ -56,9 +57,10 @@ func collectArguments() Arguments {
 	scheme := config.Config.ChooseScheme(endpoint, flags.CmdToken)
 
 	return Arguments{
-		apiEndpoint: endpoint,
-		token:       token,
-		scheme:      scheme,
+		apiEndpoint:       endpoint,
+		token:             token,
+		scheme:            scheme,
+		userProvidedToken: flags.CmdToken,
 	}
 }
 
@@ -212,7 +214,7 @@ func printResult(cmd *cobra.Command, extraArgs []string) {
 
 // listReleases fetches releases and returns them as a structured result.
 func listReleases(args Arguments) ([]*models.V4ReleaseListItem, error) {
-	clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.token)
+	clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.userProvidedToken)
 
 	if err != nil {
 		return nil, microerror.Mask(err)

--- a/commands/logout/command.go
+++ b/commands/logout/command.go
@@ -39,7 +39,8 @@ type Arguments struct {
 	// apiEndpoint is the API to log out from
 	apiEndpoint string
 	// token is the session token to expire (log out)
-	token string
+	token             string
+	userProvidedToken string
 }
 
 func collectArguments() Arguments {
@@ -47,8 +48,9 @@ func collectArguments() Arguments {
 	token := config.Config.ChooseToken(endpoint, flags.CmdToken)
 
 	return Arguments{
-		apiEndpoint: endpoint,
-		token:       token,
+		apiEndpoint:       endpoint,
+		token:             token,
+		userProvidedToken: flags.CmdToken,
 	}
 }
 
@@ -97,7 +99,7 @@ func logout(args Arguments) error {
 		return nil
 	}
 
-	clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.token)
+	clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.userProvidedToken)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/commands/scale/cluster/command.go
+++ b/commands/scale/cluster/command.go
@@ -72,6 +72,7 @@ type Arguments struct {
 	numWorkersDesired   int
 	oppressConfirmation bool
 	scheme              string
+	userProvidedToken   string
 	verbose             bool
 	workersMax          int64
 	workersMin          int64
@@ -125,6 +126,7 @@ func collectArguments(ctx context.Context, cmd *cobra.Command, clusterID string,
 		numWorkersDesired:   int(desiredNumWorkers),
 		oppressConfirmation: flags.CmdForce,
 		scheme:              scheme,
+		userProvidedToken:   flags.CmdToken,
 		verbose:             flags.CmdVerbose,
 		workersMax:          flags.CmdWorkersMax,
 		workersMin:          flags.CmdWorkersMin,
@@ -214,7 +216,7 @@ func scaleCluster(args Arguments) (*models.V4ClusterDetailsResponse, error) {
 		fmt.Println(color.WhiteString("Sending API request to modify cluster"))
 	}
 
-	clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.authToken)
+	clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.userProvidedToken)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/commands/show/cluster/command.go
+++ b/commands/show/cluster/command.go
@@ -54,11 +54,12 @@ const (
 
 // Arguments specifies all the arguments to be used for our business function.
 type Arguments struct {
-	apiEndpoint string
-	authToken   string
-	scheme      string
-	clusterID   string
-	verbose     bool
+	apiEndpoint       string
+	authToken         string
+	scheme            string
+	clusterID         string
+	userProvidedToken string
+	verbose           bool
 }
 
 // collectArguments fills arguments from user input, config, and environment.
@@ -68,11 +69,12 @@ func collectArguments() Arguments {
 	scheme := config.Config.ChooseScheme(endpoint, flags.CmdToken)
 
 	return Arguments{
-		apiEndpoint: endpoint,
-		authToken:   token,
-		scheme:      scheme,
-		clusterID:   "",
-		verbose:     flags.CmdVerbose,
+		apiEndpoint:       endpoint,
+		authToken:         token,
+		scheme:            scheme,
+		clusterID:         "",
+		userProvidedToken: flags.CmdToken,
+		verbose:           flags.CmdVerbose,
 	}
 }
 
@@ -103,7 +105,7 @@ func verifyShowClusterPreconditions(args Arguments, cmdLineArgs []string) error 
 
 // getClusterDetailsV4 returns details for one cluster.
 func getClusterDetailsV4(args Arguments) (*models.V4ClusterDetailsResponse, error) {
-	clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.authToken)
+	clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.userProvidedToken)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
@@ -135,7 +137,7 @@ func getClusterDetailsV4(args Arguments) (*models.V4ClusterDetailsResponse, erro
 
 // getClusterDetailsV5 returns details for one cluster, supporting node pools.
 func getClusterDetailsV5(args Arguments) (*models.V5ClusterDetailsResponse, error) {
-	clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.authToken)
+	clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.userProvidedToken)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
@@ -166,7 +168,7 @@ func getClusterDetailsV5(args Arguments) (*models.V5ClusterDetailsResponse, erro
 }
 
 func getOrgCredentials(orgName, credentialID string, args Arguments) (*models.V4GetCredentialResponse, error) {
-	clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.authToken)
+	clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.userProvidedToken)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
@@ -221,7 +223,7 @@ func getClusterDetails(args Arguments) (
 	clusterDetailsV5, v5Err := getClusterDetailsV5(args)
 	if v5Err == nil {
 		// fetch node pools
-		clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.authToken)
+		clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.userProvidedToken)
 		if err != nil {
 			return nil, nil, nil, nil, nil, microerror.Mask(err)
 		}
@@ -257,7 +259,7 @@ func getClusterDetails(args Arguments) (
 			return nil, nil, nil, nil, nil, microerror.Mask(clusterDetailsV4Err)
 		}
 
-		clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.authToken)
+		clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.userProvidedToken)
 		if err != nil {
 			return nil, nil, nil, nil, nil, microerror.Mask(err)
 		}

--- a/commands/show/nodepool/command.go
+++ b/commands/show/nodepool/command.go
@@ -49,10 +49,11 @@ const (
 )
 
 type Arguments struct {
-	apiEndpoint string
-	authToken   string
-	clusterID   string
-	nodePoolID  string
+	apiEndpoint       string
+	authToken         string
+	clusterID         string
+	nodePoolID        string
+	userProvidedToken string
 }
 
 // result represents all information we want to collect about one node pool.
@@ -72,10 +73,11 @@ func collectArguments(positionalArgs []string) Arguments {
 	parts := strings.Split(positionalArgs[0], "/")
 
 	return Arguments{
-		apiEndpoint: endpoint,
-		authToken:   token,
-		clusterID:   parts[0],
-		nodePoolID:  parts[1],
+		apiEndpoint:       endpoint,
+		authToken:         token,
+		clusterID:         parts[0],
+		nodePoolID:        parts[1],
+		userProvidedToken: flags.CmdToken,
 	}
 }
 
@@ -108,7 +110,7 @@ func printValidation(cmd *cobra.Command, positionalArgs []string) {
 // fetchNodePool collects all information we would want to display
 // on a node pools of a cluster.
 func fetchNodePool(args Arguments) (*result, error) {
-	clientWrapper, err := client.NewWithConfig(flags.CmdAPIEndpoint, flags.CmdToken)
+	clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.userProvidedToken)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/commands/show/release/command.go
+++ b/commands/show/release/command.go
@@ -44,11 +44,12 @@ const (
 )
 
 type Arguments struct {
-	apiEndpoint    string
-	authToken      string
-	scheme         string
-	releaseVersion string
-	verbose        bool
+	apiEndpoint       string
+	authToken         string
+	releaseVersion    string
+	scheme            string
+	userProvidedToken string
+	verbose           bool
 }
 
 func collectArguments() Arguments {
@@ -57,11 +58,12 @@ func collectArguments() Arguments {
 	scheme := config.Config.ChooseScheme(endpoint, flags.CmdToken)
 
 	return Arguments{
-		apiEndpoint:    endpoint,
-		authToken:      token,
-		scheme:         scheme,
-		releaseVersion: "",
-		verbose:        flags.CmdVerbose,
+		apiEndpoint:       endpoint,
+		authToken:         token,
+		scheme:            scheme,
+		releaseVersion:    "",
+		userProvidedToken: flags.CmdToken,
+		verbose:           flags.CmdVerbose,
 	}
 }
 
@@ -92,7 +94,7 @@ func verifyShowReleasePreconditions(args Arguments, cmdLineArgs []string) error 
 
 // getReleaseDetails fetches release details from the API
 func getReleaseDetails(args Arguments) (*models.V4ReleaseListItem, error) {
-	clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.authToken)
+	clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.userProvidedToken)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/commands/update/organization/setcredentials/command.go
+++ b/commands/update/organization/setcredentials/command.go
@@ -77,15 +77,16 @@ For details on how to prepare the account/subscription, consult the documentatio
 type Arguments struct {
 	apiEndpoint         string
 	authToken           string
-	scheme              string
-	verbose             bool
-	organizationID      string
 	awsAdminRole        string
 	awsOperatorRole     string
-	azureSubscriptionID string
-	azureTenantID       string
 	azureClientID       string
 	azureSecretKey      string
+	azureSubscriptionID string
+	azureTenantID       string
+	organizationID      string
+	scheme              string
+	userProvidedToken   string
+	verbose             bool
 }
 
 type setOrgCredentialsResult struct {
@@ -110,15 +111,16 @@ func collectArguments() Arguments {
 	return Arguments{
 		apiEndpoint:         endpoint,
 		authToken:           token,
-		scheme:              scheme,
-		organizationID:      flags.CmdOrganizationID,
-		verbose:             flags.CmdVerbose,
 		awsAdminRole:        cmdAWSAdminRoleARN,
 		awsOperatorRole:     cmdAWSOperatorRoleARN,
 		azureClientID:       cmdAzureClientID,
 		azureSecretKey:      cmdAzureSecretKey,
 		azureSubscriptionID: cmdAzureSubscriptionID,
 		azureTenantID:       cmdAzureTenantID,
+		organizationID:      flags.CmdOrganizationID,
+		scheme:              scheme,
+		userProvidedToken:   flags.CmdToken,
+		verbose:             flags.CmdVerbose,
 	}
 }
 
@@ -178,7 +180,7 @@ func verifyPreconditions(args Arguments) error {
 		fmt.Println(color.WhiteString("Determining which provider this installation uses"))
 	}
 
-	clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.authToken)
+	clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.userProvidedToken)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/commands/upgrade/cluster/command.go
+++ b/commands/upgrade/cluster/command.go
@@ -65,11 +65,12 @@ Example:
 // Arguments is the struct to pass to our business function and
 // to the validation function.
 type Arguments struct {
-	apiEndpoint string
-	authToken   string
-	clusterID   string
-	force       bool
-	verbose     bool
+	apiEndpoint       string
+	authToken         string
+	clusterID         string
+	force             bool
+	userProvidedToken string
+	verbose           bool
 }
 
 // function to create arguments based on command line flags and config
@@ -82,11 +83,12 @@ func collectArguments(cmdLineArgs []string) Arguments {
 	}
 
 	return Arguments{
-		apiEndpoint: endpoint,
-		authToken:   token,
-		clusterID:   clusterID,
-		force:       false,
-		verbose:     flags.CmdVerbose,
+		apiEndpoint:       endpoint,
+		authToken:         token,
+		clusterID:         clusterID,
+		force:             false,
+		userProvidedToken: flags.CmdToken,
+		verbose:           flags.CmdVerbose,
 	}
 }
 
@@ -201,7 +203,7 @@ func upgradeCluster(args Arguments) (upgradeClusterResult, error) {
 	result := upgradeClusterResult{}
 	var details *models.V4ClusterDetailsResponse
 
-	clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.authToken)
+	clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.userProvidedToken)
 	if err != nil {
 		return result, microerror.Mask(err)
 	}


### PR DESCRIPTION
This PR is a start to fix authentication issues introduced with recent refactorings.

The problem is that `github.com/giantswarm/gscliauth.config.ChooseScheme(endpoint, token)` always returns the scheme `giantswarm` when a non-empty token is passed via the function's parameters. The token parameter was meant to represent a token provided by the user via the command line, to override any config.

To better reflect, the command structure in this PR now distinguishes between one argument `token` and an additional one named `userProvidedToken`. The latter represents any token provided by the user as a command line argument. The existing `token` can be set based on authentication data from the config.

### TODO

- Apply the same fix to all other commands.