### PR TITLE
Support JSON output in 'list releases'

### DIFF
--- a/commands/list/releases/command.go
+++ b/commands/list/releases/command.go
@@ -2,6 +2,7 @@
 package releases
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"sort"
@@ -24,6 +25,12 @@ import (
 
 const (
 	listReleasesActivityName = "list-releases"
+
+	outputFormatJSON  = "json"
+	outputFormatTable = "table"
+
+	outputJSONPrefix = ""
+	outputJSONIndent = "  "
 )
 
 var (
@@ -37,14 +44,27 @@ A release is a software bundle that constitutes a cluster. It is identified by i
 		PreRun: printValidation,
 		Run:    printResult,
 	}
+
+	cmdOutput string
 )
+
+func init() {
+	initFlags()
+}
+
+func initFlags() {
+	Command.ResetFlags()
+
+	Command.Flags().StringVarP(&cmdOutput, "output", "o", "table", "Use 'json' for JSON output.")
+}
 
 // Arguments are the actual arguments used to call the
 // listReleases() function.
 type Arguments struct {
 	apiEndpoint       string
-	token             string
+	outputFormat      string
 	scheme            string
+	token             string
 	userProvidedToken string
 }
 
@@ -57,6 +77,7 @@ func collectArguments() Arguments {
 
 	return Arguments{
 		apiEndpoint:       endpoint,
+		outputFormat:      cmdOutput,
 		token:             token,
 		scheme:            scheme,
 		userProvidedToken: flags.Token,
@@ -85,6 +106,9 @@ func listReleasesPreconditions(args *Arguments) error {
 	if config.Config.Token == "" && args.token == "" {
 		return microerror.Mask(errors.NotLoggedInError)
 	}
+	if args.outputFormat != outputFormatJSON && args.outputFormat != outputFormatTable {
+		return microerror.Maskf(errors.OutputFormatInvalidError, fmt.Sprintf("Output format '%s' is unknown", args.outputFormat))
+	}
 
 	return nil
 }
@@ -108,6 +132,18 @@ func printResult(cmd *cobra.Command, extraArgs []string) {
 			fmt.Println(color.RedString("Error: %s", err.Error()))
 		}
 		os.Exit(1)
+	}
+
+	if args.outputFormat == "json" {
+		outputBytes, err := json.MarshalIndent(releases, outputJSONPrefix, outputJSONIndent)
+		if err != nil {
+			fmt.Println(color.RedString("Error while encoding JSON"))
+			fmt.Printf("Details: %s", err.Error())
+			os.Exit(1)
+		}
+
+		fmt.Println(string(outputBytes))
+		return
 	}
 
 	// success
@@ -207,9 +243,9 @@ func printResult(cmd *cobra.Command, extraArgs []string) {
 				calicoVersion,
 			}, "|"))
 		}
-	}
 
-	fmt.Println(columnize.SimpleFormat(output))
+		fmt.Println(columnize.SimpleFormat(output))
+	}
 }
 
 // listReleases fetches releases and returns them as a structured result.

--- a/commands/list/releases/command_test.go
+++ b/commands/list/releases/command_test.go
@@ -29,8 +29,9 @@ func Test_ListReleases_Empty(t *testing.T) {
 
 	// needed to prevent search for the default cluster
 	args := Arguments{
-		apiEndpoint: releasesMockServer.URL,
-		token:       "my-token",
+		apiEndpoint:  releasesMockServer.URL,
+		token:        "my-token",
+		outputFormat: "json",
 	}
 
 	err = listReleasesPreconditions(&args)
@@ -189,8 +190,9 @@ func Test_ListReleases_Nonempty(t *testing.T) {
 	defer releasesMockServer.Close()
 
 	args := Arguments{
-		apiEndpoint: releasesMockServer.URL,
-		token:       "my-token",
+		apiEndpoint:  releasesMockServer.URL,
+		token:        "my-token",
+		outputFormat: "table",
 	}
 
 	err = listReleasesPreconditions(&args)


### PR DESCRIPTION
Related to https://github.com/giantswarm/gsctl/issues/297

This implements JSON output for the `gsctl list releases` command.

Use the `-o json` or `--output json` flag to enable it. As in other commands, the `table` output style is the default.