### PR TITLE
'gsctl show cluster': Add handling for cluster not found error

### DIFF
--- a/commands/show/cluster/command.go
+++ b/commands/show/cluster/command.go
@@ -345,7 +345,6 @@ func printResult(cmd *cobra.Command, cmdLineArgs []string) {
 	}
 
 	clusterDetailsV4, clusterDetailsV5, nodePools, clusterStatus, credentialDetails, err := getClusterDetails(args)
-	fmt.Printf("DEBUG: err = %#v\n", err)
 	if err != nil {
 		errors.HandleCommonErrors(err)
 

--- a/commands/show/cluster/command.go
+++ b/commands/show/cluster/command.go
@@ -345,8 +345,28 @@ func printResult(cmd *cobra.Command, cmdLineArgs []string) {
 	}
 
 	clusterDetailsV4, clusterDetailsV5, nodePools, clusterStatus, credentialDetails, err := getClusterDetails(args)
+	fmt.Printf("DEBUG: err = %#v\n", err)
 	if err != nil {
 		errors.HandleCommonErrors(err)
+
+		headline := ""
+		subtext := ""
+
+		switch {
+		case errors.IsClusterNotFoundError(err):
+			headline = "Cluster not found"
+			subtext = fmt.Sprintf("Either there is no cluster with ID '%s', or you have no access to it.\n", args.clusterID)
+			subtext += "Please check whether the cluster is listed when executing 'gsctl list clusters'."
+		default:
+			headline = "Unknown error"
+			subtext = "Please contact the Giant Swarm support team and share details about the command you just executed."
+		}
+
+		fmt.Println(color.RedString(headline))
+		if subtext != "" {
+			fmt.Println(subtext)
+		}
+		os.Exit(1)
 	}
 
 	if clusterDetailsV4 != nil {


### PR DESCRIPTION
This PR adds user-friendly error output in the case that the cluster could not be found via v5 nor v4  detail endpoints. Without this change, there is no output and gsctl exits with status 0 in this case.

## Preview

```
$ gsctl show cluster dfdg -v
Fetching details for cluster dfdg.
Fetching details for cluster via v5 API endpoint.
No usable v5 response. Fetching details for cluster via v4 API endpoint.
Cluster not found
Either there is no cluster with ID 'dfdg', or you have no access to it.
Please check whether the cluster is listed when executing 'gsctl list clusters'.
```