### PR TITLE
Fix v5 -> v4 fall back in gsctl show cluster

### DIFF
--- a/commands/show/cluster/command.go
+++ b/commands/show/cluster/command.go
@@ -238,10 +238,11 @@ func getClusterDetails(args Arguments) (
 
 	} else {
 		// If this is a 404 error, we assume the cluster is not a V5 one.
+		// If it is 400, it's likely "not supported on this provider". We swallow this in order to test for v4 next.
 		// If this is a "Malformed response" error, we assume the API is not capable of
 		// handling V5 yet. TODO: This can be phased out once the API is up-to-date.
 		// In both these case we continue below, otherwise we return the error.
-		if !errors.IsClusterNotFoundError(v5Err) && !clienterror.IsMalformedResponseError(v5Err) {
+		if !errors.IsClusterNotFoundError(v5Err) && !clienterror.IsMalformedResponseError(v5Err) && !clienterror.IsBadRequestError(v5Err) {
 			return nil, nil, nil, nil, nil, microerror.Mask(v5Err)
 		}
 


### PR DESCRIPTION
Implements what https://github.com/giantswarm/gsctl/pull/449 did for the `gsctl show cluster` command. This enables the command to work again on Azure and KVM.

### Before

```
gsctl show cluster 35ac3 -e gollum -v
Fetching details for cluster 35ac3.
Fetching details for cluster via v5 API endpoint.
[GET /v5/clusters/{cluster_id}/][400] getClusterV5 default  &{Code:NOT_SUPPORTED Message:The endpoint is not implemented for this provider. (not supported error)}
```

### After

```
gsctl show cluster 35ac3 -e gollum -v
Fetching details for cluster 35ac3.
Fetching details for cluster via v5 API endpoint.
No usable v5 response. Fetching details for cluster via v4 API endpoint.
Fetching status for v4 cluster.
ID:                        35ac3
Name:                      Giant Swarm Frontend Cluster
Created:                   2019 Oct 22, 10:04 UTC
Organization:              giantswarm
Kubernetes API endpoint:   https://api.35ac3.k8s.gollum.westeurope.azure.gigantic.io
Release version:           8.4.2
Worker VM size:            Standard_D4s_v3
Worker node scaling:       pinned at 3
Worker nodes running:      3
CPU cores in workers:      12
RAM in worker nodes (GB):  51.54
```