### PR TITLE
Use clienterror matchers everywhere

### DIFF
--- a/client/clienterror/matcher.go
+++ b/client/clienterror/matcher.go
@@ -1,6 +1,10 @@
 package clienterror
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/giantswarm/microerror"
+)
 
 // IsMalformedResponseError checks whether the error is
 // "Malformed response", which can mean several things.
@@ -14,6 +18,9 @@ func IsBadRequestError(err error) bool {
 	if clientErr, ok := err.(*APIError); ok {
 		return clientErr.HTTPStatusCode == http.StatusBadRequest
 	}
+	if apiErr, apiErrOK := microerror.Cause(err).(*APIError); apiErrOK {
+		return apiErr.HTTPStatusCode == http.StatusBadRequest
+	}
 	return false
 }
 
@@ -22,6 +29,9 @@ func IsBadRequestError(err error) bool {
 func IsUnauthorizedError(err error) bool {
 	if clientErr, ok := err.(*APIError); ok {
 		return clientErr.HTTPStatusCode == http.StatusUnauthorized
+	}
+	if apiErr, apiErrOK := microerror.Cause(err).(*APIError); apiErrOK {
+		return apiErr.HTTPStatusCode == http.StatusUnauthorized
 	}
 	return false
 }
@@ -32,6 +42,9 @@ func IsAccessForbiddenError(err error) bool {
 	if clientErr, ok := err.(*APIError); ok {
 		return clientErr.HTTPStatusCode == http.StatusForbidden
 	}
+	if apiErr, apiErrOK := microerror.Cause(err).(*APIError); apiErrOK {
+		return apiErr.HTTPStatusCode == http.StatusForbidden
+	}
 	return false
 }
 
@@ -40,6 +53,9 @@ func IsAccessForbiddenError(err error) bool {
 func IsNotFoundError(err error) bool {
 	if clientErr, ok := err.(*APIError); ok {
 		return clientErr.HTTPStatusCode == http.StatusNotFound
+	}
+	if apiErr, apiErrOK := microerror.Cause(err).(*APIError); apiErrOK {
+		return apiErr.HTTPStatusCode == http.StatusNotFound
 	}
 	return false
 }
@@ -50,6 +66,9 @@ func IsConflictError(err error) bool {
 	if clientErr, ok := err.(*APIError); ok {
 		return clientErr.HTTPStatusCode == http.StatusConflict
 	}
+	if apiErr, apiErrOK := microerror.Cause(err).(*APIError); apiErrOK {
+		return apiErr.HTTPStatusCode == http.StatusConflict
+	}
 	return false
 }
 
@@ -58,6 +77,9 @@ func IsConflictError(err error) bool {
 func IsInternalServerError(err error) bool {
 	if clientErr, ok := err.(*APIError); ok {
 		return clientErr.HTTPStatusCode == http.StatusInternalServerError
+	}
+	if apiErr, apiErrOK := microerror.Cause(err).(*APIError); apiErrOK {
+		return apiErr.HTTPStatusCode == http.StatusInternalServerError
 	}
 	return false
 }

--- a/client/clienterror/matcher.go
+++ b/client/clienterror/matcher.go
@@ -17,6 +17,15 @@ func IsBadRequestError(err error) bool {
 	return false
 }
 
+// IsUnauthorizedError checks whether the error
+// is an HTTP 401 error.
+func IsUnauthorizedError(err error) bool {
+	if clientErr, ok := err.(*APIError); ok {
+		return clientErr.HTTPStatusCode == http.StatusUnauthorized
+	}
+	return false
+}
+
 // IsAccessForbiddenError checks whether the error
 // is an HTTP 403 error.
 func IsAccessForbiddenError(err error) bool {
@@ -31,6 +40,24 @@ func IsAccessForbiddenError(err error) bool {
 func IsNotFoundError(err error) bool {
 	if clientErr, ok := err.(*APIError); ok {
 		return clientErr.HTTPStatusCode == http.StatusNotFound
+	}
+	return false
+}
+
+// IsConflictError checks whether the error
+// is an HTTP 409 error.
+func IsConflictError(err error) bool {
+	if clientErr, ok := err.(*APIError); ok {
+		return clientErr.HTTPStatusCode == http.StatusConflict
+	}
+	return false
+}
+
+// IsInternalServerError checks whether the error
+// is an HTTP 500 error.
+func IsInternalServerError(err error) bool {
+	if clientErr, ok := err.(*APIError); ok {
+		return clientErr.HTTPStatusCode == http.StatusInternalServerError
 	}
 	return false
 }

--- a/commands/create/keypair/command.go
+++ b/commands/create/keypair/command.go
@@ -3,7 +3,6 @@ package keypair
 
 import (
 	"fmt"
-	"net/http"
 	"os"
 	"regexp"
 
@@ -245,16 +244,14 @@ func createKeypair(args Arguments) (createKeypairResult, error) {
 	response, err := clientWrapper.CreateKeyPair(args.clusterID, addKeyPairBody, auxParams)
 	if err != nil {
 		// create specific error types for cases we care about
-		if clientErr, ok := err.(*clienterror.APIError); ok {
-			if clientErr.HTTPStatusCode == http.StatusForbidden {
-				return result, microerror.Mask(errors.AccessForbiddenError)
-			} else if clientErr.HTTPStatusCode == http.StatusNotFound {
-				return result, microerror.Mask(errors.ClusterNotFoundError)
-			} else if clientErr.HTTPStatusCode == http.StatusForbidden {
-				return result, microerror.Mask(errors.AccessForbiddenError)
-			} else if clientErr.HTTPStatusCode == http.StatusBadRequest {
-				return result, microerror.Maskf(errors.BadRequestError, clientErr.ErrorDetails)
-			}
+		if clienterror.IsAccessForbiddenError(err) {
+			return result, microerror.Mask(errors.AccessForbiddenError)
+		}
+		if clienterror.IsBadRequestError(err) {
+			return result, microerror.Maskf(errors.BadRequestError, err.Error())
+		}
+		if clienterror.IsNotFoundError(err) {
+			return result, microerror.Mask(errors.ClusterNotFoundError)
 		}
 
 		return result, microerror.Mask(err)

--- a/commands/create/kubeconfig/command.go
+++ b/commands/create/kubeconfig/command.go
@@ -361,6 +361,7 @@ func createKubeconfig(ctx context.Context, args Arguments) (createKubeconfigResu
 	// get cluster details
 	clusterDetailsResponse, err := clientWrapper.GetClusterV4(args.clusterID, auxParams)
 	if err != nil {
+		// TODO: return properly typed errors
 		if clientErr, ok := err.(*clienterror.APIError); ok {
 			return result, microerror.Maskf(clientErr,
 				fmt.Sprintf("HTTP Status: %d, %s", clientErr.HTTPStatusCode, clientErr.ErrorMessage))

--- a/commands/create/nodepool/command.go
+++ b/commands/create/nodepool/command.go
@@ -312,6 +312,9 @@ func createNodePool(args Arguments) (*result, error) {
 		if clienterror.IsBadRequestError(err) {
 			return nil, microerror.Maskf(errors.BadRequestError, err.Error())
 		}
+		if clienterror.IsInternalServerError(err) {
+			return nil, microerror.Maskf(errors.InternalServerError, err.Error())
+		}
 
 		return r, microerror.Mask(err)
 	}

--- a/commands/delete/cluster/command.go
+++ b/commands/delete/cluster/command.go
@@ -3,7 +3,6 @@ package cluster
 
 import (
 	"fmt"
-	"net/http"
 	"os"
 
 	"github.com/fatih/color"
@@ -214,12 +213,11 @@ func deleteCluster(args Arguments) (bool, error) {
 	_, err = clientWrapper.DeleteCluster(clusterID, auxParams)
 	if err != nil {
 		// create specific error types for cases we care about
-		if clientErr, ok := err.(*clienterror.APIError); ok {
-			if clientErr.HTTPStatusCode == http.StatusForbidden {
-				return false, microerror.Mask(errors.AccessForbiddenError)
-			} else if clientErr.HTTPStatusCode == http.StatusNotFound {
-				return false, microerror.Mask(errors.ClusterNotFoundError)
-			}
+		if clienterror.IsAccessForbiddenError(err) {
+			return false, microerror.Mask(errors.AccessForbiddenError)
+		}
+		if clienterror.IsNotFoundError(err) {
+			return false, microerror.Mask(errors.ClusterNotFoundError)
 		}
 
 		return false, microerror.Maskf(errors.CouldNotDeleteClusterError, err.Error())

--- a/commands/errors/errors.go
+++ b/commands/errors/errors.go
@@ -3,8 +3,6 @@
 package errors
 
 import (
-	"net/http"
-
 	"github.com/giantswarm/gsctl/client/clienterror"
 	"github.com/giantswarm/microerror"
 )
@@ -110,8 +108,7 @@ var ClusterNotFoundError = &microerror.Error{
 // IsClusterNotFoundError asserts ClusterNotFoundError.
 func IsClusterNotFoundError(err error) bool {
 	c := microerror.Cause(err)
-	clientErr, ok := c.(*clienterror.APIError)
-	if ok && clientErr.HTTPStatusCode == http.StatusNotFound {
+	if clienterror.IsNotFoundError(err) {
 		return true
 	}
 	if c == ClusterNotFoundError {
@@ -151,8 +148,7 @@ var InternalServerError = &microerror.Error{
 // IsInternalServerError asserts InternalServerError.
 func IsInternalServerError(err error) bool {
 	c := microerror.Cause(err)
-	clientErr, ok := c.(*clienterror.APIError)
-	if ok && clientErr.HTTPStatusCode == http.StatusInternalServerError {
+	if clienterror.IsInternalServerError(err) {
 		return true
 	}
 	if c == InternalServerError {
@@ -181,8 +177,7 @@ var NotAuthorizedError = &microerror.Error{
 // IsNotAuthorizedError asserts NotAuthorizedError.
 func IsNotAuthorizedError(err error) bool {
 	c := microerror.Cause(err)
-	clientErr, ok := c.(*clienterror.APIError)
-	if ok && clientErr.HTTPStatusCode == http.StatusUnauthorized {
+	if clienterror.IsUnauthorizedError(err) {
 		return true
 	}
 	if c == NotAuthorizedError {
@@ -268,8 +263,7 @@ var OrganizationNotFoundError = &microerror.Error{
 // IsOrganizationNotFoundError asserts OrganizationNotFoundError
 func IsOrganizationNotFoundError(err error) bool {
 	c := microerror.Cause(err)
-	clientErr, ok := c.(*clienterror.APIError)
-	if ok && clientErr.HTTPStatusCode == http.StatusNotFound {
+	if clienterror.IsNotFoundError(err) {
 		return true
 	}
 	if c == OrganizationNotFoundError {
@@ -471,8 +465,7 @@ var AccessForbiddenError = &microerror.Error{
 // IsAccessForbiddenError asserts AccessForbiddenError
 func IsAccessForbiddenError(err error) bool {
 	c := microerror.Cause(err)
-	clientErr, ok := c.(*clienterror.APIError)
-	if ok && clientErr.HTTPStatusCode == http.StatusForbidden {
+	if clienterror.IsAccessForbiddenError(err) {
 		return true
 	}
 	if c == AccessForbiddenError {

--- a/commands/list/clusters/command.go
+++ b/commands/list/clusters/command.go
@@ -3,7 +3,6 @@ package clusters
 
 import (
 	"fmt"
-	"net/http"
 	"os"
 	"sort"
 	"strings"
@@ -116,13 +115,11 @@ func clustersTable(args Arguments) (string, error) {
 
 	response, err := clientWrapper.GetClusters(auxParams)
 	if err != nil {
-		if clientErr, ok := err.(*clienterror.APIError); ok {
-			switch clientErr.HTTPStatusCode {
-			case http.StatusUnauthorized:
-				return "", microerror.Mask(errors.NotAuthorizedError)
-			case http.StatusForbidden:
-				return "", microerror.Mask(errors.AccessForbiddenError)
-			}
+		if clienterror.IsUnauthorizedError(err) {
+			return "", microerror.Mask(errors.NotAuthorizedError)
+		}
+		if clienterror.IsAccessForbiddenError(err) {
+			return "", microerror.Mask(errors.AccessForbiddenError)
 		}
 
 		return "", microerror.Mask(err)

--- a/commands/list/organizations/command.go
+++ b/commands/list/organizations/command.go
@@ -3,7 +3,6 @@ package organizations
 
 import (
 	"fmt"
-	"net/http"
 	"os"
 	"sort"
 
@@ -112,12 +111,11 @@ func orgsTable(args Arguments) (string, error) {
 
 	response, err := clientWrapper.GetOrganizations(auxParams)
 	if err != nil {
-		if clientErr, ok := err.(*clienterror.APIError); ok {
-			if clientErr.HTTPStatusCode == http.StatusUnauthorized {
-				return "", microerror.Mask(errors.NotAuthorizedError)
-			} else if clientErr.HTTPStatusCode == http.StatusForbidden {
-				return "", microerror.Mask(errors.AccessForbiddenError)
-			}
+		if clienterror.IsUnauthorizedError(err) {
+			return "", microerror.Mask(errors.NotAuthorizedError)
+		}
+		if clienterror.IsAccessForbiddenError(err) {
+			return "", microerror.Mask(errors.AccessForbiddenError)
 		}
 
 		return "", microerror.Mask(err)

--- a/commands/list/releases/command.go
+++ b/commands/list/releases/command.go
@@ -3,7 +3,6 @@ package releases
 
 import (
 	"fmt"
-	"net/http"
 	"os"
 	"sort"
 	"strings"
@@ -226,12 +225,11 @@ func listReleases(args Arguments) ([]*models.V4ReleaseListItem, error) {
 	response, err := clientWrapper.GetReleases(auxParams)
 	if err != nil {
 		// create specific error types for cases we care about
-		if clientErr, ok := err.(*clienterror.APIError); ok {
-			if clientErr.HTTPStatusCode >= http.StatusInternalServerError {
-				return nil, microerror.Maskf(errors.InternalServerError, err.Error())
-			} else if clientErr.HTTPStatusCode == http.StatusUnauthorized {
-				return nil, microerror.Mask(errors.NotAuthorizedError)
-			}
+		if clienterror.IsInternalServerError(err) {
+			return nil, microerror.Maskf(errors.InternalServerError, err.Error())
+		}
+		if clienterror.IsUnauthorizedError(err) {
+			return nil, microerror.Mask(errors.NotAuthorizedError)
 		}
 
 		return nil, microerror.Mask(err)

--- a/commands/login/command_test.go
+++ b/commands/login/command_test.go
@@ -110,13 +110,9 @@ func Test_LoginInvalidPassword(t *testing.T) {
 	}
 
 	_, err = login(args)
-	convertedError, ok := err.(*clienterror.APIError)
-	if !ok {
-		t.Error("Error type assertion to *clienterror.APIError failed")
-	}
 
-	if convertedError.HTTPStatusCode != http.StatusUnauthorized {
-		t.Errorf("Expected error 401, got %#v", convertedError.HTTPStatusCode)
+	if !clienterror.IsUnauthorizedError(err) {
+		t.Errorf("Expected error 401, got %#v", err)
 	}
 }
 
@@ -205,7 +201,7 @@ func Test_LoginInactiveAccount(t *testing.T) {
 		t.Error("Error type assertion to *clienterror.APIError failed")
 	}
 
-	if convertedError.HTTPStatusCode != http.StatusUnauthorized {
+	if !clienterror.IsUnauthorizedError(err) {
 		t.Errorf("Expected error 401, got %#v", convertedError.HTTPStatusCode)
 	}
 

--- a/commands/login/sso.go
+++ b/commands/login/sso.go
@@ -50,6 +50,7 @@ func loginSSO(args Arguments) (loginResult, error) {
 		if clienterror.IsAccessForbiddenError(err) {
 			return loginResult{}, microerror.Mask(errors.AccessForbiddenError)
 		}
+		// Return any other API errors raw, so we can learn what else can happen.
 		if clientErr, ok := err.(*clienterror.APIError); ok {
 			return loginResult{}, clientErr
 		}

--- a/commands/login/sso.go
+++ b/commands/login/sso.go
@@ -3,7 +3,6 @@ package login
 import (
 	"fmt"
 	"math/rand"
-	"net/http"
 	"time"
 
 	"github.com/fatih/color"
@@ -48,11 +47,10 @@ func loginSSO(args Arguments) (loginResult, error) {
 			}
 		}
 
+		if clienterror.IsAccessForbiddenError(err) {
+			return loginResult{}, microerror.Mask(errors.AccessForbiddenError)
+		}
 		if clientErr, ok := err.(*clienterror.APIError); ok {
-			if clientErr.HTTPStatusCode == http.StatusForbidden {
-				return loginResult{}, microerror.Mask(errors.AccessForbiddenError)
-			}
-
 			return loginResult{}, clientErr
 		}
 

--- a/commands/logout/command.go
+++ b/commands/logout/command.go
@@ -3,7 +3,6 @@ package logout
 
 import (
 	"fmt"
-	"net/http"
 	"os"
 
 	"github.com/fatih/color"
@@ -71,11 +70,9 @@ func printResult(cmd *cobra.Command, extraArgs []string) {
 
 		// Special treatment: We ignore the fact that the user was not logged in
 		// and act as if she just logged out.
-		if clientError, ok := err.(*clienterror.APIError); ok {
-			if clientError.HTTPStatusCode == http.StatusUnauthorized {
-				fmt.Printf("You have logged out from endpoint %s.\n", color.CyanString(logoutArgs.apiEndpoint))
-				os.Exit(0)
-			}
+		if clienterror.IsUnauthorizedError(err) {
+			fmt.Printf("You have logged out from endpoint %s.\n", color.CyanString(logoutArgs.apiEndpoint))
+			os.Exit(0)
 		}
 
 		errors.HandleCommonErrors(err)

--- a/commands/logout/command_test.go
+++ b/commands/logout/command_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/giantswarm/microerror"
 	"github.com/spf13/afero"
 
 	"github.com/giantswarm/gsctl/client/clienterror"
@@ -60,11 +59,8 @@ func Test_LogoutInvalidToken(t *testing.T) {
 
 	err = logout(logoutArgs)
 
-	clientAPIErr, clientAPIErrOK := microerror.Cause(err).(*clienterror.APIError)
-	if !clientAPIErrOK {
-		t.Error("Type assertion to *clienterror.APIError failed. Error in unexpected type.")
-	} else if clientAPIErr.HTTPStatusCode != http.StatusUnauthorized {
-		t.Errorf("Unexpected HTTP status code: %d", clientAPIErr.HTTPStatusCode)
+	if !clienterror.IsUnauthorizedError(err) {
+		t.Errorf("Unexpected error type. Expected IsUnauthorizedError, got: %#v", err)
 	}
 }
 

--- a/commands/show/cluster/command.go
+++ b/commands/show/cluster/command.go
@@ -3,7 +3,6 @@ package cluster
 
 import (
 	"fmt"
-	"net/http"
 	"os"
 	"sort"
 	"strings"
@@ -116,17 +115,17 @@ func getClusterDetailsV4(args Arguments) (*models.V4ClusterDetailsResponse, erro
 
 	response, err := clientWrapper.GetClusterV4(args.clusterID, auxParams)
 	if err != nil {
-		if clientErr, ok := err.(*clienterror.APIError); ok {
-			switch clientErr.HTTPStatusCode {
-			case http.StatusForbidden:
-				return nil, microerror.Mask(errors.AccessForbiddenError)
-			case http.StatusUnauthorized:
-				return nil, microerror.Mask(errors.NotAuthorizedError)
-			case http.StatusNotFound:
-				return nil, microerror.Mask(errors.ClusterNotFoundError)
-			case http.StatusInternalServerError:
-				return nil, microerror.Mask(errors.InternalServerError)
-			}
+		if clienterror.IsAccessForbiddenError(err) {
+			return nil, microerror.Mask(errors.AccessForbiddenError)
+		}
+		if clienterror.IsUnauthorizedError(err) {
+			return nil, microerror.Mask(errors.NotAuthorizedError)
+		}
+		if clienterror.IsNotFoundError(err) {
+			return nil, microerror.Mask(errors.ClusterNotFoundError)
+		}
+		if clienterror.IsInternalServerError(err) {
+			return nil, microerror.Maskf(errors.InternalServerError, err.Error())
 		}
 
 		return nil, microerror.Mask(err)
@@ -148,17 +147,17 @@ func getClusterDetailsV5(args Arguments) (*models.V5ClusterDetailsResponse, erro
 
 	response, err := clientWrapper.GetClusterV5(args.clusterID, auxParams)
 	if err != nil {
-		if clientErr, ok := err.(*clienterror.APIError); ok {
-			switch clientErr.HTTPStatusCode {
-			case http.StatusForbidden:
-				return nil, microerror.Mask(errors.AccessForbiddenError)
-			case http.StatusUnauthorized:
-				return nil, microerror.Mask(errors.NotAuthorizedError)
-			case http.StatusNotFound:
-				return nil, microerror.Mask(errors.ClusterNotFoundError)
-			case http.StatusInternalServerError:
-				return nil, microerror.Mask(errors.InternalServerError)
-			}
+		if clienterror.IsAccessForbiddenError(err) {
+			return nil, microerror.Mask(errors.AccessForbiddenError)
+		}
+		if clienterror.IsUnauthorizedError(err) {
+			return nil, microerror.Mask(errors.NotAuthorizedError)
+		}
+		if clienterror.IsNotFoundError(err) {
+			return nil, microerror.Mask(errors.ClusterNotFoundError)
+		}
+		if clienterror.IsInternalServerError(err) {
+			return nil, microerror.Mask(errors.InternalServerError)
 		}
 
 		return nil, microerror.Mask(err)
@@ -178,17 +177,17 @@ func getOrgCredentials(orgName, credentialID string, args Arguments) (*models.V4
 
 	response, err := clientWrapper.GetCredential(orgName, credentialID, auxParams)
 	if err != nil {
-		if clientErr, ok := err.(*clienterror.APIError); ok {
-			switch clientErr.HTTPStatusCode {
-			case http.StatusForbidden:
-				return nil, microerror.Mask(errors.AccessForbiddenError)
-			case http.StatusUnauthorized:
-				return nil, microerror.Mask(errors.NotAuthorizedError)
-			case http.StatusNotFound:
-				return nil, microerror.Mask(errors.CredentialNotFoundError)
-			case http.StatusInternalServerError:
-				return nil, microerror.Mask(errors.InternalServerError)
-			}
+		if clienterror.IsAccessForbiddenError(err) {
+			return nil, microerror.Mask(errors.AccessForbiddenError)
+		}
+		if clienterror.IsUnauthorizedError(err) {
+			return nil, microerror.Mask(errors.NotAuthorizedError)
+		}
+		if clienterror.IsNotFoundError(err) {
+			return nil, microerror.Mask(errors.CredentialNotFoundError)
+		}
+		if clienterror.IsInternalServerError(err) {
+			return nil, microerror.Maskf(errors.InternalServerError, err.Error())
 		}
 
 		return nil, microerror.Mask(err)

--- a/commands/show/release/command.go
+++ b/commands/show/release/command.go
@@ -3,7 +3,6 @@ package release
 
 import (
 	"fmt"
-	"net/http"
 	"os"
 
 	"github.com/fatih/color"
@@ -106,12 +105,11 @@ func getReleaseDetails(args Arguments) (*models.V4ReleaseListItem, error) {
 	response, err := clientWrapper.GetReleases(auxParams)
 	if err != nil {
 		// create specific error types for cases we care about
-		if clientErr, ok := err.(*clienterror.APIError); ok {
-			if clientErr.HTTPStatusCode >= http.StatusInternalServerError {
-				return nil, microerror.Maskf(errors.InternalServerError, err.Error())
-			} else if clientErr.HTTPStatusCode == http.StatusUnauthorized {
-				return nil, microerror.Mask(errors.NotAuthorizedError)
-			}
+		if clienterror.IsInternalServerError(err) {
+			return nil, microerror.Maskf(errors.InternalServerError, err.Error())
+		}
+		if clienterror.IsUnauthorizedError(err) {
+			return nil, microerror.Mask(errors.NotAuthorizedError)
 		}
 
 		return nil, microerror.Mask(err)

--- a/commands/update/organization/setcredentials/command.go
+++ b/commands/update/organization/setcredentials/command.go
@@ -2,7 +2,6 @@ package setcredentials
 
 import (
 	"fmt"
-	"net/http"
 	"os"
 	"strings"
 
@@ -190,13 +189,13 @@ func verifyPreconditions(args Arguments) error {
 
 	response, err := clientWrapper.GetInfo(auxParams)
 	if err != nil {
-		if clientErr, ok := err.(*clienterror.APIError); ok {
-			if clientErr.HTTPStatusCode == http.StatusUnauthorized {
-				return microerror.Mask(errors.NotAuthorizedError)
-			} else if clientErr.HTTPStatusCode == http.StatusForbidden {
-				return microerror.Mask(errors.AccessForbiddenError)
-			}
+		if clienterror.IsUnauthorizedError(err) {
+			return microerror.Mask(errors.NotAuthorizedError)
 		}
+		if clienterror.IsAccessForbiddenError(err) {
+			return microerror.Mask(errors.AccessForbiddenError)
+		}
+
 		return microerror.Mask(err)
 	}
 
@@ -249,13 +248,13 @@ func verifyPreconditions(args Arguments) error {
 	orgsResponse, err := clientWrapper.GetOrganizations(auxParams)
 	{
 		if err != nil {
-			if clientErr, ok := err.(*clienterror.APIError); ok {
-				if clientErr.HTTPStatusCode == http.StatusUnauthorized {
-					return microerror.Mask(errors.NotAuthorizedError)
-				} else if clientErr.HTTPStatusCode == http.StatusForbidden {
-					return microerror.Mask(errors.AccessForbiddenError)
-				}
+			if clienterror.IsUnauthorizedError(err) {
+				return microerror.Mask(errors.NotAuthorizedError)
 			}
+			if clienterror.IsAccessForbiddenError(err) {
+				return microerror.Mask(errors.AccessForbiddenError)
+			}
+
 			return microerror.Mask(err)
 		}
 
@@ -346,11 +345,10 @@ func setOrgCredentials(args Arguments) (*setOrgCredentialsResult, error) {
 	fmt.Printf("response: %#v\n", response)
 	fmt.Printf("err: %#v\n", err)
 	if err != nil {
-		if clientErr, ok := err.(*clienterror.APIError); ok {
-			if clientErr.HTTPStatusCode == http.StatusConflict {
-				return nil, microerror.Mask(errors.CredentialsAlreadySetError)
-			}
+		if clienterror.IsConflictError(err) {
+			return nil, microerror.Mask(errors.CredentialsAlreadySetError)
 		}
+
 		return nil, microerror.Mask(err)
 	}
 


### PR DESCRIPTION
To simplify and align error matching for errors generated in the `clienterrror` sub package, this PR 

- introduces some more matchers
- makes the matches handle more cases
- and applies them everywhere.