### PR TITLE
Provide better feedback in case of TLS certificate problems

### DIFF
--- a/client/clienterror/clienterror.go
+++ b/client/clienterror/clienterror.go
@@ -2,6 +2,7 @@ package clienterror
 
 import (
 	"context"
+	"crypto/x509"
 	"fmt"
 	"net"
 	"net/http"
@@ -538,6 +539,62 @@ func New(err error) *APIError {
 
 				return ae
 			}
+		}
+
+		// certificate signed by unknown authority
+		if certError, certErrorOK := urlError.Err.(x509.UnknownAuthorityError); certErrorOK {
+			ae.OriginalError = certError
+			ae.ErrorMessage = "Certificate signed by an unknown authority"
+			ae.ErrorDetails = fmt.Sprintf("The server's certificate has been signed by '%s'.", certError.Cert.Issuer)
+
+			return ae
+		}
+
+		// certificate hostname mismatch
+		if certError, certErrorOK := urlError.Err.(x509.HostnameError); certErrorOK {
+			ae.OriginalError = certError
+			ae.ErrorMessage = "Certificate host name mismatch"
+
+			// Extract hostname from request URL, if possible.
+			displayURL := urlError.URL
+			parsedURL, parsedURLErr := url.Parse(urlError.URL)
+			if parsedURLErr == nil {
+				displayURL = parsedURL.Host
+			}
+
+			ae.ErrorDetails = fmt.Sprintf("The certificate host name(s) (%s) does not match the URL '%s'.", strings.Join(certError.Certificate.DNSNames, ", "), displayURL)
+
+			return ae
+		}
+
+		// certificate invalid
+		if certError, certErrorOK := urlError.Err.(x509.CertificateInvalidError); certErrorOK {
+			ae.OriginalError = certError
+			ae.ErrorMessage = "Certificate is invalid"
+			switch certError.Reason {
+			case x509.NotAuthorizedToSign:
+				ae.ErrorDetails += fmt.Sprintf("\nThe certificate has been signed with another cert that is not a CA.")
+			case x509.Expired:
+				ae.ErrorDetails += fmt.Sprintf("The certificate has expired (NotBefore: %s, NotAfter: %s).", certError.Cert.NotBefore, certError.Cert.NotAfter)
+			case x509.CANotAuthorizedForThisName:
+				ae.ErrorDetails += fmt.Sprintf("\nThe intermediate or root CA has a name constraint that does not permit signing a certificate with this name/IP.")
+			case x509.TooManyIntermediates:
+				ae.ErrorDetails += fmt.Sprintf("\nThere are too many intermediate CAs in the chain.")
+			case x509.IncompatibleUsage:
+				ae.ErrorDetails += fmt.Sprintf("\nThe certificate has been issued for a purpose other than server communication.")
+			case x509.NameMismatch:
+				ae.ErrorDetails += fmt.Sprintf("\nThe subject name of a parent certificate does not match the issuer name in the child.")
+			case x509.NameConstraintsWithoutSANs:
+				ae.ErrorDetails += fmt.Sprintf("\nThe CA certificate contains name constrains, but the server certififcate does not include a Subject Alternative Name extension.")
+			case x509.UnconstrainedName:
+				ae.ErrorDetails += fmt.Sprintf("\nThe CA certificate contains permitted name constrains, but the server certififcate contains a name of an unsupported or unconstrained type.")
+			case x509.TooManyConstraints:
+				ae.ErrorDetails += fmt.Sprintf("\nThe number of comparison operations needed to check the certificate exceed the limit.")
+			case x509.CANotAuthorizedForExtKeyUsage:
+				ae.ErrorDetails += fmt.Sprintf("\nThe intermediate or root certificate does not permit a requested extended key usage.")
+			}
+
+			return ae
 		}
 
 		return ae

--- a/client/clienterror/matcher.go
+++ b/client/clienterror/matcher.go
@@ -1,6 +1,7 @@
 package clienterror
 
 import (
+	"crypto/x509"
 	"net/http"
 
 	"github.com/giantswarm/microerror"
@@ -81,5 +82,41 @@ func IsInternalServerError(err error) bool {
 	if apiErr, apiErrOK := microerror.Cause(err).(*APIError); apiErrOK {
 		return apiErr.HTTPStatusCode == http.StatusInternalServerError
 	}
+	return false
+}
+
+// IsCertificateSignedByUnknownAuthorityError checks whether the error represents
+// a x509.UnknownAuthorityError
+func IsCertificateSignedByUnknownAuthorityError(err error) bool {
+	if clientErr, ok := err.(*APIError); ok {
+		if _, certErrorOK := clientErr.OriginalError.(x509.UnknownAuthorityError); certErrorOK {
+			return true
+		}
+	}
+
+	return false
+}
+
+// IsCertificateHostnameError checks whether the error represents
+// a x509.HostnameError
+func IsCertificateHostnameError(err error) bool {
+	if clientErr, ok := err.(*APIError); ok {
+		if _, certErrorOK := clientErr.OriginalError.(x509.HostnameError); certErrorOK {
+			return true
+		}
+	}
+
+	return false
+}
+
+// IsCertificateInvalidError checks whether the error represents
+// a x509.UnknownAuthorityError
+func IsCertificateInvalidError(err error) bool {
+	if clientErr, ok := err.(*APIError); ok {
+		if _, certErrorOK := clientErr.OriginalError.(x509.CertificateInvalidError); certErrorOK {
+			return true
+		}
+	}
+
 	return false
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/4121

This PR adds specific error output for cases where the API server certificate cannot be accepted.

### Previews

```
$ gsctl list clusters -e https://expired.badssl.com
Certificate is invalid
The certificate has expired (NotBefore: 2015-04-09 00:00:00 +0000 UTC, NotAfter: 2015-04-12 23:59:59 +0000 UTC).

$ gsctl list clusters -e https://wrong.host.badssl.com
Certificate host name mismatch
The certificate host name(s) (*.badssl.com, badssl.com) does not match the URL 'wrong.host.badssl.com'.

$ gsctl list clusters -e https://self-signed.badssl.com
Certificate signed by an unknown authority
The server's certificate has been signed by 'CN=*.badssl.com,O=BadSSL,L=San Francisco,ST=California,C=US'.
```

There are more cases considered in the code base, but I am unaware of any test servers to showcase them.
