### PR TITLE
Adapt 'gsctl create kubeconfig' to add support for v5 clusters

### DIFF
--- a/commands/create/keypair/command.go
+++ b/commands/create/keypair/command.go
@@ -49,6 +49,7 @@ type Arguments struct {
 	scheme                   string
 	ttlHours                 int32
 	userProvidedToken        string
+	verbose                  bool
 }
 
 // collectArguments puts together arguments for our business function
@@ -83,6 +84,7 @@ func collectArguments() (Arguments, error) {
 		scheme:                   scheme,
 		ttlHours:                 int32(ttl.Hours()),
 		userProvidedToken:        flags.Token,
+		verbose:                  flags.Verbose,
 	}, nil
 }
 

--- a/commands/create/kubeconfig/command.go
+++ b/commands/create/kubeconfig/command.go
@@ -2,6 +2,7 @@
 package kubeconfig
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -469,7 +470,9 @@ func createKubeconfig(ctx context.Context, args Arguments) (createKubeconfigResu
 	} else {
 		// create a self-contained kubeconfig
 		var yamlBytes []byte
-		logger, err := micrologger.New(micrologger.Config{})
+		logger, err := micrologger.New(micrologger.Config{
+			IOWriter: new(bytes.Buffer), // to suppress any log output
+		})
 		if err != nil {
 			return result, microerror.Mask(err)
 		}

--- a/commands/create/kubeconfig/command.go
+++ b/commands/create/kubeconfig/command.go
@@ -382,8 +382,7 @@ func getClusterDetails(clientWrapper *client.Wrapper, clusterID string, auxParam
 		}
 
 		if clientErr, ok := err.(*clienterror.APIError); ok {
-			return "", microerror.Maskf(clientErr,
-				fmt.Sprintf("HTTP Status: %d, %s", clientErr.HTTPStatusCode, clientErr.ErrorMessage))
+			return "", microerror.Maskf(clientErr, "HTTP Status: %d, %s", clientErr.HTTPStatusCode, clientErr.ErrorMessage)
 		}
 
 		return "", microerror.Mask(err)

--- a/commands/create/kubeconfig/command.go
+++ b/commands/create/kubeconfig/command.go
@@ -101,6 +101,7 @@ type Arguments struct {
 	selfContainedPath string
 	ttlHours          int32
 	userProvidedToken string
+	verbose           bool
 }
 
 // collectArguments gathers arguments based on command line
@@ -144,6 +145,7 @@ func collectArguments() (Arguments, error) {
 		selfContainedPath: cmdKubeconfigSelfContained,
 		ttlHours:          int32(ttl.Hours()),
 		userProvidedToken: flags.Token,
+		verbose:           flags.Verbose,
 	}, nil
 }
 
@@ -339,10 +341,12 @@ func createKubeconfigRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 		fmt.Println(color.YellowString("    kubectl cluster-info\n"))
 
 	} else {
-		fmt.Println("Certificate and key files written to:")
-		fmt.Println(result.caCertPath)
-		fmt.Println(result.clientCertPath)
-		fmt.Println(result.clientKeyPath)
+		if args.verbose {
+			fmt.Println(color.WhiteString("Certificate and key files written to:"))
+			fmt.Println(color.WhiteString(result.caCertPath))
+			fmt.Println(color.WhiteString(result.clientCertPath))
+			fmt.Println(color.WhiteString(result.clientKeyPath))
+		}
 
 		fmt.Printf("Switched to kubectl context '%s'\n\n", result.contextName)
 

--- a/commands/create/kubeconfig/command_test.go
+++ b/commands/create/kubeconfig/command_test.go
@@ -21,7 +21,10 @@ func makeMockServer() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Printf("mockServer request: %s %s\n", r.Method, r.URL)
 		w.Header().Set("Content-Type", "application/json")
-		if r.Method == "GET" && r.URL.String() == "/v4/clusters/test-cluster-id/" {
+		if r.Method == "GET" && r.URL.String() == "/v5/clusters/test-cluster-id/" {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"code": "RESOURCE_NOT_FOUND", "message": "There is no v5 cluster with this ID."}`))
+		} else if r.Method == "GET" && r.URL.String() == "/v4/clusters/test-cluster-id/" {
 			// return cluster details
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(`{


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6447, https://github.com/giantswarm/giantswarm/issues/5465

This PR changes the behaviour if the `gsctl create kubeconfig` command

- to support v5 clusters, as it attempts to fetch v5 cluster details for the given cluster ID first, then only attempts v4 if that failed.
- some output regarding the crteated files is only printed when the `-v`/`--verbose` flag is applied, to make the output cleaner.

### Preview

![image](https://user-images.githubusercontent.com/273727/65887863-ed795300-e39e-11e9-9af6-dfdb6cc0cf15.png)
