### PR TITLE
Add support for intenal-api kubeconfig rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,19 @@ Whenever you want to switch to using this context:
     kubectl config use-context giantswarm-xl8t1
 ```
 
+#### Cluster acccess via internal networks
+
+Internal Kubernetes API allows you talking to Kubernetes via internal load balancer. That can be useful for peered networks.
+
+In case you want to use internal Kubernetes API, pass `--tenant-internal=true` to gsctl:
+```nohighlight
+$ gsctl create kubeconfig -c h8d0j
+```
+
+This will render kubeconfig with internal Kubernetes API server (`internal-api`).
+
+* Internal API is awailable only for AWS installations.
+
 ## Install
 
 See the [`gsctl` reference docs](https://docs.giantswarm.io/reference/gsctl/#install)

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Whenever you want to switch to using this context:
 
 #### Cluster acccess via internal networks
 
-Internal Kubernetes API allows you talking to Kubernetes via internal load balancer. That can be useful for peered networks.
+The Internal Kubernetes API allows you to talk to Kubernetes via the internal load balancer. That can be useful for peered networks.
 
 In case you want to use internal Kubernetes API, pass `--tenant-internal=true` to gsctl:
 ```nohighlight

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ In case you want to use internal Kubernetes API, pass `--tenant-internal=true` t
 $ gsctl create kubeconfig -c h8d0j
 ```
 
-This will render kubeconfig with internal Kubernetes API server (`internal-api`).
+This will render a kubeconfig with the internal Kubernetes API server address (`internal-api`).
 
 * Internal API is available only on AWS installations.
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Whenever you want to switch to using this context:
 
 The Internal Kubernetes API allows you to talk to Kubernetes via the internal load balancer. That can be useful for peered networks.
 
-In case you want to use internal Kubernetes API, pass `--tenant-internal=true` to gsctl:
+In case you want to use the internal Kubernetes API, pass `--tenant-internal=true` to gsctl:
 ```nohighlight
 $ gsctl create kubeconfig -c h8d0j
 ```

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ $ gsctl create kubeconfig -c h8d0j
 
 This will render kubeconfig with internal Kubernetes API server (`internal-api`).
 
-* Internal API is awailable only for AWS installations.
+* Internal API is available only on AWS installations.
 
 ## Install
 

--- a/commands/create/kubeconfig/command.go
+++ b/commands/create/kubeconfig/command.go
@@ -383,7 +383,7 @@ func createKubeconfig(ctx context.Context, args Arguments) (createKubeconfigResu
 	{
 		if args.tenantInternal {
 			baseEndpoint := strings.Split(clusterDetailsResponse.Payload.APIEndpoint, urlDelimiter)[1:]
-			apiEndpoint = fmt.Sprintf("%s.%s", tenantInternalAPIPrefix, strings.Join(baseEndpoint, urlDelimiter))
+			apiEndpoint = fmt.Sprintf("https://%s.%s", tenantInternalAPIPrefix, strings.Join(baseEndpoint, urlDelimiter))
 		} else {
 			apiEndpoint = clusterDetailsResponse.Payload.APIEndpoint
 		}

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -25,6 +25,10 @@ var (
 	// Description represents the description passed as a flag.
 	Description string
 
+	// TenantInternal represents the type of Kubernetes API endpoints
+	// used to generate kubeconfig
+	TenantInternal bool
+
 	// TTL represents a TTL (time to live) value passed as a flag.
 	TTL string
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6924

The solution here is not super nice.
But as the first step for providing customer access to k8s only via internal API - should work fine. 

It basically reconstructs tenant api domain with `internal-api` prefix as flag `tenant-internal=true` 