### PR TITLE
Configure micrologger to be quiet

### DIFF
--- a/commands/create/kubeconfig/command.go
+++ b/commands/create/kubeconfig/command.go
@@ -2,6 +2,7 @@
 package kubeconfig
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -443,7 +444,9 @@ func createKubeconfig(ctx context.Context, args Arguments) (createKubeconfigResu
 	} else {
 		// create a self-contained kubeconfig
 		var yamlBytes []byte
-		logger, err := micrologger.New(micrologger.Config{})
+		logger, err := micrologger.New(micrologger.Config{
+			IOWriter: new(bytes.Buffer), // to suppress any log output
+		})
 		if err != nil {
 			return result, microerror.Mask(err)
 		}


### PR DESCRIPTION
`gsctl create kubeconfig` when executed with the `--self-contained` flag would print two lines of JSON debug logging, coming from `github.com/giantswarm/operatorkit/client/k8srestconfig`.

This PR disables any logging from `k8srestconfig`, as this is in general not desired in a CLI like gsctl.

### Before

```
./gsctl create kubeconfig --self-contained output.yaml -c v4cls

{"caller":"github.com/giantswarm/operatorkit/client/k8srestconfig/k8s_rest_config.go:158","level":"debug","message":"creating out-cluster REST config","time":"2019-10-02T12:07:44.633711+00:00"}
{"caller":"github.com/giantswarm/operatorkit/client/k8srestconfig/k8s_rest_config.go:173","level":"debug","message":"created out-cluster REST config","time":"2019-10-02T12:07:44.633778+00:00"}
New key pair created with ID 48b901ce3… and expiry of 1 day
Self-contained kubectl config file written to: output.yaml

To make use of this file, run:

    export KUBECONFIG=output.yaml
    kubectl cluster-info
```

### After

```
./gsctl create kubeconfig --self-contained output.yaml -c v4cls

New key pair created with ID 48b901ce3… and expiry of 1 day
Self-contained kubectl config file written to: output.yaml

To make use of this file, run:

    export KUBECONFIG=output.yaml
    kubectl cluster-info
```