### PR TITLE
Add command: gsctl update cluster

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -350,6 +350,24 @@ func (w *Wrapper) ModifyCluster(clusterID string, body *models.V4ModifyClusterRe
 	return response, nil
 }
 
+// ModifyClusterV5 modifies a V5 cluster.
+func (w *Wrapper) ModifyClusterV5(clusterID string, body *models.V5ModifyClusterRequest, p *AuxiliaryParams) (*clusters.ModifyClusterV5OK, error) {
+	params := clusters.NewModifyClusterV5Params().WithClusterID(clusterID).WithBody(body)
+	setParams(p, w, params)
+
+	authWriter, err := getAuthorization(w)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	response, err := w.gsclient.Clusters.ModifyClusterV5(params, authWriter)
+	if err != nil {
+		return nil, clienterror.New(err)
+	}
+
+	return response, nil
+}
+
 // DeleteCluster deletes a cluster using the gsclientgen client.
 func (w *Wrapper) DeleteCluster(clusterID string, p *AuxiliaryParams) (*clusters.DeleteClusterAccepted, error) {
 	params := clusters.NewDeleteClusterParams().WithClusterID(clusterID)

--- a/commands/update/cluster/command.go
+++ b/commands/update/cluster/command.go
@@ -1,0 +1,219 @@
+// Package cluster implements the "update nodepool" command.
+package cluster
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/fatih/color"
+	"github.com/giantswarm/gscliauth/config"
+	"github.com/giantswarm/gsclientgen/models"
+	"github.com/giantswarm/microerror"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/gsctl/client"
+	"github.com/giantswarm/gsctl/commands/errors"
+	"github.com/giantswarm/gsctl/flags"
+)
+
+var (
+	// Command is the cobra command for 'gsctl show nodepool'
+	Command = &cobra.Command{
+		Use: "cluster <cluster-id>",
+		// Args: cobra.ExactArgs(1) guarantees that cobra will fail if no positional argument is given.
+		Args:  cobra.ExactArgs(1),
+		Short: "Modify cluster details",
+		Long: `Change the name oif a cluster
+
+Examples:
+
+  gsctl update cluster f01r4 --name "Precious Production Cluster"
+
+`,
+
+		// PreRun checks a few general things, like authentication.
+		PreRun: printValidation,
+
+		// Run calls the business function and prints results and errors.
+		Run: printResult,
+	}
+)
+
+const (
+	activityName = "update-cluster"
+)
+
+func init() {
+	initFlags()
+}
+
+// initFlags initializes flags in a re-usable way, so we can call it from multiple tests.
+func initFlags() {
+	Command.ResetFlags()
+	Command.Flags().StringVarP(&flags.Name, "name", "n", "", "name or purpose description of the node pool")
+}
+
+// Arguments represents all the ways the user can influence the command.
+type Arguments struct {
+	APIEndpoint       string
+	AuthToken         string
+	ClusterID         string
+	Name              string
+	UserProvidedToken string
+	Verbose           bool
+}
+
+func collectArguments(positionalArgs []string) Arguments {
+	endpoint := config.Config.ChooseEndpoint(flags.APIEndpoint)
+	token := config.Config.ChooseToken(endpoint, flags.Token)
+
+	return Arguments{
+		APIEndpoint:       endpoint,
+		AuthToken:         token,
+		ClusterID:         strings.TrimSpace(positionalArgs[0]),
+		Name:              flags.Name,
+		UserProvidedToken: flags.Token,
+		Verbose:           flags.Verbose,
+	}
+}
+
+// result represents all information we get back from modifying a cluster.
+type result struct {
+	ClusterName string
+}
+
+func verifyPreconditions(args Arguments) error {
+	if args.AuthToken == "" && args.UserProvidedToken == "" {
+		return microerror.Mask(errors.NotLoggedInError)
+	} else if args.ClusterID == "" {
+		return microerror.Mask(errors.ClusterIDMissingError)
+	} else if args.Name == "" {
+		return microerror.Mask(errors.NoOpError)
+	}
+
+	return nil
+}
+
+func printValidation(cmd *cobra.Command, positionalArgs []string) {
+	args := collectArguments(positionalArgs)
+	err := verifyPreconditions(args)
+
+	if err == nil {
+		return
+	}
+
+	errors.HandleCommonErrors(err)
+	client.HandleErrors(err)
+
+	headline := ""
+	subtext := ""
+
+	switch {
+	// If there are specific errors to handle, add them here.
+	default:
+		headline = err.Error()
+	}
+
+	// print output
+	fmt.Println(color.RedString(headline))
+	if subtext != "" {
+		fmt.Println(subtext)
+	}
+	os.Exit(1)
+}
+
+// updateCluster updates the cluster.
+// It determines whether it is a v5 or v4 cluster and uses the appropriate mechanism.
+func updateCluster(args Arguments) (*result, error) {
+	clientWrapper, err := client.NewWithConfig(args.APIEndpoint, args.UserProvidedToken)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	auxParams := clientWrapper.DefaultAuxiliaryParams()
+	auxParams.ActivityName = activityName
+
+	// First try v5.
+	if args.Verbose {
+		fmt.Println(color.WhiteString("Fetching details for cluster via v5 API endpoint."))
+	}
+	_, errV5 := clientWrapper.GetClusterV5(args.ClusterID, auxParams)
+	if errV5 == nil {
+		requestBody := &models.V5ModifyClusterRequest{}
+		if args.Name != "" {
+			requestBody.Name = args.Name
+		}
+
+		if args.Verbose {
+			fmt.Println(color.WhiteString("Sending cluster modification request to v5 endpoint."))
+		}
+		response, err := clientWrapper.ModifyClusterV5(args.ClusterID, requestBody, auxParams)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		r := &result{
+			ClusterName: response.Payload.Name,
+		}
+
+		return r, nil
+	}
+
+	// Fallback: try v4.
+	if args.Verbose {
+		fmt.Println(color.WhiteString("No usable v5 response. Fetching details for cluster via v4 API endpoint."))
+	}
+	_, errV4 := clientWrapper.GetClusterV4(args.ClusterID, auxParams)
+	if errV4 == nil {
+		requestBody := &models.V4ModifyClusterRequest{}
+		if args.Name != "" {
+			requestBody.Name = args.Name
+		}
+
+		if args.Verbose {
+			fmt.Println(color.WhiteString("Sending cluster modification request to v4 endpoint."))
+		}
+		response, err := clientWrapper.ModifyCluster(args.ClusterID, requestBody, auxParams)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		r := &result{
+			ClusterName: response.Payload.Name,
+		}
+
+		return r, nil
+	}
+
+	// We return the last error here, representatively.
+	return nil, microerror.Mask(errV4)
+}
+
+func printResult(cmd *cobra.Command, positionalArgs []string) {
+	args := collectArguments(positionalArgs)
+
+	_, err := updateCluster(args)
+	if err != nil {
+		errors.HandleCommonErrors(err)
+		client.HandleErrors(err)
+
+		headline := ""
+		subtext := ""
+
+		switch {
+		// If there are specific errors to handle, add them here.
+		default:
+			headline = err.Error()
+		}
+
+		// print output
+		fmt.Println(color.RedString(headline))
+		if subtext != "" {
+			fmt.Println(subtext)
+		}
+		os.Exit(1)
+	}
+
+	fmt.Println(color.GreenString("Cluster '%s' has been modified.", args.ClusterID))
+}

--- a/commands/update/cluster/command_test.go
+++ b/commands/update/cluster/command_test.go
@@ -1,0 +1,286 @@
+package cluster
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/giantswarm/gsctl/commands/errors"
+	"github.com/giantswarm/gsctl/testutils"
+	"github.com/google/go-cmp/cmp"
+	"github.com/spf13/afero"
+)
+
+// configYAML is a mock configuration used by some of the tests.
+const configYAML = `last_version_check: 0001-01-01T00:00:00Z
+endpoints:
+  https://foo:
+    email: email@example.com
+    token: some-token
+selected_endpoint: https://foo
+updated: 2017-09-29T11:23:15+02:00
+`
+
+// TestCollectArgs tests whether collectArguments produces the expected results.
+func TestCollectArgs(t *testing.T) {
+	var testCases = []struct {
+		// The positional arguments we pass.
+		positionalArguments []string
+		// How we execute the command.
+		commandExecution func()
+		// What we expect as arguments.
+		resultingArgs Arguments
+	}{
+		{
+			[]string{"clusterid"},
+			func() {
+				initFlags()
+				Command.ParseFlags([]string{"clusterid"})
+			},
+			Arguments{
+				APIEndpoint: "https://foo",
+				AuthToken:   "some-token",
+				ClusterID:   "clusterid",
+			},
+		},
+		{
+			[]string{"clusterid", "--name=NewName"},
+			func() {
+				initFlags()
+				Command.ParseFlags([]string{"clusterid", "--name=NewName"})
+			},
+			Arguments{
+				APIEndpoint: "https://foo",
+				AuthToken:   "some-token",
+				ClusterID:   "clusterid",
+				Name:        "NewName",
+			},
+		},
+	}
+
+	fs := afero.NewMemMapFs()
+	_, err := testutils.TempConfig(fs, configYAML)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			tc.commandExecution()
+			args := collectArguments(tc.positionalArguments)
+
+			if diff := cmp.Diff(tc.resultingArgs, args); diff != "" {
+				t.Errorf("Case %d - Resulting args unequal. (-expected +got):\n%s", i, diff)
+			}
+		})
+	}
+}
+
+// Test_verifyPreconditions tests cases where validating preconditions fails.
+func Test_verifyPreconditions(t *testing.T) {
+	var testCases = []struct {
+		args         Arguments
+		errorMatcher func(error) bool
+	}{
+		// Cluster ID is missing.
+		{
+			Arguments{
+				AuthToken:   "token",
+				APIEndpoint: "https://mock-url",
+			},
+			errors.IsClusterIDMissingError,
+		},
+		// No token provided.
+		{
+			Arguments{
+				APIEndpoint: "https://mock-url",
+				ClusterID:   "cluster-id",
+			},
+			errors.IsNotLoggedInError,
+		},
+		// Nothing to change.
+		{
+			Arguments{
+				AuthToken:   "token",
+				APIEndpoint: "https://mock-url",
+				ClusterID:   "cluster-id",
+			},
+			errors.IsNoOpError,
+		},
+	}
+
+	fs := afero.NewMemMapFs()
+	_, err := testutils.TempConfig(fs, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			err := verifyPreconditions(tc.args)
+			if err == nil {
+				t.Errorf("Case %d - Expected error, got nil", i)
+			} else if !tc.errorMatcher(err) {
+				t.Errorf("Case %d - Error did not match expectec type. Got '%s'", i, err)
+			}
+		})
+	}
+}
+
+// TestSuccess tests node pool creation with cases that are expected to succeed.
+func TestSuccess(t *testing.T) {
+	var testCases = []struct {
+		args           Arguments
+		responseBody   string
+		expectedResult *result
+	}{
+		// Name change.
+		{
+			args: Arguments{
+				ClusterID: "clusterid",
+				AuthToken: "token",
+				Name:      "New name",
+			},
+			responseBody: `{
+				"id": "clusterid",
+				"name": "New name"
+			}`,
+			expectedResult: &result{
+				ClusterName: "New name",
+			},
+		},
+	}
+
+	fs := afero.NewMemMapFs()
+	_, err := testutils.TempConfig(fs, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			// set up mock server
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				t.Logf("Mock request: %s %s", r.Method, r.URL.Path)
+				w.Header().Set("Content-Type", "application/json")
+				if r.Method == "PATCH" && r.URL.Path == "/v5/clusters/clusterid/" {
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte(tc.responseBody))
+				} else if r.Method == "GET" && r.URL.Path == "/v5/clusters/clusterid/" {
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte(`{"id": "clusterid", "name": "old cluster name"}`))
+				} else {
+					t.Errorf("Case %d - Unsupported operation %s %s called in mock server", i, r.Method, r.URL.Path)
+				}
+			}))
+			defer mockServer.Close()
+
+			tc.args.APIEndpoint = mockServer.URL
+
+			err := verifyPreconditions(tc.args)
+			if err != nil {
+				t.Fatalf("Case %d - Unxpected error '%s'", i, err)
+			}
+
+			result, err := updateCluster(tc.args)
+			if err != nil {
+				t.Fatalf("Case %d - Unxpected error '%s'", i, err)
+			}
+
+			if diff := cmp.Diff(tc.expectedResult, result); diff != "" {
+				t.Errorf("Case %d - Results unequal. (-expected +got):\n%s", i, diff)
+			}
+		})
+	}
+}
+
+// TestExecuteWithError tests the error handling.
+func TestExecuteWithError(t *testing.T) {
+	var testCases = []struct {
+		args               Arguments
+		responseStatusCode int
+		responseBody       string
+		errorMatcher       func(error) bool
+	}{
+		{
+			Arguments{
+				ClusterID:   "clusterid",
+				AuthToken:   "token",
+				APIEndpoint: "https://mock-url",
+				Name:        "weird-name",
+			},
+			401,
+			`{"code": "FORBIDDEN", "message": "Here is some error message"}`,
+			errors.IsNotAuthorizedError,
+		},
+		{
+			Arguments{
+				ClusterID:   "clusterid",
+				AuthToken:   "token",
+				APIEndpoint: "https://mock-url",
+				Name:        "weird-name",
+			},
+			403,
+			`{"code": "FORBIDDEN", "message": "Here is some error message"}`,
+			errors.IsAccessForbiddenError,
+		},
+		{
+			Arguments{
+				ClusterID:   "clusterid",
+				AuthToken:   "token",
+				APIEndpoint: "https://mock-url",
+				Name:        "weird-name",
+			},
+			404,
+			`{"code": "RESOURCE_NOT_FOUND", "message": "Here is some error message"}`,
+			errors.IsClusterNotFoundError,
+		},
+		{
+			Arguments{
+				ClusterID:   "clusterid",
+				AuthToken:   "token",
+				APIEndpoint: "https://mock-url",
+				Name:        "weird-name",
+			},
+			500,
+			`{"code": "UNKNOWN_ERROR", "message": "Here is some error message"}`,
+			errors.IsInternalServerError,
+		},
+	}
+
+	fs := afero.NewMemMapFs()
+	_, err := testutils.TempConfig(fs, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if r.Method == "PATCH" && r.URL.Path == "/v5/clusters/clusterid/" {
+					w.WriteHeader(tc.responseStatusCode)
+					w.Write([]byte(tc.responseBody))
+				} else if r.Method == "GET" && r.URL.Path == "/v5/clusters/clusterid/" {
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte(`{"id": "clusterid", "name": "old cluster name"}`))
+				} else {
+					t.Errorf("Unsupported operation %s %s called in mock server", r.Method, r.URL.Path)
+					w.WriteHeader(http.StatusNotFound)
+					w.Write([]byte(`{"code": "RESOURCE_NOT_FOUND", "message": "Status for this cluster is not yet available."}`))
+				}
+			}))
+			defer mockServer.Close()
+
+			tc.args.APIEndpoint = mockServer.URL
+
+			_, err := updateCluster(tc.args)
+			if err == nil {
+				t.Errorf("Case %d - Expected error, got nil", i)
+			} else if !tc.errorMatcher(err) {
+				t.Errorf("Case %d - Error did not match expectec type. Got '%s'", i, err)
+			}
+		})
+	}
+}

--- a/commands/update/command.go
+++ b/commands/update/command.go
@@ -3,6 +3,7 @@ package update
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/giantswarm/gsctl/commands/update/cluster"
 	"github.com/giantswarm/gsctl/commands/update/nodepool"
 	"github.com/giantswarm/gsctl/commands/update/organization"
 )
@@ -17,6 +18,7 @@ var (
 )
 
 func init() {
+	Command.AddCommand(cluster.Command)
 	Command.AddCommand(organization.Command)
 	Command.AddCommand(nodepool.Command)
 }


### PR DESCRIPTION
Closes https://github.com/giantswarm/gsctl/issues/157

This implements the `gsctl update cluster` command to change cluster details. The only supported detail to change for now is the cluster name.

### Preview

```
$ gsctl update cluster pv6vx --name "test cluster" 
Cluster 'pv6vx' has been modified.
```