### PR TITLE
gsctl list nodepools: If no node pools exist, print friendly info

### DIFF
--- a/commands/list/nodepools/command.go
+++ b/commands/list/nodepools/command.go
@@ -172,6 +172,11 @@ func printResult(cmd *cobra.Command, positionalArgs []string) {
 		os.Exit(1)
 	}
 
+	if len(nodePools) == 0 {
+		fmt.Println(color.YellowString("This cluster has no node pools"))
+		return
+	}
+
 	table := []string{}
 
 	headers := []string{


### PR DESCRIPTION
### Before

```
$ gsctl list nodepools abc12
ID  NAME  AZ  INSTANCE TYPE  NODES MIN/MAX  NODES DESIRED  NODES READY  CPUS  RAM (GB)
```

### After

```
$ gsctl list nodepools abc12
This cluster has no node pools
```