### PR TITLE
'create cluster': Allow passing cluster definition to STDIN

### DIFF
--- a/commands/create/cluster/command.go
+++ b/commands/create/cluster/command.go
@@ -250,6 +250,13 @@ func printResult(cmd *cobra.Command, positionalArgs []string) {
 		case errors.IsNotEnoughWorkerNodesError(err):
 			headline = "Not enough worker nodes specified"
 			subtext = fmt.Sprintf("If you specify workers in your definition file, you'll have to specify at least %d worker nodes for a useful cluster.", limits.MinimumNumWorkers)
+		case errors.IsYAMLNotParseableError(err):
+			headline = "Could not parse YAML"
+			if aca.InputYAMLFile == "-" {
+				subtext = "The YAML data given via STDIN could not be parsed into a cluster definition."
+			} else {
+				subtext = fmt.Sprintf("The YAML data read from file '%s' could not be parsed into a cluster definition.", aca.InputYAMLFile)
+			}
 		case errors.IsYAMLFileNotReadableError(err):
 			headline = "Could not read YAML file"
 			subtext = fmt.Sprintf("The file '%s' could not read. Please make sure that it is valid YAML.", aca.InputYAMLFile)

--- a/commands/create/cluster/command.go
+++ b/commands/create/cluster/command.go
@@ -525,7 +525,6 @@ func addCluster(args Arguments) (*creationResult, error) {
 
 		result.definition, err = readDefinitionFromYAML([]byte(yamlString))
 		if err != nil {
-			fmt.Printf("Error: %#v\n", err)
 			return nil, microerror.Maskf(errors.YAMLFileNotReadableError, err.Error())
 		}
 	} else if args.InputYAMLFile != "" {

--- a/commands/create/cluster/command.go
+++ b/commands/create/cluster/command.go
@@ -252,14 +252,14 @@ func printResult(cmd *cobra.Command, positionalArgs []string) {
 		case errors.IsNotEnoughWorkerNodesError(err):
 			headline = "Not enough worker nodes specified"
 			subtext = fmt.Sprintf("If you specify workers in your definition file, you'll have to specify at least %d worker nodes for a useful cluster.", limits.MinimumNumWorkers)
-		case errors.IsYAMLNotParseableError(err):
+		case errors.IsYAMLNotParseable(err):
 			headline = "Could not parse YAML"
 			if aca.InputYAMLFile == "-" {
 				subtext = "The YAML data given via STDIN could not be parsed into a cluster definition."
 			} else {
 				subtext = fmt.Sprintf("The YAML data read from file '%s' could not be parsed into a cluster definition.", aca.InputYAMLFile)
 			}
-		case errors.IsYAMLFileNotReadableError(err):
+		case errors.IsYAMLFileNotReadable(err):
 			headline = "Could not read YAML file"
 			subtext = fmt.Sprintf("The file '%s' could not be read. Please make sure that it is readable and contains valid YAML.", aca.InputYAMLFile)
 		case errors.IsCouldNotCreateJSONRequestBodyError(err):

--- a/commands/create/cluster/command_test.go
+++ b/commands/create/cluster/command_test.go
@@ -197,12 +197,12 @@ func Test_ReadDefinitionFiles(t *testing.T) {
 func Test_ParseYAMLDefinition(t *testing.T) {
 	var testCases = []struct {
 		inputYAML      []byte
-		expectedOutput types.ClusterDefinition
+		expectedOutput *types.ClusterDefinition
 	}{
 		// Minimal YAML.
 		{
 			[]byte(`owner: myorg`),
-			types.ClusterDefinition{
+			&types.ClusterDefinition{
 				Owner: "myorg",
 			},
 		},
@@ -215,7 +215,7 @@ availability_zones: 3
 scaling:
   min: 3
   max: 5`),
-			types.ClusterDefinition{
+			&types.ClusterDefinition{
 				Owner:             "myorg",
 				Name:              "My cluster",
 				ReleaseVersion:    "1.2.3",
@@ -243,7 +243,7 @@ workers:
   storage:
     size_gb: 50
 `),
-			types.ClusterDefinition{
+			&types.ClusterDefinition{
 				Owner: "myorg",
 				Workers: []types.NodeDefinition{
 					types.NodeDefinition{
@@ -263,8 +263,7 @@ workers:
 
 	for i, tc := range testCases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			def := types.ClusterDefinition{}
-			err := yaml.Unmarshal(tc.inputYAML, &def)
+			def, err := readDefinitionFromYAML(tc.inputYAML)
 			if err != nil {
 				t.Errorf("Case %d - Unexpected error %v", i, err)
 			}

--- a/commands/create/cluster/command_test.go
+++ b/commands/create/cluster/command_test.go
@@ -458,7 +458,7 @@ func Test_CreateClusterExecutionFailures(t *testing.T) {
 			},
 			serverResponseJSON: []byte(``),
 			responseStatus:     0,
-			errorMatcher:       errors.IsYAMLFileNotReadableError,
+			errorMatcher:       errors.IsYAMLFileNotReadable,
 		},
 	}
 

--- a/commands/errors/errors.go
+++ b/commands/errors/errors.go
@@ -308,8 +308,8 @@ var YAMLFileNotReadableError = &microerror.Error{
 	Kind: "YAMLFileNotReadableError",
 }
 
-// IsYAMLFileNotReadableError asserts YAMLFileNotReadableError.
-func IsYAMLFileNotReadableError(err error) bool {
+// IsYAMLFileNotReadable asserts YAMLFileNotReadableError.
+func IsYAMLFileNotReadable(err error) bool {
 	return microerror.Cause(err) == YAMLFileNotReadableError
 }
 
@@ -318,8 +318,8 @@ var YAMLNotParseableError = &microerror.Error{
 	Kind: "YAMLNotParseableError",
 }
 
-// IsYAMLNotParseableError asserts YAMLNotParseableError.
-func IsYAMLNotParseableError(err error) bool {
+// IsYAMLNotParseable asserts YAMLNotParseableError.
+func IsYAMLNotParseable(err error) bool {
 	return microerror.Cause(err) == YAMLNotParseableError
 }
 

--- a/commands/errors/errors.go
+++ b/commands/errors/errors.go
@@ -313,6 +313,16 @@ func IsYAMLFileNotReadableError(err error) bool {
 	return microerror.Cause(err) == YAMLFileNotReadableError
 }
 
+// YAMLNotParseableError means a YAML file was not readable
+var YAMLNotParseableError = &microerror.Error{
+	Kind: "YAMLNotParseableError",
+}
+
+// IsYAMLNotParseableError asserts YAMLNotParseableError.
+func IsYAMLNotParseableError(err error) bool {
+	return microerror.Cause(err) == YAMLNotParseableError
+}
+
 // CouldNotCreateJSONRequestBodyError occurs when we could not create a JSON
 // request body based on the input we have, so something in out input attributes
 // is wrong.


### PR DESCRIPTION
Towards https://github.com/giantswarm/gsctl/pull/355

This enables passing cluster definition YAML to `gsctl create cluster` via the command line.

### Example

```
$ gsctl create cluster -f - <<EOF
owner: giantswarm
name: My test cluster
release: 7.1.1
EOF

$ gsctl create cluster -f - <myfile.yaml

$ cat myfile.yaml | gsctl create cluster -f -
```

Especially with the first method it becomes more handy to write more complex cluster creation examples which can be copy/pasted for re-use without the need to create a file, at least into bash.
