### PR TITLE
Update gsclientgen commit ref

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/giantswarm/apiextensions v0.0.0-20190724141707-66d1dbb49135
 	github.com/giantswarm/columnize v2.0.3-0.20190718092621-cc99d98ffb29+incompatible
 	github.com/giantswarm/gscliauth v0.0.0-20190725094024-6a88de70cd85
-	github.com/giantswarm/gsclientgen v2.0.1-0.20191029094646-c110dc909ccf+incompatible
+	github.com/giantswarm/gsclientgen v2.0.1-0.20191029145335-6948ab5cbaaf+incompatible
 	github.com/giantswarm/kubeconfig v0.0.0-20190403073151-2c7a472873b0
 	github.com/giantswarm/microerror v0.0.0-20191011121515-e0ebc4ecf5a5
 	github.com/giantswarm/micrologger v0.0.0-20190118112544-0926d9b7c541

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,8 @@ github.com/giantswarm/columnize v2.0.3-0.20190718092621-cc99d98ffb29+incompatibl
 github.com/giantswarm/columnize v2.0.3-0.20190718092621-cc99d98ffb29+incompatible/go.mod h1:V/9Aa/R3o321yAbarEACmGhTg0SiPge6nFDtIH7CTvE=
 github.com/giantswarm/gscliauth v0.0.0-20190725094024-6a88de70cd85 h1:LYeRTofeQacoK7jz0esmnbCXsVAIXUUAogzJK9ZlDEo=
 github.com/giantswarm/gscliauth v0.0.0-20190725094024-6a88de70cd85/go.mod h1:qYjj5CylbM318aJhK1qc912yMTp9fUk0na2IaIQU7xc=
-github.com/giantswarm/gsclientgen v2.0.1-0.20191029094646-c110dc909ccf+incompatible h1:0iSsMuu4P1oh5aiIrtzoXsxYOQQlejo/vFhiKrm+yQ8=
-github.com/giantswarm/gsclientgen v2.0.1-0.20191029094646-c110dc909ccf+incompatible/go.mod h1:w3fPQmyNcZPB0I/eULLADOfkk0VTSn8Pijvj7JacnNQ=
+github.com/giantswarm/gsclientgen v2.0.1-0.20191029145335-6948ab5cbaaf+incompatible h1:gHtpT5M4cU4ATPqhkO3ed7ei3VXL6pM1refqx2BtkEc=
+github.com/giantswarm/gsclientgen v2.0.1-0.20191029145335-6948ab5cbaaf+incompatible/go.mod h1:w3fPQmyNcZPB0I/eULLADOfkk0VTSn8Pijvj7JacnNQ=
 github.com/giantswarm/kubeconfig v0.0.0-20190403073151-2c7a472873b0 h1:X/NIxCdhA6tpBI9DynV1YMB2dFIY6R6ZKdj0vHUEy1s=
 github.com/giantswarm/kubeconfig v0.0.0-20190403073151-2c7a472873b0/go.mod h1:XJHVL/1hBzfAPkCtwTNg/1NTS6AFbj5h2HzUCi01Ox4=
 github.com/giantswarm/microerror v0.0.0-20191011121515-e0ebc4ecf5a5 h1:ZjMQRWyxNkGlFP8yOf+G86XH7DugnigsBpzie1R/nxM=


### PR DESCRIPTION
GitHub rewrites the commit when merging through the UI which gives it a
new ID. Update the dependency to reference the commit ID on master branch of
gsclientgen.