### PR TITLE
Rename flags variables to remove `Cmd` prefix

### DIFF
--- a/commands/create/cluster/command.go
+++ b/commands/create/cluster/command.go
@@ -50,9 +50,9 @@ type Arguments struct {
 }
 
 func collectArguments() Arguments {
-	endpoint := config.Config.ChooseEndpoint(flags.CmdAPIEndpoint)
-	token := config.Config.ChooseToken(endpoint, flags.CmdToken)
-	scheme := config.Config.ChooseScheme(endpoint, flags.CmdToken)
+	endpoint := config.Config.ChooseEndpoint(flags.APIEndpoint)
+	token := config.Config.ChooseToken(endpoint, flags.Token)
+	scheme := config.Config.ChooseScheme(endpoint, flags.Token)
 
 	return Arguments{
 		apiEndpoint:             endpoint,
@@ -61,20 +61,20 @@ func collectArguments() Arguments {
 		dryRun:                  cmdDryRun,
 		inputYAMLFile:           cmdInputYAMLFile,
 		fileSystem:              config.FileSystem,
-		numWorkers:              flags.CmdNumWorkers,
+		numWorkers:              flags.NumWorkers,
 		owner:                   cmdOwner,
-		releaseVersion:          flags.CmdRelease,
+		releaseVersion:          flags.Release,
 		scheme:                  scheme,
 		token:                   token,
-		userProvidedToken:       flags.CmdToken,
-		verbose:                 flags.CmdVerbose,
-		wokerAwsEc2InstanceType: flags.CmdWorkerAwsEc2InstanceType,
+		userProvidedToken:       flags.Token,
+		verbose:                 flags.Verbose,
+		wokerAwsEc2InstanceType: flags.WorkerAwsEc2InstanceType,
 		wokerAzureVMSize:        cmdWorkerAzureVMSize,
-		workerMemorySizeGB:      flags.CmdWorkerMemorySizeGB,
-		workerNumCPUs:           flags.CmdWorkerNumCPUs,
-		workersMax:              flags.CmdWorkersMax,
-		workersMin:              flags.CmdWorkersMin,
-		workerStorageSizeGB:     flags.CmdWorkerStorageSizeGB,
+		workerMemorySizeGB:      flags.WorkerMemorySizeGB,
+		workerNumCPUs:           flags.WorkerNumCPUs,
+		workersMax:              flags.WorkersMax,
+		workersMin:              flags.WorkersMin,
+		workerStorageSizeGB:     flags.WorkerStorageSizeGB,
 	}
 }
 
@@ -158,15 +158,15 @@ func init() {
 	Command.Flags().StringVarP(&cmdInputYAMLFile, "file", "f", "", "Path to a cluster definition YAML file")
 	Command.Flags().StringVarP(&cmdClusterName, "name", "n", "", "Cluster name")
 	Command.Flags().StringVarP(&cmdOwner, "owner", "o", "", "Organization to own the cluster")
-	Command.Flags().StringVarP(&flags.CmdRelease, "release", "r", "", "Release version to use, e. g. '1.2.3'. Defaults to the latest. See 'gsctl list releases --help' for details.")
-	Command.Flags().IntVarP(&flags.CmdNumWorkers, "num-workers", "", 0, "Shorthand to set --workers-min and --workers-max to the same value. Can't be used with -f|--file.")
-	Command.Flags().Int64VarP(&flags.CmdWorkersMin, "workers-min", "", 0, "Minimum number of worker nodes. Can't be used with -f|--file.")
-	Command.Flags().Int64VarP(&flags.CmdWorkersMax, "workers-max", "", 0, "Maximum number of worker nodes. Can't be used with -f|--file.")
-	Command.Flags().StringVarP(&flags.CmdWorkerAwsEc2InstanceType, "aws-instance-type", "", "", "EC2 instance type to use for workers (AWS only), e. g. 'm3.large'")
+	Command.Flags().StringVarP(&flags.Release, "release", "r", "", "Release version to use, e. g. '1.2.3'. Defaults to the latest. See 'gsctl list releases --help' for details.")
+	Command.Flags().IntVarP(&flags.NumWorkers, "num-workers", "", 0, "Shorthand to set --workers-min and --workers-max to the same value. Can't be used with -f|--file.")
+	Command.Flags().Int64VarP(&flags.WorkersMin, "workers-min", "", 0, "Minimum number of worker nodes. Can't be used with -f|--file.")
+	Command.Flags().Int64VarP(&flags.WorkersMax, "workers-max", "", 0, "Maximum number of worker nodes. Can't be used with -f|--file.")
+	Command.Flags().StringVarP(&flags.WorkerAwsEc2InstanceType, "aws-instance-type", "", "", "EC2 instance type to use for workers (AWS only), e. g. 'm3.large'")
 	Command.Flags().StringVarP(&cmdWorkerAzureVMSize, "azure-vm-size", "", "", "VmSize to use for workers (Azure only), e. g. 'Standard_D2s_v3'")
-	Command.Flags().IntVarP(&flags.CmdWorkerNumCPUs, "num-cpus", "", 0, "Number of CPU cores per worker node. Can't be used with -f|--file.")
-	Command.Flags().Float32VarP(&flags.CmdWorkerMemorySizeGB, "memory-gb", "", 0, "RAM per worker node. Can't be used with -f|--file.")
-	Command.Flags().Float32VarP(&flags.CmdWorkerStorageSizeGB, "storage-gb", "", 0, "Local storage size per worker node. Can't be used with -f|--file.")
+	Command.Flags().IntVarP(&flags.WorkerNumCPUs, "num-cpus", "", 0, "Number of CPU cores per worker node. Can't be used with -f|--file.")
+	Command.Flags().Float32VarP(&flags.WorkerMemorySizeGB, "memory-gb", "", 0, "RAM per worker node. Can't be used with -f|--file.")
+	Command.Flags().Float32VarP(&flags.WorkerStorageSizeGB, "storage-gb", "", 0, "Local storage size per worker node. Can't be used with -f|--file.")
 	Command.Flags().BoolVarP(&cmdDryRun, "dry-run", "", false, "If set, the cluster won't be created. Useful with -v|--verbose.")
 }
 

--- a/commands/create/cluster/command_test.go
+++ b/commands/create/cluster/command_test.go
@@ -303,7 +303,7 @@ func Test_CreateClusterExecutionFailures(t *testing.T) {
 		defer mockServer.Close()
 
 		// client
-		flags.CmdAPIEndpoint = mockServer.URL // required to make InitClient() work
+		flags.APIEndpoint = mockServer.URL // required to make InitClient() work
 		testCase.inputArgs.apiEndpoint = mockServer.URL
 
 		err := validatePreConditions(*testCase.inputArgs)

--- a/commands/create/keypair/command.go
+++ b/commands/create/keypair/command.go
@@ -55,16 +55,16 @@ type Arguments struct {
 // collectArguments puts together arguments for our business function
 // based on command line flags and config.
 func collectArguments() (Arguments, error) {
-	endpoint := config.Config.ChooseEndpoint(flags.CmdAPIEndpoint)
-	token := config.Config.ChooseToken(endpoint, flags.CmdToken)
-	scheme := config.Config.ChooseScheme(endpoint, flags.CmdToken)
+	endpoint := config.Config.ChooseEndpoint(flags.APIEndpoint)
+	token := config.Config.ChooseToken(endpoint, flags.Token)
+	scheme := config.Config.ChooseScheme(endpoint, flags.Token)
 
-	description := flags.CmdDescription
+	description := flags.Description
 	if description == "" {
 		description = "Added by user " + config.Config.Email + " using 'gsctl create keypair'"
 	}
 
-	ttl, err := util.ParseDuration(flags.CmdTTL)
+	ttl, err := util.ParseDuration(flags.TTL)
 	if errors.IsInvalidDurationError(err) {
 		return Arguments{}, microerror.Mask(errors.InvalidDurationError)
 	} else if errors.IsDurationExceededError(err) {
@@ -76,14 +76,14 @@ func collectArguments() (Arguments, error) {
 	return Arguments{
 		apiEndpoint:              endpoint,
 		authToken:                token,
-		certificateOrganizations: flags.CmdCertificateOrganizations,
-		clusterID:                flags.CmdClusterID,
-		commonNamePrefix:         flags.CmdCNPrefix,
+		certificateOrganizations: flags.CertificateOrganizations,
+		clusterID:                flags.ClusterID,
+		commonNamePrefix:         flags.CNPrefix,
 		description:              description,
 		fileSystem:               config.FileSystem,
 		scheme:                   scheme,
 		ttlHours:                 int32(ttl.Hours()),
-		userProvidedToken:        flags.CmdToken,
+		userProvidedToken:        flags.Token,
 	}, nil
 }
 
@@ -103,11 +103,11 @@ type createKeypairResult struct {
 }
 
 func init() {
-	Command.Flags().StringVarP(&flags.CmdClusterID, "cluster", "c", "", "ID of the cluster to create a key pair for")
-	Command.Flags().StringVarP(&flags.CmdDescription, "description", "d", "", "Description for the key pair")
-	Command.Flags().StringVarP(&flags.CmdCNPrefix, "cn-prefix", "", "", "The common name prefix for the issued certificates 'CN' field.")
-	Command.Flags().StringVarP(&flags.CmdCertificateOrganizations, "certificate-organizations", "", "", "A comma separated list of organizations for the issued certificates 'O' fields.")
-	Command.Flags().StringVarP(&flags.CmdTTL, "ttl", "", "30d", "Lifetime of the created key pair, e.g. 3h. Allowed units: h, d, w, m, y.")
+	Command.Flags().StringVarP(&flags.ClusterID, "cluster", "c", "", "ID of the cluster to create a key pair for")
+	Command.Flags().StringVarP(&flags.Description, "description", "d", "", "Description for the key pair")
+	Command.Flags().StringVarP(&flags.CNPrefix, "cn-prefix", "", "", "The common name prefix for the issued certificates 'CN' field.")
+	Command.Flags().StringVarP(&flags.CertificateOrganizations, "certificate-organizations", "", "", "A comma separated list of organizations for the issued certificates 'O' fields.")
+	Command.Flags().StringVarP(&flags.TTL, "ttl", "", "30d", "Lifetime of the created key pair, e.g. 3h. Allowed units: h, d, w, m, y.")
 
 	Command.MarkFlagRequired("cluster")
 }

--- a/commands/create/kubeconfig/command.go
+++ b/commands/create/kubeconfig/command.go
@@ -100,21 +100,21 @@ type Arguments struct {
 // collectArguments gathers arguments based on command line
 // flags and config and applies defaults.
 func collectArguments() (Arguments, error) {
-	endpoint := config.Config.ChooseEndpoint(flags.CmdAPIEndpoint)
-	token := config.Config.ChooseToken(endpoint, flags.CmdToken)
-	scheme := config.Config.ChooseScheme(endpoint, flags.CmdToken)
+	endpoint := config.Config.ChooseEndpoint(flags.APIEndpoint)
+	token := config.Config.ChooseToken(endpoint, flags.Token)
+	scheme := config.Config.ChooseScheme(endpoint, flags.Token)
 
-	description := flags.CmdDescription
+	description := flags.Description
 	if description == "" {
 		description = "Added by user " + config.Config.Email + " using 'gsctl create kubeconfig'"
 	}
 
 	contextName := cmdKubeconfigContextName
 	if cmdKubeconfigContextName == "" {
-		contextName = "giantswarm-" + flags.CmdClusterID
+		contextName = "giantswarm-" + flags.ClusterID
 	}
 
-	ttl, err := util.ParseDuration(flags.CmdTTL)
+	ttl, err := util.ParseDuration(flags.TTL)
 	if errors.IsInvalidDurationError(err) {
 		return Arguments{}, microerror.Mask(errors.InvalidDurationError)
 	} else if errors.IsDurationExceededError(err) {
@@ -126,17 +126,17 @@ func collectArguments() (Arguments, error) {
 	return Arguments{
 		apiEndpoint:       endpoint,
 		authToken:         token,
-		certOrgs:          flags.CmdCertificateOrganizations,
-		clusterID:         flags.CmdClusterID,
-		cnPrefix:          flags.CmdCNPrefix,
+		certOrgs:          flags.CertificateOrganizations,
+		clusterID:         flags.ClusterID,
+		cnPrefix:          flags.CNPrefix,
 		contextName:       contextName,
 		description:       description,
 		fileSystem:        config.FileSystem,
-		force:             flags.CmdForce,
+		force:             flags.Force,
 		scheme:            scheme,
 		selfContainedPath: cmdKubeconfigSelfContained,
 		ttlHours:          int32(ttl.Hours()),
-		userProvidedToken: flags.CmdToken,
+		userProvidedToken: flags.Token,
 	}, nil
 }
 
@@ -160,14 +160,14 @@ type createKubeconfigResult struct {
 }
 
 func init() {
-	Command.Flags().StringVarP(&flags.CmdClusterID, "cluster", "c", "", "ID of the cluster")
-	Command.Flags().StringVarP(&flags.CmdDescription, "description", "d", "", "Description for the key pair")
-	Command.Flags().StringVarP(&flags.CmdCNPrefix, "cn-prefix", "", "", "The common name prefix for the issued certificates 'CN' field.")
+	Command.Flags().StringVarP(&flags.ClusterID, "cluster", "c", "", "ID of the cluster")
+	Command.Flags().StringVarP(&flags.Description, "description", "d", "", "Description for the key pair")
+	Command.Flags().StringVarP(&flags.CNPrefix, "cn-prefix", "", "", "The common name prefix for the issued certificates 'CN' field.")
 	Command.Flags().StringVarP(&cmdKubeconfigSelfContained, "self-contained", "", "", "Create a self-contained kubectl config with embedded credentials and write it to this path.")
 	Command.Flags().StringVarP(&cmdKubeconfigContextName, "context", "", "", "Set a custom context name. Defaults to 'giantswarm-<cluster-id>'.")
-	Command.Flags().StringVarP(&flags.CmdCertificateOrganizations, "certificate-organizations", "", "", "A comma separated list of organizations for the issued certificates 'O' fields.")
-	Command.Flags().BoolVarP(&flags.CmdForce, "force", "", false, "If set, --self-contained will overwrite existing files without interactive confirmation.")
-	Command.Flags().StringVarP(&flags.CmdTTL, "ttl", "", "30d", "Lifetime of the created key pair, e.g. 3h. Allowed units: h, d, w, m, y.")
+	Command.Flags().StringVarP(&flags.CertificateOrganizations, "certificate-organizations", "", "", "A comma separated list of organizations for the issued certificates 'O' fields.")
+	Command.Flags().BoolVarP(&flags.Force, "force", "", false, "If set, --self-contained will overwrite existing files without interactive confirmation.")
+	Command.Flags().StringVarP(&flags.TTL, "ttl", "", "30d", "Lifetime of the created key pair, e.g. 3h. Allowed units: h, d, w, m, y.")
 
 	Command.MarkFlagRequired("cluster")
 }

--- a/commands/create/kubeconfig/command_test.go
+++ b/commands/create/kubeconfig/command_test.go
@@ -234,7 +234,7 @@ func Test_CreateKubeconfigCustomContext(t *testing.T) {
 		fileSystem:  fs,
 	}
 
-	flags.CmdAPIEndpoint = mockServer.URL
+	flags.APIEndpoint = mockServer.URL
 
 	err = verifyCreateKubeconfigPreconditions(args, []string{})
 	if err != nil {

--- a/commands/create/nodepool/command.go
+++ b/commands/create/nodepool/command.go
@@ -110,9 +110,9 @@ func initFlags() {
 	Command.Flags().StringVarP(&cmdName, "name", "n", "", "name or purpose description of the node pool")
 	Command.Flags().IntVarP(&cmdAvailabilityZonesNum, "num-availability-zones", "", 0, "Number of availability zones to use. Default is 1.")
 	Command.Flags().StringSliceVarP(&cmdAvailabilityZones, "availability-zones", "", nil, "List of availability zones to use, instead of setting a number. Use comma to separate values.")
-	Command.Flags().StringVarP(&flags.CmdWorkerAwsEc2InstanceType, "aws-instance-type", "", "", "EC2 instance type to use for workers, e. g. 'm5.2xlarge'")
-	Command.Flags().Int64VarP(&flags.CmdWorkersMin, "nodes-min", "", 0, "Minimum number of worker nodes for the node pool.")
-	Command.Flags().Int64VarP(&flags.CmdWorkersMax, "nodes-max", "", 0, "Maximum number of worker nodes for the node pool.")
+	Command.Flags().StringVarP(&flags.WorkerAwsEc2InstanceType, "aws-instance-type", "", "", "EC2 instance type to use for workers, e. g. 'm5.2xlarge'")
+	Command.Flags().Int64VarP(&flags.WorkersMin, "nodes-min", "", 0, "Minimum number of worker nodes for the node pool.")
+	Command.Flags().Int64VarP(&flags.WorkersMax, "nodes-max", "", 0, "Maximum number of worker nodes for the node pool.")
 }
 
 // Arguments defines the arguments this command can take into consideration.
@@ -140,24 +140,24 @@ type result struct {
 // collectArguments populates an arguments struct with values both from command flags,
 // from config, and potentially from built-in defaults.
 func collectArguments(positionalArgs []string) (Arguments, error) {
-	endpoint := config.Config.ChooseEndpoint(flags.CmdAPIEndpoint)
-	token := config.Config.ChooseToken(endpoint, flags.CmdToken)
-	scheme := config.Config.ChooseScheme(endpoint, flags.CmdToken)
+	endpoint := config.Config.ChooseEndpoint(flags.APIEndpoint)
+	token := config.Config.ChooseToken(endpoint, flags.Token)
+	scheme := config.Config.ChooseScheme(endpoint, flags.Token)
 
 	var err error
 
 	zones := cmdAvailabilityZones
 	if zones != nil && len(zones) > 0 {
-		zones, err = expandZones(zones, endpoint, flags.CmdToken)
+		zones, err = expandZones(zones, endpoint, flags.Token)
 		if err != nil {
 			return Arguments{}, microerror.Mask(err)
 		}
 	}
 
-	if flags.CmdWorkersMin > 0 && flags.CmdWorkersMax == 0 {
-		flags.CmdWorkersMax = flags.CmdWorkersMin
-	} else if flags.CmdWorkersMax > 0 && flags.CmdWorkersMin == 0 {
-		flags.CmdWorkersMin = flags.CmdWorkersMax
+	if flags.WorkersMin > 0 && flags.WorkersMax == 0 {
+		flags.WorkersMax = flags.WorkersMin
+	} else if flags.WorkersMax > 0 && flags.WorkersMin == 0 {
+		flags.WorkersMin = flags.WorkersMax
 	}
 
 	return Arguments{
@@ -166,13 +166,13 @@ func collectArguments(positionalArgs []string) (Arguments, error) {
 		AvailabilityZonesList: zones,
 		AvailabilityZonesNum:  cmdAvailabilityZonesNum,
 		ClusterID:             positionalArgs[0],
-		InstanceType:          flags.CmdWorkerAwsEc2InstanceType,
+		InstanceType:          flags.WorkerAwsEc2InstanceType,
 		Name:                  cmdName,
-		ScalingMax:            flags.CmdWorkersMax,
-		ScalingMin:            flags.CmdWorkersMin,
+		ScalingMax:            flags.WorkersMax,
+		ScalingMin:            flags.WorkersMin,
 		Scheme:                scheme,
-		UserProvidedToken:     flags.CmdToken,
-		Verbose:               flags.CmdVerbose,
+		UserProvidedToken:     flags.Token,
+		Verbose:               flags.Verbose,
 	}, nil
 }
 

--- a/commands/delete/cluster/command.go
+++ b/commands/delete/cluster/command.go
@@ -39,9 +39,9 @@ type Arguments struct {
 }
 
 func collectArguments(positionalArgs []string) Arguments {
-	endpoint := config.Config.ChooseEndpoint(flags.CmdAPIEndpoint)
-	token := config.Config.ChooseToken(endpoint, flags.CmdToken)
-	scheme := config.Config.ChooseScheme(endpoint, flags.CmdToken)
+	endpoint := config.Config.ChooseEndpoint(flags.APIEndpoint)
+	token := config.Config.ChooseToken(endpoint, flags.Token)
+	scheme := config.Config.ChooseScheme(endpoint, flags.Token)
 
 	clusterID := ""
 	if len(positionalArgs) > 0 {
@@ -51,12 +51,12 @@ func collectArguments(positionalArgs []string) Arguments {
 	return Arguments{
 		apiEndpoint:       endpoint,
 		clusterID:         clusterID,
-		force:             flags.CmdForce,
-		legacyClusterID:   flags.CmdClusterID,
+		force:             flags.Force,
+		legacyClusterID:   flags.ClusterID,
 		scheme:            scheme,
 		token:             token,
-		userProvidedToken: flags.CmdToken,
-		verbose:           flags.CmdVerbose,
+		userProvidedToken: flags.Token,
+		verbose:           flags.Verbose,
 	}
 }
 
@@ -83,8 +83,8 @@ Example:
 )
 
 func init() {
-	Command.Flags().StringVarP(&flags.CmdClusterID, "cluster", "c", "", "ID of the cluster to delete")
-	Command.Flags().BoolVarP(&flags.CmdForce, "force", "", false, "If set, no interactive confirmation will be required (risky!).")
+	Command.Flags().StringVarP(&flags.ClusterID, "cluster", "c", "", "ID of the cluster to delete")
+	Command.Flags().BoolVarP(&flags.Force, "force", "", false, "If set, no interactive confirmation will be required (risky!).")
 
 	Command.Flags().MarkDeprecated("cluster", "You no longer need to pass the cluster ID with -c/--cluster. Use --help for details.")
 }

--- a/commands/info/command.go
+++ b/commands/info/command.go
@@ -44,16 +44,16 @@ type Arguments struct {
 // collectArguments returns an Arguments object populated by the user's
 // command line arguments and/or config.
 func collectArguments() Arguments {
-	endpoint := config.Config.ChooseEndpoint(flags.CmdAPIEndpoint)
-	token := config.Config.ChooseToken(endpoint, flags.CmdToken)
-	scheme := config.Config.ChooseScheme(endpoint, flags.CmdToken)
+	endpoint := config.Config.ChooseEndpoint(flags.APIEndpoint)
+	token := config.Config.ChooseToken(endpoint, flags.Token)
+	scheme := config.Config.ChooseScheme(endpoint, flags.Token)
 
 	return Arguments{
 		apiEndpoint:       endpoint,
 		scheme:            scheme,
 		token:             token,
-		userProvidedToken: flags.CmdToken,
-		verbose:           flags.CmdVerbose,
+		userProvidedToken: flags.Token,
+		verbose:           flags.Verbose,
 	}
 }
 

--- a/commands/list/clusters/command.go
+++ b/commands/list/clusters/command.go
@@ -45,15 +45,15 @@ type Arguments struct {
 }
 
 func collectArguments() Arguments {
-	endpoint := config.Config.ChooseEndpoint(flags.CmdAPIEndpoint)
-	token := config.Config.ChooseToken(endpoint, flags.CmdToken)
-	scheme := config.Config.ChooseScheme(endpoint, flags.CmdToken)
+	endpoint := config.Config.ChooseEndpoint(flags.APIEndpoint)
+	token := config.Config.ChooseToken(endpoint, flags.Token)
+	scheme := config.Config.ChooseScheme(endpoint, flags.Token)
 
 	return Arguments{
 		apiEndpoint:       endpoint,
 		authToken:         token,
 		scheme:            scheme,
-		userProvidedToken: flags.CmdToken,
+		userProvidedToken: flags.Token,
 	}
 }
 

--- a/commands/list/endpoints/command.go
+++ b/commands/list/endpoints/command.go
@@ -37,9 +37,9 @@ type Arguments struct {
 // collectArguments returns Arguments
 // with settings loaded from flags etc.
 func collectArguments() Arguments {
-	endpoint := config.Config.ChooseEndpoint(flags.CmdAPIEndpoint)
-	token := config.Config.ChooseToken(endpoint, flags.CmdToken)
-	scheme := config.Config.ChooseScheme(endpoint, flags.CmdToken)
+	endpoint := config.Config.ChooseEndpoint(flags.APIEndpoint)
+	token := config.Config.ChooseToken(endpoint, flags.Token)
+	scheme := config.Config.ChooseScheme(endpoint, flags.Token)
 	return Arguments{
 		apiEndpoint: endpoint,
 		token:       token,

--- a/commands/list/keypairs/command.go
+++ b/commands/list/keypairs/command.go
@@ -54,16 +54,16 @@ type Arguments struct {
 // collectArguments returns a new Arguments struct
 // based on global variables (= command line options from cobra).
 func collectArguments() Arguments {
-	endpoint := config.Config.ChooseEndpoint(flags.CmdAPIEndpoint)
-	token := config.Config.ChooseToken(endpoint, flags.CmdToken)
-	scheme := config.Config.ChooseScheme(endpoint, flags.CmdToken)
+	endpoint := config.Config.ChooseEndpoint(flags.APIEndpoint)
+	token := config.Config.ChooseToken(endpoint, flags.Token)
+	scheme := config.Config.ChooseScheme(endpoint, flags.Token)
 
 	return Arguments{
 		apiEndpoint:       endpoint,
-		clusterID:         flags.CmdClusterID,
-		full:              flags.CmdFull,
+		clusterID:         flags.ClusterID,
+		full:              flags.Full,
 		token:             token,
-		userProvidedToken: flags.CmdToken,
+		userProvidedToken: flags.Token,
 		scheme:            scheme,
 	}
 }
@@ -74,8 +74,8 @@ type listKeypairsResult struct {
 }
 
 func init() {
-	Command.Flags().StringVarP(&flags.CmdClusterID, "cluster", "c", "", "ID of the cluster to list key pairs for")
-	Command.Flags().BoolVarP(&flags.CmdFull, "full", "", false, "Enables output of full, untruncated values")
+	Command.Flags().StringVarP(&flags.ClusterID, "cluster", "c", "", "ID of the cluster to list key pairs for")
+	Command.Flags().BoolVarP(&flags.Full, "full", "", false, "Enables output of full, untruncated values")
 
 	Command.MarkFlagRequired("cluster")
 }
@@ -112,7 +112,7 @@ func listKeypairsValidate(args *Arguments) error {
 		// use default cluster if possible
 		clusterID, _ := clientWrapper.GetDefaultCluster(nil)
 		if clusterID != "" {
-			flags.CmdClusterID = clusterID
+			flags.ClusterID = clusterID
 		} else {
 			return microerror.Mask(errors.ClusterIDMissingError)
 		}

--- a/commands/list/nodepools/command.go
+++ b/commands/list/nodepools/command.go
@@ -78,16 +78,16 @@ type resultRow struct {
 
 // collectArguments creates arguments based on command line flags and config.
 func collectArguments(cmdLineArgs []string) Arguments {
-	endpoint := config.Config.ChooseEndpoint(flags.CmdAPIEndpoint)
-	token := config.Config.ChooseToken(endpoint, flags.CmdToken)
-	scheme := config.Config.ChooseScheme(endpoint, flags.CmdToken)
+	endpoint := config.Config.ChooseEndpoint(flags.APIEndpoint)
+	token := config.Config.ChooseToken(endpoint, flags.Token)
+	scheme := config.Config.ChooseScheme(endpoint, flags.Token)
 
 	return Arguments{
 		apiEndpoint:       endpoint,
 		authToken:         token,
 		clusterID:         cmdLineArgs[0],
 		scheme:            scheme,
-		userProvidedToken: flags.CmdToken,
+		userProvidedToken: flags.Token,
 	}
 }
 

--- a/commands/list/organizations/command.go
+++ b/commands/list/organizations/command.go
@@ -43,15 +43,15 @@ type Arguments struct {
 
 // collectArguments creates arguments based on command line flags and config
 func collectArguments() Arguments {
-	endpoint := config.Config.ChooseEndpoint(flags.CmdAPIEndpoint)
-	token := config.Config.ChooseToken(endpoint, flags.CmdToken)
-	scheme := config.Config.ChooseScheme(endpoint, flags.CmdToken)
+	endpoint := config.Config.ChooseEndpoint(flags.APIEndpoint)
+	token := config.Config.ChooseToken(endpoint, flags.Token)
+	scheme := config.Config.ChooseScheme(endpoint, flags.Token)
 
 	return Arguments{
 		apiEndpoint:       endpoint,
 		authToken:         token,
 		scheme:            scheme,
-		userProvidedToken: flags.CmdToken,
+		userProvidedToken: flags.Token,
 	}
 }
 

--- a/commands/list/releases/command.go
+++ b/commands/list/releases/command.go
@@ -52,15 +52,15 @@ type Arguments struct {
 // collectArguments returns a new Arguments struct
 // based on global variables (= command line options from cobra).
 func collectArguments() Arguments {
-	endpoint := config.Config.ChooseEndpoint(flags.CmdAPIEndpoint)
-	token := config.Config.ChooseToken(endpoint, flags.CmdToken)
-	scheme := config.Config.ChooseScheme(endpoint, flags.CmdToken)
+	endpoint := config.Config.ChooseEndpoint(flags.APIEndpoint)
+	token := config.Config.ChooseToken(endpoint, flags.Token)
+	scheme := config.Config.ChooseScheme(endpoint, flags.Token)
 
 	return Arguments{
 		apiEndpoint:       endpoint,
 		token:             token,
 		scheme:            scheme,
-		userProvidedToken: flags.CmdToken,
+		userProvidedToken: flags.Token,
 	}
 }
 

--- a/commands/login/command.go
+++ b/commands/login/command.go
@@ -66,13 +66,13 @@ type Arguments struct {
 }
 
 func collectArguments() Arguments {
-	endpoint := config.Config.ChooseEndpoint(flags.CmdAPIEndpoint)
+	endpoint := config.Config.ChooseEndpoint(flags.APIEndpoint)
 
 	return Arguments{
 		apiEndpoint: endpoint,
 		email:       cmdEmail,
 		password:    cmdPassword,
-		verbose:     flags.CmdVerbose,
+		verbose:     flags.Verbose,
 	}
 }
 
@@ -137,7 +137,7 @@ func verifyLoginPreconditions(positionalArgs []string) error {
 
 	// using auth token flag? The 'login' command is the only exception
 	// where we can't accept this argument.
-	if flags.CmdToken != "" {
+	if flags.Token != "" {
 		return microerror.Mask(errors.TokenArgumentNotApplicableError)
 	}
 

--- a/commands/logout/command.go
+++ b/commands/logout/command.go
@@ -44,18 +44,18 @@ type Arguments struct {
 }
 
 func collectArguments() Arguments {
-	endpoint := config.Config.ChooseEndpoint(flags.CmdAPIEndpoint)
-	token := config.Config.ChooseToken(endpoint, flags.CmdToken)
+	endpoint := config.Config.ChooseEndpoint(flags.APIEndpoint)
+	token := config.Config.ChooseToken(endpoint, flags.Token)
 
 	return Arguments{
 		apiEndpoint:       endpoint,
 		token:             token,
-		userProvidedToken: flags.CmdToken,
+		userProvidedToken: flags.Token,
 	}
 }
 
 func printValidation(cmd *cobra.Command, args []string) {
-	if config.Config.Token == "" && flags.CmdToken == "" {
+	if config.Config.Token == "" && flags.Token == "" {
 		fmt.Println("You weren't logged in here, but better be safe than sorry.")
 		os.Exit(1)
 	}

--- a/commands/ping/command.go
+++ b/commands/ping/command.go
@@ -32,7 +32,7 @@ var (
 // runCommand executes the ping() function
 // and prints output in a user-friendly way
 func runCommand(cmd *cobra.Command, args []string) {
-	endpoint := config.Config.ChooseEndpoint(flags.CmdAPIEndpoint)
+	endpoint := config.Config.ChooseEndpoint(flags.APIEndpoint)
 
 	duration, err := ping(endpoint)
 	if err != nil {

--- a/commands/root.go
+++ b/commands/root.go
@@ -32,10 +32,10 @@ var RootCommand = &cobra.Command{
 }
 
 func init() {
-	RootCommand.PersistentFlags().StringVarP(&flags.CmdAPIEndpoint, "endpoint", "e", "", "The API endpoint to use")
-	RootCommand.PersistentFlags().StringVarP(&flags.CmdToken, "auth-token", "", "", "Authorization token to use")
-	RootCommand.PersistentFlags().StringVarP(&flags.CmdConfigDirPath, "config-dir", "", config.DefaultConfigDirPath, "Configuration directory path to use")
-	RootCommand.PersistentFlags().BoolVarP(&flags.CmdVerbose, "verbose", "v", false, "Print more information")
+	RootCommand.PersistentFlags().StringVarP(&flags.APIEndpoint, "endpoint", "e", "", "The API endpoint to use")
+	RootCommand.PersistentFlags().StringVarP(&flags.Token, "auth-token", "", "", "Authorization token to use")
+	RootCommand.PersistentFlags().StringVarP(&flags.ConfigDirPath, "config-dir", "", config.DefaultConfigDirPath, "Configuration directory path to use")
+	RootCommand.PersistentFlags().BoolVarP(&flags.Verbose, "verbose", "v", false, "Print more information")
 
 	// add subcommands
 	RootCommand.AddCommand(CompletionCommand)
@@ -58,9 +58,9 @@ func init() {
 // before any command is executed (see PersistentPreRunE above).
 func initConfig(cmd *cobra.Command, args []string) error {
 	fs := afero.NewOsFs()
-	err := config.Initialize(fs, flags.CmdConfigDirPath)
+	err := config.Initialize(fs, flags.ConfigDirPath)
 	if err != nil {
-		if flags.CmdVerbose {
+		if flags.Verbose {
 			fmt.Printf("Error initializing configuration: %#v\n", err)
 		}
 		return microerror.Mask(err)

--- a/commands/show/cluster/command.go
+++ b/commands/show/cluster/command.go
@@ -64,17 +64,17 @@ type Arguments struct {
 
 // collectArguments fills arguments from user input, config, and environment.
 func collectArguments() Arguments {
-	endpoint := config.Config.ChooseEndpoint(flags.CmdAPIEndpoint)
-	token := config.Config.ChooseToken(endpoint, flags.CmdToken)
-	scheme := config.Config.ChooseScheme(endpoint, flags.CmdToken)
+	endpoint := config.Config.ChooseEndpoint(flags.APIEndpoint)
+	token := config.Config.ChooseToken(endpoint, flags.Token)
+	scheme := config.Config.ChooseScheme(endpoint, flags.Token)
 
 	return Arguments{
 		apiEndpoint:       endpoint,
 		authToken:         token,
 		scheme:            scheme,
 		clusterID:         "",
-		userProvidedToken: flags.CmdToken,
-		verbose:           flags.CmdVerbose,
+		userProvidedToken: flags.Token,
+		verbose:           flags.Verbose,
 	}
 }
 

--- a/commands/show/nodepool/command.go
+++ b/commands/show/nodepool/command.go
@@ -67,8 +67,8 @@ type result struct {
 }
 
 func collectArguments(positionalArgs []string) Arguments {
-	endpoint := config.Config.ChooseEndpoint(flags.CmdAPIEndpoint)
-	token := config.Config.ChooseToken(endpoint, flags.CmdToken)
+	endpoint := config.Config.ChooseEndpoint(flags.APIEndpoint)
+	token := config.Config.ChooseToken(endpoint, flags.Token)
 
 	parts := strings.Split(positionalArgs[0], "/")
 
@@ -77,7 +77,7 @@ func collectArguments(positionalArgs []string) Arguments {
 		authToken:         token,
 		clusterID:         parts[0],
 		nodePoolID:        parts[1],
-		userProvidedToken: flags.CmdToken,
+		userProvidedToken: flags.Token,
 	}
 }
 

--- a/commands/show/release/command.go
+++ b/commands/show/release/command.go
@@ -53,17 +53,17 @@ type Arguments struct {
 }
 
 func collectArguments() Arguments {
-	endpoint := config.Config.ChooseEndpoint(flags.CmdAPIEndpoint)
-	token := config.Config.ChooseToken(endpoint, flags.CmdToken)
-	scheme := config.Config.ChooseScheme(endpoint, flags.CmdToken)
+	endpoint := config.Config.ChooseEndpoint(flags.APIEndpoint)
+	token := config.Config.ChooseToken(endpoint, flags.Token)
+	scheme := config.Config.ChooseScheme(endpoint, flags.Token)
 
 	return Arguments{
 		apiEndpoint:       endpoint,
 		authToken:         token,
 		scheme:            scheme,
 		releaseVersion:    "",
-		userProvidedToken: flags.CmdToken,
-		verbose:           flags.CmdVerbose,
+		userProvidedToken: flags.Token,
+		verbose:           flags.Verbose,
 	}
 }
 

--- a/commands/update/organization/command.go
+++ b/commands/update/organization/command.go
@@ -23,7 +23,7 @@ Examples:
 )
 
 func init() {
-	Command.Flags().StringVarP(&flags.CmdOrganizationID, "organization", "o", "", "ID of the organization to modify")
+	Command.Flags().StringVarP(&flags.OrganizationID, "organization", "o", "", "ID of the organization to modify")
 
 	Command.AddCommand(setcredentials.Command)
 }

--- a/commands/update/organization/setcredentials/command.go
+++ b/commands/update/organization/setcredentials/command.go
@@ -94,7 +94,7 @@ type setOrgCredentialsResult struct {
 }
 
 func init() {
-	Command.Flags().StringVarP(&flags.CmdOrganizationID, "organization", "o", "", "ID of the organization to set credentials for")
+	Command.Flags().StringVarP(&flags.OrganizationID, "organization", "o", "", "ID of the organization to set credentials for")
 	Command.Flags().StringVarP(&cmdAWSOperatorRoleARN, "aws-operator-role", "", "", "AWS ARN of the role to use for operating clusters")
 	Command.Flags().StringVarP(&cmdAWSAdminRoleARN, "aws-admin-role", "", "", "AWS ARN of the role to be used by Giant Swarm staff")
 	Command.Flags().StringVarP(&cmdAzureSubscriptionID, "azure-subscription-id", "", "", "ID of the Azure subscription to run clusters in")
@@ -104,9 +104,9 @@ func init() {
 }
 
 func collectArguments() Arguments {
-	endpoint := config.Config.ChooseEndpoint(flags.CmdAPIEndpoint)
-	token := config.Config.ChooseToken(endpoint, flags.CmdToken)
-	scheme := config.Config.ChooseScheme(endpoint, flags.CmdToken)
+	endpoint := config.Config.ChooseEndpoint(flags.APIEndpoint)
+	token := config.Config.ChooseToken(endpoint, flags.Token)
+	scheme := config.Config.ChooseScheme(endpoint, flags.Token)
 
 	return Arguments{
 		apiEndpoint:         endpoint,
@@ -117,10 +117,10 @@ func collectArguments() Arguments {
 		azureSecretKey:      cmdAzureSecretKey,
 		azureSubscriptionID: cmdAzureSubscriptionID,
 		azureTenantID:       cmdAzureTenantID,
-		organizationID:      flags.CmdOrganizationID,
+		organizationID:      flags.OrganizationID,
 		scheme:              scheme,
-		userProvidedToken:   flags.CmdToken,
-		verbose:             flags.CmdVerbose,
+		userProvidedToken:   flags.Token,
+		verbose:             flags.Verbose,
 	}
 }
 

--- a/commands/upgrade/cluster/command.go
+++ b/commands/upgrade/cluster/command.go
@@ -75,8 +75,8 @@ type Arguments struct {
 
 // function to create arguments based on command line flags and config
 func collectArguments(cmdLineArgs []string) Arguments {
-	endpoint := config.Config.ChooseEndpoint(flags.CmdAPIEndpoint)
-	token := config.Config.ChooseToken(endpoint, flags.CmdToken)
+	endpoint := config.Config.ChooseEndpoint(flags.APIEndpoint)
+	token := config.Config.ChooseToken(endpoint, flags.Token)
 	clusterID := ""
 	if len(cmdLineArgs) > 0 {
 		clusterID = cmdLineArgs[0]
@@ -87,8 +87,8 @@ func collectArguments(cmdLineArgs []string) Arguments {
 		authToken:         token,
 		clusterID:         clusterID,
 		force:             false,
-		userProvidedToken: flags.CmdToken,
-		verbose:           flags.CmdVerbose,
+		userProvidedToken: flags.Token,
+		verbose:           flags.Verbose,
 	}
 }
 
@@ -100,7 +100,7 @@ type upgradeClusterResult struct {
 
 // Here we populate our cobra command
 func init() {
-	Command.Flags().BoolVarP(&flags.CmdForce, "force", "", false, "If set, no interactive confirmation will be required (risky!).")
+	Command.Flags().BoolVarP(&flags.Force, "force", "", false, "If set, no interactive confirmation will be required (risky!).")
 }
 
 // Prints results of our pre-validation

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -1,64 +1,64 @@
 package flags
 
 var (
-	// CmdAPIEndpoint represents the API endpoint URL flag.
-	CmdAPIEndpoint string
+	// APIEndpoint represents the API endpoint URL flag.
+	APIEndpoint string
 
-	// CmdToken represents the auth token passed as a flag.
-	CmdToken string
+	// Token represents the auth token passed as a flag.
+	Token string
 
-	// CmdConfigDirPath represents the configuration path to use temporarily passed as a flag.
-	CmdConfigDirPath string
+	// ConfigDirPath represents the configuration path to use temporarily passed as a flag.
+	ConfigDirPath string
 
-	// CmdVerbose represents the verbosity switch passed as a flag.
-	CmdVerbose bool
+	// Verbose represents the verbosity switch passed as a flag.
+	Verbose bool
 
-	// CmdCertificateOrganizations represents the O value for key pairs passed as a flag.
-	CmdCertificateOrganizations string
+	// CertificateOrganizations represents the O value for key pairs passed as a flag.
+	CertificateOrganizations string
 
-	// CmdClusterID represents the cluster ID passed as a flag.
-	CmdClusterID string
+	// ClusterID represents the cluster ID passed as a flag.
+	ClusterID string
 
-	// CmdCNPrefix represents the CN prefix passed as a flag.
-	CmdCNPrefix string
+	// CNPrefix represents the CN prefix passed as a flag.
+	CNPrefix string
 
-	// CmdDescription represents the description passed as a flag.
-	CmdDescription string
+	// Description represents the description passed as a flag.
+	Description string
 
-	// CmdTTL represents a TTL (time to live) value passed as a flag.
-	CmdTTL string
+	// TTL represents a TTL (time to live) value passed as a flag.
+	TTL string
 
-	// CmdForce represents the value of the force flag, passed as a flag.
+	// Force represents the value of the force flag, passed as a flag.
 	// If true, all warnings should be suppressed.
-	CmdForce bool
+	Force bool
 
-	// CmdFull represents the switch to disable all output truncation, passed as a flag.
-	CmdFull bool
+	// Full represents the switch to disable all output truncation, passed as a flag.
+	Full bool
 
-	// CmdNumWorkers is the number of workers required via flag on execution.
-	CmdNumWorkers int
+	// NumWorkers is the number of workers required via flag on execution.
+	NumWorkers int
 
-	// CmdOrganizationID represents an organization ID, passed as a flag.
-	CmdOrganizationID string
+	// OrganizationID represents an organization ID, passed as a flag.
+	OrganizationID string
 
-	// CmdRelease sets a release to use, provided as a command line flag.
-	CmdRelease string
+	// Release sets a release to use, provided as a command line flag.
+	Release string
 
-	// CmdWorkerNumCPUs prepresents the number of CPUs per worker as required via flag.
-	CmdWorkerNumCPUs int
+	// WorkerNumCPUs prepresents the number of CPUs per worker as required via flag.
+	WorkerNumCPUs int
 
-	// CmdWorkerMemorySizeGB represents the RAM size per worker node in GB per worker as required via flag.
-	CmdWorkerMemorySizeGB float32
+	// WorkerMemorySizeGB represents the RAM size per worker node in GB per worker as required via flag.
+	WorkerMemorySizeGB float32
 
-	// CmdWorkerStorageSizeGB represents the local storage per worker node in GB per worker as required via flag.
-	CmdWorkerStorageSizeGB float32
+	// WorkerStorageSizeGB represents the local storage per worker node in GB per worker as required via flag.
+	WorkerStorageSizeGB float32
 
-	// CmdWorkersMin is the minimum number of workers created for the cluster or node pool.
-	CmdWorkersMin int64
+	// WorkersMin is the minimum number of workers created for the cluster or node pool.
+	WorkersMin int64
 
-	// CmdWorkersMax is the minimum number of workers created for the cluster or node pool.
-	CmdWorkersMax int64
+	// WorkersMax is the minimum number of workers created for the cluster or node pool.
+	WorkersMax int64
 
-	// CmdWorkerAwsEc2InstanceType is the instance type name for nodes in AWS.
-	CmdWorkerAwsEc2InstanceType string
+	// WorkerAwsEc2InstanceType is the instance type name for nodes in AWS.
+	WorkerAwsEc2InstanceType string
 )


### PR DESCRIPTION
This is a cosmetic PR for renaming of attributes of the `flags` package to remove the `Cmd` prefix everywhere.