### PR TITLE
Allow JSON output for 'gsctl list clusters'

### DIFF
--- a/commands/errors/errors.go
+++ b/commands/errors/errors.go
@@ -666,6 +666,16 @@ func IsWorkersMinMaxInvalid(err error) bool {
 	return microerror.Cause(err) == WorkersMinMaxInvalidError
 }
 
+// OutputFormatInvalidError is raised when the user specifies an unsupported output format.
+var OutputFormatInvalidError = &microerror.Error{
+	Kind: "OutputFormatInvalidError",
+}
+
+// IsOutputFormatInvalid asserts OutputFormatInvalidError.
+func IsOutputFormatInvalid(err error) bool {
+	return microerror.Cause(err) == OutputFormatInvalidError
+}
+
 // NoOpError is raised when the user calls a command without any meaningful
 // parameters, resulting in no change/nothing done.
 var NoOpError = &microerror.Error{

--- a/commands/list/clusters/command_test.go
+++ b/commands/list/clusters/command_test.go
@@ -68,7 +68,7 @@ func Test_ListClusters(t *testing.T) {
 		t.Error(err)
 	}
 
-	table, err := clustersTable(args)
+	table, err := getClustersOutput(args)
 	if err != nil {
 		t.Error(err)
 	}
@@ -95,7 +95,7 @@ func Test_ListClustersEmpty(t *testing.T) {
 		t.Error(err)
 	}
 
-	table, err := clustersTable(args)
+	table, err := getClustersOutput(args)
 	if err != nil {
 		t.Error(err)
 	}
@@ -124,7 +124,7 @@ func Test_ListClustersUnauthorized(t *testing.T) {
 		t.Error(err)
 	}
 
-	_, err = clustersTable(args)
+	_, err = getClustersOutput(args)
 	if !errors.IsNotAuthorizedError(err) {
 		t.Errorf("Expected NotAuthorizedError, got %#v", err)
 	}

--- a/commands/list/clusters/command_test.go
+++ b/commands/list/clusters/command_test.go
@@ -59,8 +59,9 @@ func Test_ListClusters(t *testing.T) {
 	defer mockServer.Close()
 
 	args := Arguments{
-		apiEndpoint: mockServer.URL,
-		authToken:   "testtoken",
+		apiEndpoint:  mockServer.URL,
+		authToken:    "testtoken",
+		outputFormat: "table",
 	}
 
 	err := verifyListClusterPreconditions(args)
@@ -86,8 +87,9 @@ func Test_ListClustersEmpty(t *testing.T) {
 	defer mockServer.Close()
 
 	args := Arguments{
-		apiEndpoint: mockServer.URL,
-		authToken:   "testtoken",
+		apiEndpoint:  mockServer.URL,
+		authToken:    "testtoken",
+		outputFormat: "table",
 	}
 
 	err := verifyListClusterPreconditions(args)
@@ -115,8 +117,9 @@ func Test_ListClustersUnauthorized(t *testing.T) {
 	defer mockServer.Close()
 
 	args := Arguments{
-		apiEndpoint: mockServer.URL,
-		authToken:   "testtoken",
+		apiEndpoint:  mockServer.URL,
+		authToken:    "testtoken",
+		outputFormat: "table",
 	}
 
 	err := verifyListClusterPreconditions(args)


### PR DESCRIPTION
Towards https://github.com/giantswarm/gsctl/issues/297

This PR adds a flag `-o` or `--output` to the `gsctl list clusters` command to print machine-readable JSON output instead of the human-friendly table.

The JSON output resembles exactly what the API provides for the according calls, applying indentation for general readability.

### Preview

Empty result:

```nohighlight
$ gsctl list clusters
No clusters

$ gsctl list clusters -o json
[]
```

Result with entries:

```nohighlight
$ gsctl list clusters -o json
[
  {
    "create_date": "2019-08-14T12:46:22.950823608Z",
    "id": "0xhzq",
    "name": "test_cluster",
    "owner": "acme
    "path": "/v4/clusters/0xhzq/",
    "release_version": "8.3.0"
  },
  ...
]

$ gsctl list clusters -o json | jq .[2]
{
  "create_date": "2018-07-19T14:09:15.444580239Z",
  "id": "6iec4",
  "name": "Giant Swarm Frontend",
  "owner": "giantswarm",
  "path": "/v4/clusters/6iec4/",
  "release_version": "8.2.0"
}
```
