### PR TITLE
Allow for automatic creation of pre-releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,6 @@ workflows:
       - dist:
           filters:
             tags:
-              only: /^[0-9]+\.[0-9]+\.[0-9]+$/
+              only: ^[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)*$
             branches:
               ignore: /.*/


### PR DESCRIPTION
This PR should extend the tag matching regex in the CircleCI config. As a result, it should be possible to create a release automatically from a tag such as

    0.18.0-rc1

We want to make this the convention for a pre-release.