### PR TITLE
Align build info in version and info commands

### DIFF
--- a/buildinfo/buildinfo.go
+++ b/buildinfo/buildinfo.go
@@ -1,8 +1,13 @@
 // Package buildinfo defines variables which are set by the Go linker on build time using ldflags.
 package buildinfo
 
-// Placeholder is the text we use to pre-set our variables.
-const Placeholder = "Not set - please use a binary release or use 'make' to build gsctl."
+const (
+	// Placeholder is the text we use to pre-set our variables.
+	Placeholder = "Not set - please use a binary release or use 'make' to build gsctl."
+
+	// VersionPlaceholder is the default we use for the verison number.
+	VersionPlaceholder = "Not set - only available in a binary release."
+)
 
 var (
 	// BuildDate is a string representing when the binary is built.
@@ -10,5 +15,5 @@ var (
 	// Commit is the commit SHA hash representing the state of the repository.
 	Commit = Placeholder
 	// Version is the semantic version number of the build.
-	Version = Placeholder
+	Version = VersionPlaceholder
 )

--- a/commands/info/command.go
+++ b/commands/info/command.go
@@ -94,10 +94,10 @@ func printInfo(cmd *cobra.Command, args []string) {
 
 	output := []string{}
 
-	if result.version != buildinfo.Placeholder && result.version != "" {
+	if result.version != buildinfo.VersionPlaceholder && result.version != "" {
 		output = append(output, color.YellowString("%s version:", config.ProgramName)+"|"+color.CyanString(result.version)+" - https://github.com/giantswarm/gsctl/releases/tag/"+result.version)
 	} else {
-		output = append(output, color.YellowString("%s version:", config.ProgramName)+"|"+color.RedString(buildinfo.Placeholder))
+		output = append(output, color.YellowString("%s version:", config.ProgramName)+"|"+color.CyanString(buildinfo.VersionPlaceholder))
 	}
 
 	if result.buildDate != buildinfo.Placeholder && result.buildDate != "" {

--- a/commands/info/command.go
+++ b/commands/info/command.go
@@ -94,22 +94,22 @@ func printInfo(cmd *cobra.Command, args []string) {
 
 	output := []string{}
 
+	if result.version != buildinfo.Placeholder && result.version != "" {
+		output = append(output, color.YellowString("%s version:", config.ProgramName)+"|"+color.CyanString(result.version)+" - https://github.com/giantswarm/gsctl/releases/tag/"+result.version)
+	} else {
+		output = append(output, color.YellowString("%s version:", config.ProgramName)+"|"+color.RedString(buildinfo.Placeholder))
+	}
+
+	if result.buildDate != buildinfo.Placeholder && result.buildDate != "" {
+		output = append(output, color.YellowString("%s build:", config.ProgramName)+"|"+color.CyanString(result.buildDate))
+	} else {
+		output = append(output, color.YellowString("%s build:", config.ProgramName)+"|"+color.RedString(buildinfo.Placeholder))
+	}
+
 	if result.commitHash != buildinfo.Placeholder {
 		output = append(output, color.YellowString("%s commit hash:", config.ProgramName)+"|"+color.CyanString(result.commitHash)+" - https://github.com/giantswarm/gsctl/commit/"+result.commitHash)
 	} else {
-		output = append(output, color.YellowString("%s commit hash:", config.ProgramName)+"|n/a")
-	}
-
-	if result.version != buildinfo.Placeholder {
-		output = append(output, color.YellowString("%s version:", config.ProgramName)+"|"+color.CyanString(result.version))
-	} else {
-		output = append(output, color.YellowString("%s version:", config.ProgramName)+"|n/a")
-	}
-
-	if result.buildDate != buildinfo.Placeholder {
-		output = append(output, color.YellowString("%s build:", config.ProgramName)+"|"+color.CyanString(result.buildDate))
-	} else {
-		output = append(output, color.YellowString("%s build:", config.ProgramName)+"|"+color.RedString(result.buildDate))
+		output = append(output, color.YellowString("%s commit hash:", config.ProgramName)+"|"+color.RedString(buildinfo.Placeholder))
 	}
 
 	output = append(output, color.YellowString("Config path:")+"|"+color.CyanString(result.configFilePath))

--- a/commands/version/command.go
+++ b/commands/version/command.go
@@ -12,6 +12,7 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/spf13/cobra"
 
+	"github.com/giantswarm/gsctl/buildinfo"
 	"github.com/giantswarm/gsctl/commands/errors"
 	"github.com/giantswarm/gsctl/util"
 )
@@ -42,16 +43,24 @@ When executed with the -v/--verbose flag, the build date is printed in addition.
 func printVersion(cmd *cobra.Command, args []string) {
 	output := []string{}
 
-	if config.Version != "" {
-		output = append(output, color.YellowString("Version:")+"|"+color.CyanString(config.Version))
+	if buildinfo.Version != buildinfo.Placeholder && buildinfo.Version != "" {
+		output = append(output, color.YellowString("Version:")+"|"+color.CyanString(buildinfo.Version)+" - https://github.com/giantswarm/gsctl/releases/tag/"+buildinfo.Version)
 	} else {
-		output = append(output, color.YellowString("Version:")+"|"+color.CyanString("n/a (version number is only available in a built binary)"))
+		output = append(output, color.YellowString("Version:")+"|"+color.RedString(buildinfo.Placeholder))
 	}
-	if config.BuildDate != "" {
-		output = append(output, color.YellowString("Build date:")+"|"+color.CyanString(config.BuildDate))
+
+	if buildinfo.BuildDate != buildinfo.Placeholder {
+		output = append(output, color.YellowString("Build date:")+"|"+color.CyanString(buildinfo.BuildDate))
 	} else {
-		output = append(output, color.YellowString("Build date:")+"|"+color.CyanString("n/a (build date/time is only available in a built binary)"))
+		output = append(output, color.YellowString("Build date:")+"|"+color.RedString(buildinfo.Placeholder))
 	}
+
+	if buildinfo.Commit != buildinfo.Placeholder {
+		output = append(output, color.YellowString("Commit hash:")+"|"+color.CyanString(buildinfo.Commit)+" - https://github.com/giantswarm/gsctl/commit/"+buildinfo.Commit)
+	} else {
+		output = append(output, color.YellowString("Commit hash:")+"|"+color.RedString(buildinfo.Placeholder))
+	}
+
 	fmt.Println(columnize.SimpleFormat(output))
 
 	// check for an update

--- a/commands/version/command.go
+++ b/commands/version/command.go
@@ -43,10 +43,10 @@ When executed with the -v/--verbose flag, the build date is printed in addition.
 func printVersion(cmd *cobra.Command, args []string) {
 	output := []string{}
 
-	if buildinfo.Version != buildinfo.Placeholder && buildinfo.Version != "" {
+	if buildinfo.Version != buildinfo.VersionPlaceholder && buildinfo.Version != "" {
 		output = append(output, color.YellowString("Version:")+"|"+color.CyanString(buildinfo.Version)+" - https://github.com/giantswarm/gsctl/releases/tag/"+buildinfo.Version)
 	} else {
-		output = append(output, color.YellowString("Version:")+"|"+color.RedString(buildinfo.Placeholder))
+		output = append(output, color.YellowString("Version:")+"|"+color.CyanString(buildinfo.VersionPlaceholder))
 	}
 
 	if buildinfo.BuildDate != buildinfo.Placeholder {


### PR DESCRIPTION
This fixes several problems in the `gsctl info` and `gsctl version` command output.

- Use the `buildinfo` package in the `gsctl version` command to actually output build info again
- Align the output between `gsctl info` and `gsctl version`

One goal is to hunch user to use `make` over `go build` so they have a git hash compiled in which can be helpful in a debugging situation.

### Preview

Output for a build done via `go build`:

![image](https://user-images.githubusercontent.com/273727/63158294-3d7f9e80-c019-11e9-9ac5-129cb57bea51.png)

Output for a build done via `make`:

![image](https://user-images.githubusercontent.com/273727/63158564-ceef1080-c019-11e9-9adc-0d0d275df7a3.png)

