### PR TITLE
Remove more v2 naming

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -300,7 +300,7 @@ func setParamsWithAuthorization(p *AuxiliaryParams, w *Wrapper, params paramSett
 	return nil
 }
 
-// CreateAuthToken creates an auth token using the V2 client.
+// CreateAuthToken creates an auth token using the gsclientgen client.
 func (w *Wrapper) CreateAuthToken(email, password string, p *AuxiliaryParams) (*auth_tokens.CreateAuthTokenOK, error) {
 	params := auth_tokens.NewCreateAuthTokenParams().WithBody(&models.V4CreateAuthTokenRequest{
 		Email:          email,
@@ -316,7 +316,7 @@ func (w *Wrapper) CreateAuthToken(email, password string, p *AuxiliaryParams) (*
 	return response, nil
 }
 
-// DeleteAuthToken calls the API's deleteAuthToken operation using the V2 client.
+// DeleteAuthToken calls the API's deleteAuthToken operation using the gsclientgen client.
 func (w *Wrapper) DeleteAuthToken(authToken string, p *AuxiliaryParams) (*auth_tokens.DeleteAuthTokenOK, error) {
 	params := auth_tokens.NewDeleteAuthTokenParams().WithAuthorization("giantswarm " + authToken)
 	setParams(p, w, params)
@@ -329,7 +329,7 @@ func (w *Wrapper) DeleteAuthToken(authToken string, p *AuxiliaryParams) (*auth_t
 	return response, nil
 }
 
-// CreateCluster creates cluster using the V2 client.
+// CreateCluster creates cluster using the gsclientgen client.
 func (w *Wrapper) CreateCluster(addClusterRequest *models.V4AddClusterRequest, p *AuxiliaryParams) (*clusters.AddClusterCreated, error) {
 	params := clusters.NewAddClusterParams().WithBody(addClusterRequest)
 	err := setParamsWithAuthorization(p, w, params)
@@ -345,7 +345,7 @@ func (w *Wrapper) CreateCluster(addClusterRequest *models.V4AddClusterRequest, p
 	return response, nil
 }
 
-// ModifyCluster modifies a cluster using the V2 client.
+// ModifyCluster modifies a cluster using the gsclientgen client.
 func (w *Wrapper) ModifyCluster(clusterID string, body *models.V4ModifyClusterRequest, p *AuxiliaryParams) (*clusters.ModifyClusterOK, error) {
 	params := clusters.NewModifyClusterParams().WithClusterID(clusterID).WithBody(body)
 	err := setParamsWithAuthorization(p, w, params)
@@ -361,7 +361,7 @@ func (w *Wrapper) ModifyCluster(clusterID string, body *models.V4ModifyClusterRe
 	return response, nil
 }
 
-// DeleteCluster deletes a cluster using the V2 client.
+// DeleteCluster deletes a cluster using the gsclientgen client.
 func (w *Wrapper) DeleteCluster(clusterID string, p *AuxiliaryParams) (*clusters.DeleteClusterAccepted, error) {
 	params := clusters.NewDeleteClusterParams().WithClusterID(clusterID)
 	err := setParamsWithAuthorization(p, w, params)
@@ -377,7 +377,7 @@ func (w *Wrapper) DeleteCluster(clusterID string, p *AuxiliaryParams) (*clusters
 	return response, nil
 }
 
-// GetClusters fetches a list of clusters using the V2 client.
+// GetClusters fetches a list of clusters using the gsclientgen client.
 func (w *Wrapper) GetClusters(p *AuxiliaryParams) (*clusters.GetClustersOK, error) {
 	params := clusters.NewGetClustersParams()
 	err := setParamsWithAuthorization(p, w, params)
@@ -494,7 +494,7 @@ func (w *Wrapper) GetDefaultCluster(p *AuxiliaryParams) (string, error) {
 	return "", nil
 }
 
-// CreateKeyPair calls the addKeyPair API operation using the V2 client.
+// CreateKeyPair calls the addKeyPair API operation using the gsclientgen client.
 func (w *Wrapper) CreateKeyPair(clusterID string, addKeyPairRequest *models.V4AddKeyPairRequest, p *AuxiliaryParams) (*key_pairs.AddKeyPairOK, error) {
 	params := key_pairs.NewAddKeyPairParams().WithClusterID(clusterID).WithBody(addKeyPairRequest)
 	err := setParamsWithAuthorization(p, w, params)
@@ -510,7 +510,7 @@ func (w *Wrapper) CreateKeyPair(clusterID string, addKeyPairRequest *models.V4Ad
 	return response, nil
 }
 
-// GetKeyPairs calls the API to fetch key pairs using the V2 client.
+// GetKeyPairs calls the API to fetch key pairs using the gsclientgen client.
 func (w *Wrapper) GetKeyPairs(clusterID string, p *AuxiliaryParams) (*key_pairs.GetKeyPairsOK, error) {
 	params := key_pairs.NewGetKeyPairsParams().WithClusterID(clusterID)
 	err := setParamsWithAuthorization(p, w, params)
@@ -526,7 +526,7 @@ func (w *Wrapper) GetKeyPairs(clusterID string, p *AuxiliaryParams) (*key_pairs.
 	return response, nil
 }
 
-// GetInfo calls the API's getInfo operation using the V2 client.
+// GetInfo calls the API's getInfo operation using the gsclientgen client.
 func (w *Wrapper) GetInfo(p *AuxiliaryParams) (*info.GetInfoOK, error) {
 	params := info.NewGetInfoParams()
 	err := setParamsWithAuthorization(p, w, params)
@@ -542,7 +542,7 @@ func (w *Wrapper) GetInfo(p *AuxiliaryParams) (*info.GetInfoOK, error) {
 	return response, nil
 }
 
-// GetReleases calls the API's getReleases operation using the V2 client.
+// GetReleases calls the API's getReleases operation using the gsclientgen client.
 func (w *Wrapper) GetReleases(p *AuxiliaryParams) (*releases.GetReleasesOK, error) {
 	params := releases.NewGetReleasesParams()
 	err := setParamsWithAuthorization(p, w, params)
@@ -558,7 +558,7 @@ func (w *Wrapper) GetReleases(p *AuxiliaryParams) (*releases.GetReleasesOK, erro
 	return response, nil
 }
 
-// GetOrganizations calls the API's getOrganizations operation using the new client.
+// GetOrganizations calls the API's getOrganizations operation using the gsclientgen client.
 func (w *Wrapper) GetOrganizations(p *AuxiliaryParams) (*organizations.GetOrganizationsOK, error) {
 	params := organizations.NewGetOrganizationsParams()
 	err := setParamsWithAuthorization(p, w, params)
@@ -574,7 +574,7 @@ func (w *Wrapper) GetOrganizations(p *AuxiliaryParams) (*organizations.GetOrgani
 	return response, nil
 }
 
-// GetCredential calls the API's getCredential operation using the V2 client.
+// GetCredential calls the API's getCredential operation using the gsclientgen client.
 func (w *Wrapper) GetCredential(organizationID string, credentialID string, p *AuxiliaryParams) (*organizations.GetCredentialOK, error) {
 	params := organizations.NewGetCredentialParams().WithOrganizationID(organizationID).WithCredentialID(credentialID)
 	err := setParamsWithAuthorization(p, w, params)
@@ -606,7 +606,7 @@ func (w *Wrapper) SetCredentials(organizationID string, addCredentialsRequest *m
 	return response, nil
 }
 
-// GetClusterStatus fetches details on a cluster using the V2 client.
+// GetClusterStatus fetches details on a cluster using the gsclientgen client.
 func (w *Wrapper) GetClusterStatus(clusterID string, p *AuxiliaryParams) (*ClusterStatus, error) {
 	params := clusters.NewGetClusterStatusParams().WithClusterID(clusterID)
 	err := setParamsWithAuthorization(p, w, params)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -43,9 +43,9 @@ func TestRedactPasswordArgs(t *testing.T) {
 	}
 }
 
-// TestV2NoConnection checks out how the latest client deals with a missing
+// TestNoConnection checks out how the latest client deals with a missing
 // server connection.
-func TestV2NoConnection(t *testing.T) {
+func TestNoConnection(t *testing.T) {
 	// a non-existing endpoint (must use an IP, not a hostname)
 	config := &Configuration{
 		Endpoint: "http://127.0.0.1:55555",
@@ -85,9 +85,9 @@ func TestV2NoConnection(t *testing.T) {
 	}
 }
 
-// TestV2HostnameUnresolvable checks out how the latest client deals with a
+// TestHostnameUnresolvable checks out how the latest client deals with a
 // non-resolvable host name.
-func TestV2HostnameUnresolvable(t *testing.T) { // Our test server.
+func TestHostnameUnresolvable(t *testing.T) { // Our test server.
 
 	// a non-existing host name
 	config := &Configuration{
@@ -128,8 +128,8 @@ func TestV2HostnameUnresolvable(t *testing.T) { // Our test server.
 	}
 }
 
-// TestV2Timeout tests if the latest client handles timeouts as expected.
-func TestV2Timeout(t *testing.T) {
+// TestTimeout tests if the latest client handles timeouts as expected.
+func TestTimeout(t *testing.T) {
 	// Our test server.
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// enforce a timeout longer than the client's
@@ -161,8 +161,8 @@ func TestV2Timeout(t *testing.T) {
 	}
 }
 
-// TestV2UserAgent tests whether our user-agent header appears in requests.
-func TestV2UserAgent(t *testing.T) {
+// TestUserAgent tests whether our user-agent header appears in requests.
+func TestUserAgent(t *testing.T) {
 	clientConfig := &Configuration{
 		UserAgent: "my own user agent/1.0",
 	}
@@ -191,9 +191,9 @@ func TestV2UserAgent(t *testing.T) {
 	gsClient.CreateAuthToken("email", "password", nil)
 }
 
-// TestV2Forbidden tests out how the latest client gives access to
+// TestForbidden tests out how the latest client gives access to
 // HTTP error details for a 403 error.
-func TestV2Forbidden(t *testing.T) { // Our test server.
+func TestForbidden(t *testing.T) { // Our test server.
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
 		w.WriteHeader(http.StatusForbidden)
@@ -224,9 +224,9 @@ func TestV2Forbidden(t *testing.T) { // Our test server.
 	}
 }
 
-// TestV2Unauthorized tests out how the latest client gives access to
+// TestUnauthorized tests out how the latest client gives access to
 // HTTP error details for a 401 error.
-func TestV2Unauthorized(t *testing.T) { // Our test server.
+func TestUnauthorized(t *testing.T) { // Our test server.
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusUnauthorized)
@@ -256,9 +256,9 @@ func TestV2Unauthorized(t *testing.T) { // Our test server.
 	}
 }
 
-// TestV2AuxiliaryParams checks whether the client carries through our auxiliary
+// TestAuxiliaryParams checks whether the client carries through our auxiliary
 // parameters.
-func TestV2AuxiliaryParams(t *testing.T) { // Our test server.
+func TestAuxiliaryParams(t *testing.T) { // Our test server.
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
 		if r.Header.Get("X-Request-ID") != "request-id" {
@@ -294,9 +294,9 @@ func TestV2AuxiliaryParams(t *testing.T) { // Our test server.
 	gsClient.CreateAuthToken("foo", "bar", ap)
 }
 
-// TestV2CreateAuthToken checks out how creating an auth token works in
+// TestCreateAuthToken checks out how creating an auth token works in
 // our new client.
-func TestV2CreateAuthToken(t *testing.T) { // Our test server.
+func TestCreateAuthToken(t *testing.T) { // Our test server.
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -323,9 +323,9 @@ func TestV2CreateAuthToken(t *testing.T) { // Our test server.
 	}
 }
 
-// TestV2DeleteAuthToken checks out how to issue an authenticted request
+// TestDeleteAuthToken checks out how to issue an authenticted request
 // using the new client.
-func TestV2DeleteAuthToken(t *testing.T) { // Our test server.
+func TestDeleteAuthToken(t *testing.T) { // Our test server.
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") != "giantswarm test-token" {
 			t.Error("Bad authorization header:", r.Header.Get("Authorization"))
@@ -474,9 +474,9 @@ selected_endpoint: ` + mockServer.URL
 		t.Error(err)
 	}
 
-	clientV2, err := NewWithConfig(mockServer.URL, "")
+	clientWrapper, err := NewWithConfig(mockServer.URL, "")
 
-	clusterID, err := clientV2.GetDefaultCluster(nil)
+	clusterID, err := clientWrapper.GetDefaultCluster(nil)
 	if err != nil {
 		t.Error(err)
 	}

--- a/client/error.go
+++ b/client/error.go
@@ -10,14 +10,14 @@ import (
 	"github.com/giantswarm/gsctl/client/clienterror"
 )
 
-// clientV2NotInitializedError is used when the new client hasn't been initialized.
-var clientV2NotInitializedError = &microerror.Error{
-	Kind: "clientV2NotInitializedError",
+// clientNotInitializedError is used when the new client hasn't been initialized.
+var clientNotInitializedError = &microerror.Error{
+	Kind: "clientNotInitializedError",
 }
 
-// IsClientV2NotInitializedError asserts clientV2NotInitializedError.
-func IsClientV2NotInitializedError(err error) bool {
-	return microerror.Cause(err) == clientV2NotInitializedError
+// IsClientNotInitializedError asserts clientNotInitializedError.
+func IsClientNotInitializedError(err error) bool {
+	return microerror.Cause(err) == clientNotInitializedError
 }
 
 // endpointInvalidError is used if an endpoint string is not a valid URL.
@@ -59,7 +59,6 @@ func HandleErrors(err error) {
 	var headline = ""
 	var subtext = ""
 
-	// V2 client error handling
 	if convertedErr, ok := microerror.Cause(err).(*clienterror.APIError); ok {
 		headline = convertedErr.ErrorMessage
 		subtext = convertedErr.ErrorDetails

--- a/commands/errors/handling.go
+++ b/commands/errors/handling.go
@@ -21,7 +21,7 @@ func HandleCommonErrors(err error) {
 	var headline = ""
 	var subtext = ""
 
-	// V2 client error handling
+	// client error handling
 	if convertedErr, ok := microerror.Cause(err).(*clienterror.APIError); ok {
 		headline = convertedErr.ErrorMessage
 		subtext = convertedErr.ErrorDetails


### PR DESCRIPTION
We had still a lot of mentions of "v2" in tests and comments, which only made sense while we had two different versions of the API client in use in parallel. This PR should remove the remainders.