### PR TITLE
Add 'update nodepool' command

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -473,6 +473,22 @@ func (w *Wrapper) GetNodePools(clusterID string, p *AuxiliaryParams) (*nodepools
 	return response, nil
 }
 
+// ModifyNodePool modifies a node pool.
+func (w *Wrapper) ModifyNodePool(clusterID, nodePoolID string, modifyNodePoolRequest *models.V5ModifyNodePoolRequest, p *AuxiliaryParams) (*nodepools.ModifyNodePoolOK, error) {
+	params := nodepools.NewModifyNodePoolParams().WithClusterID(clusterID).WithNodepoolID(nodePoolID).WithBody(modifyNodePoolRequest)
+	err := setParamsWithAuthorization(p, w, params)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	response, err := w.gsclient.Nodepools.ModifyNodePool(params, nil)
+	if err != nil {
+		return nil, clienterror.New(err)
+	}
+
+	return response, nil
+}
+
 // DeleteNodePool deletes a node pool.
 func (w *Wrapper) DeleteNodePool(clusterID, nodePoolID string, p *AuxiliaryParams) (*nodepools.DeleteNodePoolAccepted, error) {
 	params := nodepools.NewDeleteNodePoolParams().WithClusterID(clusterID).WithNodepoolID(nodePoolID)

--- a/client/clienterror/clienterror.go
+++ b/client/clienterror/clienterror.go
@@ -333,6 +333,31 @@ func New(err error) *APIError {
 		}
 	}
 
+	// modify node pool
+	if modifyNodePoolsUnauthorizedErr, ok := err.(*nodepools.ModifyNodePoolUnauthorized); ok {
+		return &APIError{
+			HTTPStatusCode: http.StatusUnauthorized,
+			OriginalError:  modifyNodePoolsUnauthorizedErr,
+			ErrorMessage:   "Unauthorized",
+			ErrorDetails:   "You don't have permission to modify this node pool.",
+		}
+	}
+	if modifyNodePoolsNotFoundErr, ok := err.(*nodepools.ModifyNodePoolNotFound); ok {
+		return &APIError{
+			HTTPStatusCode: http.StatusNotFound,
+			OriginalError:  modifyNodePoolsNotFoundErr,
+			ErrorMessage:   "Not found",
+			ErrorDetails:   "The cluster or node pool was not found or you don't have access to it.",
+		}
+	}
+	if modifyNodePoolsDefaultErr, ok := err.(*nodepools.ModifyNodePoolDefault); ok {
+		return &APIError{
+			HTTPStatusCode: modifyNodePoolsDefaultErr.Code(),
+			OriginalError:  modifyNodePoolsDefaultErr,
+			ErrorMessage:   modifyNodePoolsDefaultErr.Error(),
+		}
+	}
+
 	// delete node pool
 	if deleteNodePoolsUnauthorizedErr, ok := err.(*nodepools.DeleteNodePoolUnauthorized); ok {
 		return &APIError{

--- a/commands/create/nodepool/command.go
+++ b/commands/create/nodepool/command.go
@@ -91,7 +91,6 @@ Examples:
 	}
 
 	cmdAwsEc2InstanceType   string
-	cmdName                 string
 	cmdAvailabilityZonesNum int
 	cmdAvailabilityZones    []string
 )
@@ -107,7 +106,7 @@ func init() {
 // initFlags initializes flags in a re-usable way, so we can call it from multiple tests.
 func initFlags() {
 	Command.ResetFlags()
-	Command.Flags().StringVarP(&cmdName, "name", "n", "", "name or purpose description of the node pool")
+	Command.Flags().StringVarP(&flags.Name, "name", "n", "", "name or purpose description of the node pool")
 	Command.Flags().IntVarP(&cmdAvailabilityZonesNum, "num-availability-zones", "", 0, "Number of availability zones to use. Default is 1.")
 	Command.Flags().StringSliceVarP(&cmdAvailabilityZones, "availability-zones", "", nil, "List of availability zones to use, instead of setting a number. Use comma to separate values.")
 	Command.Flags().StringVarP(&flags.WorkerAwsEc2InstanceType, "aws-instance-type", "", "", "EC2 instance type to use for workers, e. g. 'm5.2xlarge'")
@@ -167,7 +166,7 @@ func collectArguments(positionalArgs []string) (Arguments, error) {
 		AvailabilityZonesNum:  cmdAvailabilityZonesNum,
 		ClusterID:             positionalArgs[0],
 		InstanceType:          flags.WorkerAwsEc2InstanceType,
-		Name:                  cmdName,
+		Name:                  flags.Name,
 		ScalingMax:            flags.WorkersMax,
 		ScalingMin:            flags.WorkersMin,
 		Scheme:                scheme,

--- a/commands/errors/errors.go
+++ b/commands/errors/errors.go
@@ -100,6 +100,16 @@ func IsNodePoolIDMissingError(err error) bool {
 	return microerror.Cause(err) == NodePoolIDMissingError
 }
 
+// NodePoolIDMalformedError means a cluster/nodepool ID tuple has been formatted the wrong way.
+var NodePoolIDMalformedError = &microerror.Error{
+	Kind: "NodePoolIDMalformedError",
+}
+
+// IsNodePoolIDMalformedError asserts IsNodePoolIDMalformedError.
+func IsNodePoolIDMalformedError(err error) bool {
+	return microerror.Cause(err) == NodePoolIDMalformedError
+}
+
 // ClusterNotFoundError means that a given cluster does not exist
 var ClusterNotFoundError = &microerror.Error{
 	Kind: "ClusterNotFoundError",

--- a/commands/errors/errors.go
+++ b/commands/errors/errors.go
@@ -655,3 +655,15 @@ var WorkersMinMaxInvalidError = &microerror.Error{
 func IsWorkersMinMaxInvalid(err error) bool {
 	return microerror.Cause(err) == WorkersMinMaxInvalidError
 }
+
+// NoOpError is raised when the user calls a command without any meaningful
+// parameters, resulting in no change/nothing done.
+var NoOpError = &microerror.Error{
+	Kind: "NoOpError",
+	Desc: "Nothing to be done",
+}
+
+// IsNoOpError asserts NoOpError.
+func IsNoOpError(err error) bool {
+	return microerror.Cause(err) == NoOpError
+}

--- a/commands/update/command.go
+++ b/commands/update/command.go
@@ -3,6 +3,7 @@ package update
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/giantswarm/gsctl/commands/update/nodepool"
 	"github.com/giantswarm/gsctl/commands/update/organization"
 )
 
@@ -10,11 +11,12 @@ var (
 	// Command is the command to modify resources
 	Command = &cobra.Command{
 		Use:   "update",
-		Short: "Modify organization details",
-		Long:  `Modify details of an organization`,
+		Short: "Modify node pool or organization details",
+		Long:  `Modify details of a node pool or an organization`,
 	}
 )
 
 func init() {
 	Command.AddCommand(organization.Command)
+	Command.AddCommand(nodepool.Command)
 }

--- a/commands/update/nodepool/command.go
+++ b/commands/update/nodepool/command.go
@@ -1,0 +1,203 @@
+// Package nodepool implements the "update nodepool" command.
+package nodepool
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/fatih/color"
+	"github.com/giantswarm/gscliauth/config"
+	"github.com/giantswarm/gsclientgen/models"
+	"github.com/giantswarm/microerror"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/gsctl/client"
+	"github.com/giantswarm/gsctl/commands/errors"
+	"github.com/giantswarm/gsctl/flags"
+)
+
+var (
+	// Command is the cobra command for 'gsctl show nodepool'
+	Command = &cobra.Command{
+		Hidden:  true, // TODO: set to false to make this command visible once the release is out.
+		Use:     "nodepool <cluster-id>/<nodepool-id>",
+		Aliases: []string{"np"},
+		// Args: cobra.ExactArgs(1) guarantees that cobra will fail if no positional argument is given.
+		Args:  cobra.ExactArgs(1),
+		Short: "Modify node pool details",
+		Long: `Change the name or the scaling settings of a node pool.
+
+Examples:
+
+  gsctl update nodepool f01r4/75rh1 --name "General purpose M5"
+
+  gsctl update nodepool f01r4/75rh1 --nodes-min 10 --nodes-max 20
+
+`,
+
+		// PreRun checks a few general things, like authentication.
+		PreRun: printValidation,
+
+		// Run calls the business function and prints results and errors.
+		Run: printResult,
+	}
+)
+
+const (
+	activityName = "update-nodepool"
+)
+
+func init() {
+	initFlags()
+}
+
+// initFlags initializes flags in a re-usable way, so we can call it from multiple tests.
+func initFlags() {
+	Command.ResetFlags()
+	Command.Flags().StringVarP(&flags.Name, "name", "n", "", "name or purpose description of the node pool")
+	Command.Flags().Int64VarP(&flags.WorkersMin, "nodes-min", "", 0, "Minimum number of worker nodes for the node pool.")
+	Command.Flags().Int64VarP(&flags.WorkersMax, "nodes-max", "", 0, "Maximum number of worker nodes for the node pool.")
+}
+
+// Arguments represents all the ways the user can influence the command.
+type Arguments struct {
+	APIEndpoint       string
+	AuthToken         string
+	ClusterID         string
+	Name              string
+	NodePoolID        string
+	ScalingMax        int64
+	ScalingMin        int64
+	UserProvidedToken string
+}
+
+func collectArguments(positionalArgs []string) (Arguments, error) {
+	endpoint := config.Config.ChooseEndpoint(flags.APIEndpoint)
+	token := config.Config.ChooseToken(endpoint, flags.Token)
+
+	parts := strings.Split(positionalArgs[0], "/")
+	if len(parts) != 2 {
+		return Arguments{}, microerror.Mask(errors.NodePoolIDMalformedError)
+	}
+
+	return Arguments{
+		APIEndpoint:       endpoint,
+		AuthToken:         token,
+		ClusterID:         strings.TrimSpace(parts[0]),
+		Name:              flags.Name,
+		NodePoolID:        strings.TrimSpace(parts[1]),
+		ScalingMax:        flags.WorkersMax,
+		ScalingMin:        flags.WorkersMin,
+		UserProvidedToken: flags.Token,
+	}, nil
+}
+
+// result represents all information we get back from modifying a node pool.
+type result struct {
+	// nodePool contains all the node pool details as returned from the API.
+	nodePool *models.V5GetNodePoolResponse
+}
+
+func verifyPreconditions(args Arguments) error {
+	if args.AuthToken == "" && args.UserProvidedToken == "" {
+		return microerror.Mask(errors.NotLoggedInError)
+	} else if args.ClusterID == "" {
+		return microerror.Mask(errors.ClusterIDMissingError)
+	} else if args.NodePoolID == "" {
+		return microerror.Mask(errors.NodePoolIDMissingError)
+	}
+
+	return nil
+}
+
+func printValidation(cmd *cobra.Command, positionalArgs []string) {
+	args, err := collectArguments(positionalArgs)
+	if err == nil {
+		err = verifyPreconditions(args)
+	}
+
+	if err == nil {
+		return
+	}
+
+	errors.HandleCommonErrors(err)
+
+	headline := ""
+	subtext := ""
+
+	if errors.IsNodePoolIDMalformedError(err) {
+		headline = "Bad format for Cluster ID/Node Pool ID argument"
+		subtext = "Please provide cluster ID and node pool ID separated by a slash. See --help for examples."
+	}
+
+	// print output
+	fmt.Println(color.RedString(headline))
+	if subtext != "" {
+		fmt.Println(subtext)
+	}
+	os.Exit(1)
+}
+
+func updateNodepool(args Arguments) (*result, error) {
+	clientWrapper, err := client.NewWithConfig(args.APIEndpoint, args.UserProvidedToken)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	requestBody := &models.V5ModifyNodePoolRequest{}
+	if args.Name != "" {
+		requestBody.Name = args.Name
+	}
+	if args.ScalingMin != 0 || args.ScalingMax != 0 {
+		requestBody.Scaling = &models.V5ModifyNodePoolRequestScaling{}
+	}
+	if args.ScalingMin != 0 {
+		requestBody.Scaling.Min = args.ScalingMin
+	}
+	if args.ScalingMax != 0 {
+		requestBody.Scaling.Max = args.ScalingMax
+	}
+
+	auxParams := clientWrapper.DefaultAuxiliaryParams()
+	auxParams.ActivityName = activityName
+
+	response, err := clientWrapper.ModifyNodePool(args.ClusterID, args.NodePoolID, requestBody, auxParams)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r := &result{
+		nodePool: response.Payload,
+	}
+
+	return r, nil
+}
+
+func printResult(cmd *cobra.Command, positionalArgs []string) {
+	args, _ := collectArguments(positionalArgs)
+
+	r, err := updateNodepool(args)
+	if err != nil {
+		errors.HandleCommonErrors(err)
+		client.HandleErrors(err)
+
+		headline := ""
+		subtext := ""
+
+		switch {
+		// If there are specific errors to handle, add them here.
+		default:
+			headline = err.Error()
+		}
+
+		// print output
+		fmt.Println(color.RedString(headline))
+		if subtext != "" {
+			fmt.Println(subtext)
+		}
+		os.Exit(1)
+	}
+
+	fmt.Println(color.GreenString("Node pool '%s' (ID '%s') in cluster '%s' has been modified.", r.nodePool.Name, r.nodePool.ID, args.ClusterID))
+}

--- a/commands/update/nodepool/command_test.go
+++ b/commands/update/nodepool/command_test.go
@@ -1,0 +1,408 @@
+package nodepool
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/giantswarm/gsclientgen/models"
+	"github.com/giantswarm/gsctl/commands/errors"
+	"github.com/giantswarm/gsctl/testutils"
+	"github.com/google/go-cmp/cmp"
+	"github.com/spf13/afero"
+)
+
+// configYAML is a mock configuration used by some of the tests.
+const configYAML = `last_version_check: 0001-01-01T00:00:00Z
+endpoints:
+  https://foo:
+    email: email@example.com
+    token: some-token
+selected_endpoint: https://foo
+updated: 2017-09-29T11:23:15+02:00
+`
+
+// TestCollectArgs tests whether collectArguments produces the expected results.
+func TestCollectArgs(t *testing.T) {
+	var testCases = []struct {
+		// The positional arguments we pass.
+		positionalArguments []string
+		// How we execute the command.
+		commandExecution func()
+		// What we expect as arguments.
+		resultingArgs Arguments
+	}{
+		{
+			[]string{"clusterid/nodepoolid"},
+			func() {
+				initFlags()
+				Command.ParseFlags([]string{"clusterid/nodepoolid"})
+			},
+			Arguments{
+				APIEndpoint: "https://foo",
+				AuthToken:   "some-token",
+				ClusterID:   "clusterid",
+				NodePoolID:  "nodepoolid",
+			},
+		},
+		{
+			[]string{"clusterid/nodepoolid", "--nodes-min=3", "--nodes-max=5", "--name=NewName"},
+			func() {
+				initFlags()
+				Command.ParseFlags([]string{"clusterid/nodepoolid", "--nodes-min=3", "--nodes-max=5", "--name=NewName"})
+			},
+			Arguments{
+				APIEndpoint: "https://foo",
+				AuthToken:   "some-token",
+				ClusterID:   "clusterid",
+				NodePoolID:  "nodepoolid",
+				ScalingMin:  3,
+				ScalingMax:  5,
+				Name:        "NewName",
+			},
+		},
+	}
+
+	fs := afero.NewMemMapFs()
+	_, err := testutils.TempConfig(fs, configYAML)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			tc.commandExecution()
+			args, err := collectArguments(tc.positionalArguments)
+			if err != nil {
+				t.Errorf("Case %d - Unexpected error '%s'", i, err)
+			}
+			if diff := cmp.Diff(tc.resultingArgs, args); diff != "" {
+				t.Errorf("Case %d - Resulting args unequal. (-expected +got):\n%s", i, diff)
+			}
+		})
+	}
+}
+
+// Test_verifyPreconditions tests cases where validating preconditions fails.
+func Test_verifyPreconditions(t *testing.T) {
+	var testCases = []struct {
+		args         Arguments
+		errorMatcher func(error) bool
+	}{
+		// Cluster ID is missing.
+		{
+			Arguments{
+				AuthToken:   "token",
+				APIEndpoint: "https://mock-url",
+				NodePoolID:  "abc",
+			},
+			errors.IsClusterIDMissingError,
+		},
+		// Node pool ID is missing.
+		{
+			Arguments{
+				AuthToken:   "token",
+				APIEndpoint: "https://mock-url",
+				ClusterID:   "abc",
+			},
+			errors.IsNodePoolIDMissingError,
+		},
+		// No token provided.
+		{
+			Arguments{
+				APIEndpoint: "https://mock-url",
+				ClusterID:   "cluster-id",
+			},
+			errors.IsNotLoggedInError,
+		},
+		// Nothing to change.
+		{
+			Arguments{
+				AuthToken:   "token",
+				APIEndpoint: "https://mock-url",
+				ClusterID:   "cluster-id",
+				NodePoolID:  "abc",
+			},
+			errors.IsNoOpError,
+		},
+		// Bad scaling parameters
+		{
+			Arguments{
+				AuthToken:   "token",
+				APIEndpoint: "https://mock-url",
+				ClusterID:   "cluster-id",
+				NodePoolID:  "abc",
+				ScalingMin:  10,
+				ScalingMax:  1,
+			},
+			errors.IsWorkersMinMaxInvalid,
+		},
+	}
+
+	fs := afero.NewMemMapFs()
+	_, err := testutils.TempConfig(fs, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			err := verifyPreconditions(tc.args)
+			if err == nil {
+				t.Errorf("Case %d - Expected error, got nil", i)
+			} else if !tc.errorMatcher(err) {
+				t.Errorf("Case %d - Error did not match expectec type. Got '%s'", i, err)
+			}
+		})
+	}
+}
+
+// TestSuccess tests node pool creation with cases that are expected to succeed.
+func TestSuccess(t *testing.T) {
+	var testCases = []struct {
+		args           Arguments
+		responseBody   string
+		expectedResult *result
+	}{
+		// Name change.
+		{
+			Arguments{
+				ClusterID:  "clusterid",
+				NodePoolID: "nodepoolid",
+				AuthToken:  "token",
+				Name:       "New name",
+			},
+			`{
+				"id": "nodepoolid",
+				"name": "New name",
+				"scaling": {
+					"min": 3,
+					"max": 5
+				}
+			}`,
+			&result{
+				NodePool: &models.V5GetNodePoolResponse{
+					ID:   "nodepoolid",
+					Name: "New name",
+					Scaling: &models.V5GetNodePoolResponseScaling{
+						Min: 3,
+						Max: 5,
+					},
+				},
+			},
+		},
+		// Scaling change.
+		{
+			Arguments{
+				ClusterID:  "clusterid",
+				NodePoolID: "nodepoolid",
+				AuthToken:  "token",
+				ScalingMin: 10,
+				ScalingMax: 20,
+			},
+			`{
+				"id": "nodepoolid",
+				"name": "New name",
+				"scaling": {
+					"min": 10,
+					"max": 20
+				}
+			}`,
+			&result{
+				NodePool: &models.V5GetNodePoolResponse{
+					ID:   "nodepoolid",
+					Name: "New name",
+					Scaling: &models.V5GetNodePoolResponseScaling{
+						Min: 10,
+						Max: 20,
+					},
+				},
+			},
+		},
+		// Scaling change min only.
+		{
+			Arguments{
+				ClusterID:  "clusterid",
+				NodePoolID: "nodepoolid",
+				AuthToken:  "token",
+				ScalingMin: 10,
+			},
+			`{
+				"id": "nodepoolid",
+				"name": "New name",
+				"scaling": {
+					"min": 10,
+					"max": 20
+				}
+			}`,
+			&result{
+				NodePool: &models.V5GetNodePoolResponse{
+					ID:   "nodepoolid",
+					Name: "New name",
+					Scaling: &models.V5GetNodePoolResponseScaling{
+						Min: 10,
+						Max: 20,
+					},
+				},
+			},
+		},
+		// Scaling change max only.
+		{
+			Arguments{
+				ClusterID:  "clusterid",
+				NodePoolID: "nodepoolid",
+				AuthToken:  "token",
+				ScalingMax: 10,
+			},
+			`{
+				"id": "nodepoolid",
+				"name": "New name",
+				"scaling": {
+					"min": 3,
+					"max": 10
+				}
+			}`,
+			&result{
+				NodePool: &models.V5GetNodePoolResponse{
+					ID:   "nodepoolid",
+					Name: "New name",
+					Scaling: &models.V5GetNodePoolResponseScaling{
+						Min: 3,
+						Max: 10,
+					},
+				},
+			},
+		},
+	}
+
+	fs := afero.NewMemMapFs()
+	_, err := testutils.TempConfig(fs, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			// set up mock server
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				t.Logf("Mock request: %s %s", r.Method, r.URL.Path)
+				w.Header().Set("Content-Type", "application/json")
+				if r.Method == "PATCH" && r.URL.Path == "/v5/clusters/clusterid/nodepools/nodepoolid/" {
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte(tc.responseBody))
+				} else {
+					t.Errorf("Case %d - Unsupported operation %s %s called in mock server", i, r.Method, r.URL.Path)
+				}
+			}))
+			defer mockServer.Close()
+
+			tc.args.APIEndpoint = mockServer.URL
+
+			err := verifyPreconditions(tc.args)
+			if err != nil {
+				t.Fatalf("Case %d - Unxpected error '%s'", i, err)
+			}
+
+			result, err := updateNodePool(tc.args)
+			if err != nil {
+				t.Fatalf("Case %d - Unxpected error '%s'", i, err)
+			}
+
+			if diff := cmp.Diff(tc.expectedResult, result); diff != "" {
+				t.Errorf("Case %d - Results unequal. (-expected +got):\n%s", i, diff)
+			}
+		})
+	}
+}
+
+// TestExecuteWithError tests the error handling.
+func TestExecuteWithError(t *testing.T) {
+	var testCases = []struct {
+		args               Arguments
+		responseStatusCode int
+		responseBody       string
+		errorMatcher       func(error) bool
+	}{
+		{
+			Arguments{
+				ClusterID:   "clusterid",
+				NodePoolID:  "nodepoolid",
+				AuthToken:   "token",
+				APIEndpoint: "https://mock-url",
+				Name:        "weird-name",
+			},
+			401,
+			`{"code": "FORBIDDEN", "message": "Here is some error message"}`,
+			errors.IsNotAuthorizedError,
+		},
+		{
+			Arguments{
+				ClusterID:   "clusterid",
+				NodePoolID:  "nodepoolid",
+				AuthToken:   "token",
+				APIEndpoint: "https://mock-url",
+				Name:        "weird-name",
+			},
+			403,
+			`{"code": "FORBIDDEN", "message": "Here is some error message"}`,
+			errors.IsAccessForbiddenError,
+		},
+		{
+			Arguments{
+				ClusterID:   "clusterid",
+				NodePoolID:  "nodepoolid",
+				AuthToken:   "token",
+				APIEndpoint: "https://mock-url",
+				Name:        "weird-name",
+			},
+			404,
+			`{"code": "RESOURCE_NOT_FOUND", "message": "Here is some error message"}`,
+			errors.IsClusterNotFoundError,
+		},
+		{
+			Arguments{
+				ClusterID:   "clusterid",
+				NodePoolID:  "nodepoolid",
+				AuthToken:   "token",
+				APIEndpoint: "https://mock-url",
+				Name:        "weird-name",
+			},
+			500,
+			`{"code": "UNKNOWN_ERROR", "message": "Here is some error message"}`,
+			errors.IsInternalServerError,
+		},
+	}
+
+	fs := afero.NewMemMapFs()
+	_, err := testutils.TempConfig(fs, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if r.Method == "PATCH" && r.URL.Path == "/v5/clusters/clusterid/nodepools/nodepoolid/" {
+					w.WriteHeader(tc.responseStatusCode)
+					w.Write([]byte(tc.responseBody))
+				} else {
+					t.Errorf("Unsupported operation %s %s called in mock server", r.Method, r.URL.Path)
+					w.WriteHeader(http.StatusNotFound)
+					w.Write([]byte(`{"code": "RESOURCE_NOT_FOUND", "message": "Status for this cluster is not yet available."}`))
+				}
+			}))
+			defer mockServer.Close()
+
+			tc.args.APIEndpoint = mockServer.URL
+
+			_, err := updateNodePool(tc.args)
+			if err == nil {
+				t.Errorf("Case %d - Expected error, got nil", i)
+			} else if !tc.errorMatcher(err) {
+				t.Errorf("Case %d - Error did not match expectec type. Got '%s'", i, err)
+			}
+		})
+	}
+}

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -35,6 +35,9 @@ var (
 	// Full represents the switch to disable all output truncation, passed as a flag.
 	Full bool
 
+	// Name is the name of a cluster or node pool.
+	Name string
+
 	// NumWorkers is the number of workers required via flag on execution.
 	NumWorkers int
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6447

This PR adds the `gsctl updatge nodepool` command to modify a node pool.

## Usage preview

```
$ gsctl update nodepool -h
Change the name or the scaling settings of a node pool.

Examples:

  gsctl update nodepool f01r4/75rh1 --name "General purpose M5"

  gsctl update nodepool f01r4/75rh1 --nodes-min 10 --nodes-max 20

Usage:
  gsctl update nodepool <cluster-id>/<nodepool-id> [flags]

Aliases:
  nodepool, np

Flags:
  -h, --help            help for nodepool
  -n, --name string     name or purpose description of the node pool
      --nodes-max int   Maximum number of worker nodes for the node pool.
      --nodes-min int   Minimum number of worker nodes for the node pool.

...
```

## Execution preview

```
$ gsctl update nodepool m0ckd/foo --nodes-min 1 --nodes-max 2 --name "my great pool"
Node pool 'my great pool' (ID 'foo') in cluster 'm0ckd' has been modified.
```

## TODO

- [ ] Add tests