### PR TITLE
Fix new output bug in 'list releases'

### DIFF
--- a/commands/list/releases/command.go
+++ b/commands/list/releases/command.go
@@ -243,9 +243,9 @@ func printResult(cmd *cobra.Command, extraArgs []string) {
 				calicoVersion,
 			}, "|"))
 		}
-
-		fmt.Println(columnize.SimpleFormat(output))
 	}
+
+	fmt.Println(columnize.SimpleFormat(output))
 }
 
 // listReleases fetches releases and returns them as a structured result.


### PR DESCRIPTION
This fixes a bug where output would be printed repeatedly, likely introduced with the latest change in this command.