### PR TITLE
Handle error 500 consistently in all commands

### DIFF
--- a/client/clienterror/clienterror.go
+++ b/client/clienterror/clienterror.go
@@ -107,6 +107,7 @@ func New(err error) *APIError {
 			HTTPStatusCode: createClusterDefaultErr.Code(),
 			OriginalError:  createClusterDefaultErr,
 			ErrorMessage:   createClusterDefaultErr.Error(),
+			ErrorDetails:   createClusterDefaultErr.Payload.Message,
 		}
 		if ae.HTTPStatusCode == http.StatusNotFound {
 			ae.ErrorMessage = "Not found"
@@ -133,6 +134,7 @@ func New(err error) *APIError {
 			HTTPStatusCode: createClusterDefaultErr.Code(),
 			OriginalError:  createClusterDefaultErr,
 			ErrorMessage:   createClusterDefaultErr.Error(),
+			ErrorDetails:   createClusterDefaultErr.Payload.Message,
 		}
 		if ae.HTTPStatusCode == http.StatusNotFound {
 			ae.ErrorMessage = "Organization does not exist"
@@ -151,6 +153,7 @@ func New(err error) *APIError {
 			HTTPStatusCode: modifyClusterFailedErr.Code(),
 			OriginalError:  modifyClusterFailedErr,
 			ErrorMessage:   modifyClusterFailedErr.Error(),
+			ErrorDetails:   modifyClusterFailedErr.Payload.Message,
 		}
 
 		if ae.HTTPStatusCode == http.StatusInternalServerError {
@@ -187,6 +190,7 @@ func New(err error) *APIError {
 			HTTPStatusCode: modifyClusterFailedErr.Code(),
 			OriginalError:  modifyClusterFailedErr,
 			ErrorMessage:   modifyClusterFailedErr.Error(),
+			ErrorDetails:   modifyClusterFailedErr.Payload.Message,
 		}
 
 		if ae.HTTPStatusCode == http.StatusInternalServerError {
@@ -244,6 +248,7 @@ func New(err error) *APIError {
 			HTTPStatusCode: deleteClusterDefaultErr.Code(),
 			OriginalError:  deleteClusterDefaultErr,
 			ErrorMessage:   deleteClusterDefaultErr.Error(),
+			ErrorDetails:   deleteClusterDefaultErr.Payload.Message,
 		}
 	}
 
@@ -261,6 +266,7 @@ func New(err error) *APIError {
 			HTTPStatusCode: getClustersDefaultErr.Code(),
 			OriginalError:  getClustersDefaultErr,
 			ErrorMessage:   getClustersDefaultErr.Error(),
+			ErrorDetails:   getClustersDefaultErr.Payload.Message,
 		}
 	}
 
@@ -286,6 +292,7 @@ func New(err error) *APIError {
 			HTTPStatusCode: getClusterDefaultErr.Code(),
 			OriginalError:  getClusterDefaultErr,
 			ErrorMessage:   getClusterDefaultErr.Error(),
+			ErrorDetails:   getClusterDefaultErr.Payload.Message,
 		}
 	}
 
@@ -295,6 +302,7 @@ func New(err error) *APIError {
 			HTTPStatusCode: getClusterStatusDefaultErr.Code(),
 			OriginalError:  getClusterStatusDefaultErr,
 			ErrorMessage:   getClusterStatusDefaultErr.Error(),
+			ErrorDetails:   getClusterStatusDefaultErr.Payload.Message,
 		}
 	}
 
@@ -320,6 +328,7 @@ func New(err error) *APIError {
 			HTTPStatusCode: getClusterDefaultErr.Code(),
 			OriginalError:  getClusterDefaultErr,
 			ErrorMessage:   getClusterDefaultErr.Error(),
+			ErrorDetails:   getClusterDefaultErr.Payload.Message,
 		}
 	}
 
@@ -353,6 +362,7 @@ func New(err error) *APIError {
 			HTTPStatusCode: addNodePoolDefaultErr.Code(),
 			OriginalError:  addNodePoolDefaultErr,
 			ErrorMessage:   addNodePoolDefaultErr.Error(),
+			ErrorDetails:   addNodePoolDefaultErr.Payload.Message,
 		}
 	}
 
@@ -396,6 +406,7 @@ func New(err error) *APIError {
 			HTTPStatusCode: getNodePoolsDefaultErr.Code(),
 			OriginalError:  getNodePoolsDefaultErr,
 			ErrorMessage:   getNodePoolsDefaultErr.Error(),
+			ErrorDetails:   getNodePoolsDefaultErr.Payload.Message,
 		}
 	}
 
@@ -421,6 +432,7 @@ func New(err error) *APIError {
 			HTTPStatusCode: modifyNodePoolsDefaultErr.Code(),
 			OriginalError:  modifyNodePoolsDefaultErr,
 			ErrorMessage:   modifyNodePoolsDefaultErr.Error(),
+			ErrorDetails:   modifyNodePoolsDefaultErr.Payload.Message,
 		}
 	}
 
@@ -446,6 +458,7 @@ func New(err error) *APIError {
 			HTTPStatusCode: deleteNodePoolsDefaultErr.Code(),
 			OriginalError:  deleteNodePoolsDefaultErr,
 			ErrorMessage:   deleteNodePoolsDefaultErr.Error(),
+			ErrorDetails:   deleteNodePoolsDefaultErr.Payload.Message,
 		}
 	}
 
@@ -473,6 +486,7 @@ func New(err error) *APIError {
 			HTTPStatusCode: getKeyPairsDefaultErr.Code(),
 			OriginalError:  getKeyPairsDefaultErr,
 			ErrorMessage:   getKeyPairsDefaultErr.Error(),
+			ErrorDetails:   getKeyPairsDefaultErr.Payload.Message,
 		}
 	}
 
@@ -487,6 +501,7 @@ func New(err error) *APIError {
 	}
 	if getInfoDefaultErr, ok := err.(*info.GetInfoDefault); ok {
 		return &APIError{
+			ErrorDetails:   getInfoDefaultErr.Payload.Message,
 			ErrorMessage:   getInfoDefaultErr.Error(),
 			HTTPStatusCode: getInfoDefaultErr.Code(),
 			OriginalError:  getInfoDefaultErr,
@@ -514,6 +529,7 @@ func New(err error) *APIError {
 	}
 	if getOrganizationsDefault, ok := err.(*organizations.GetOrganizationsDefault); ok {
 		return &APIError{
+			ErrorDetails:   getOrganizationsDefault.Payload.Message,
 			ErrorMessage:   getOrganizationsDefault.Error(),
 			HTTPStatusCode: getOrganizationsDefault.Code(),
 			OriginalError:  getOrganizationsDefault,
@@ -539,6 +555,7 @@ func New(err error) *APIError {
 	}
 	if addCredentialsDefault, ok := err.(*organizations.AddCredentialsDefault); ok {
 		return &APIError{
+			ErrorDetails:   addCredentialsDefault.Payload.Message,
 			ErrorMessage:   addCredentialsDefault.Error(),
 			HTTPStatusCode: addCredentialsDefault.Code(),
 			OriginalError:  addCredentialsDefault,
@@ -548,6 +565,7 @@ func New(err error) *APIError {
 	// get credential
 	if myerr, ok := err.(*organizations.GetCredentialDefault); ok {
 		return &APIError{
+			ErrorDetails:   myerr.Payload.Message,
 			ErrorMessage:   myerr.Error(),
 			HTTPStatusCode: myerr.Code(),
 			OriginalError:  myerr,

--- a/client/error.go
+++ b/client/error.go
@@ -68,17 +68,29 @@ func HandleErrors(err error) {
 
 	var headline = ""
 	var subtext = ""
+	var httpStatusCode int
+	var message string
+	var details string
 
 	if convertedErr, ok := microerror.Cause(err).(*clienterror.APIError); ok {
-		headline = convertedErr.ErrorMessage
-		subtext = convertedErr.ErrorDetails
+		httpStatusCode = convertedErr.HTTPStatusCode
+		message = convertedErr.ErrorMessage
+		details = convertedErr.ErrorDetails
 	} else if convertedErr, ok := err.(*clienterror.APIError); ok {
-		headline = convertedErr.ErrorMessage
-		subtext = convertedErr.ErrorDetails
+		httpStatusCode = convertedErr.HTTPStatusCode
+		message = convertedErr.ErrorMessage
+		details = convertedErr.ErrorDetails
 	} else if IsEndpointNotSpecifiedError(err) {
 		// legacy client error handling
 		headline = "No endpoint has been specified."
 		subtext = "Please use the '-e|--endpoint' flag or select an endpoint using 'gsctl select endpoint'."
+	}
+
+	if httpStatusCode == 500 {
+		headline = "An internal error occurred."
+		subtext = details
+	} else if message != "" {
+		headline = message
 	}
 
 	if headline == "" {

--- a/commands/create/cluster/command.go
+++ b/commands/create/cluster/command.go
@@ -202,6 +202,7 @@ func printValidation(cmd *cobra.Command, positionalArgs []string) {
 
 	err := verifyPreconditions(args)
 	if err != nil {
+		client.HandleErrors(err)
 		errors.HandleCommonErrors(err)
 
 		switch {
@@ -228,8 +229,8 @@ func printResult(cmd *cobra.Command, positionalArgs []string) {
 
 	result, err := addCluster(args)
 	if err != nil {
-		errors.HandleCommonErrors(err)
 		client.HandleErrors(err)
+		errors.HandleCommonErrors(err)
 
 		var headline string
 		var subtext string

--- a/commands/create/keypair/command.go
+++ b/commands/create/keypair/command.go
@@ -134,6 +134,7 @@ func printValidation(cmd *cobra.Command, cmdLineArgs []string) {
 		return
 	}
 
+	client.HandleErrors(err)
 	errors.HandleCommonErrors(err)
 
 	headline := ""
@@ -186,8 +187,8 @@ func printResult(cmd *cobra.Command, cmdLineArgs []string) {
 	result, err := createKeypair(args)
 
 	if err != nil {
-		errors.HandleCommonErrors(err)
 		client.HandleErrors(err)
+		errors.HandleCommonErrors(err)
 
 		var headline string
 		var subtext string

--- a/commands/create/kubeconfig/command.go
+++ b/commands/create/kubeconfig/command.go
@@ -204,6 +204,7 @@ func createKubeconfigPreRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 		return
 	}
 
+	client.HandleErrors(err)
 	errors.HandleCommonErrors(err)
 
 	var headline string
@@ -285,8 +286,8 @@ func createKubeconfigRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 	result, err := createKubeconfig(ctx, args)
 
 	if err != nil {
-		errors.HandleCommonErrors(err)
 		client.HandleErrors(err)
+		errors.HandleCommonErrors(err)
 
 		var headline string
 		var subtext string

--- a/commands/create/nodepool/command.go
+++ b/commands/create/nodepool/command.go
@@ -236,8 +236,8 @@ func printValidation(cmd *cobra.Command, positionalArgs []string) {
 		return
 	}
 
-	errors.HandleCommonErrors(err)
 	client.HandleErrors(err)
+	errors.HandleCommonErrors(err)
 
 	headline := ""
 	subtext := ""
@@ -333,8 +333,8 @@ func printResult(cmd *cobra.Command, positionalArgs []string) {
 	}
 
 	if err != nil {
-		errors.HandleCommonErrors(err)
 		client.HandleErrors(err)
+		errors.HandleCommonErrors(err)
 
 		headline := ""
 		subtext := ""

--- a/commands/delete/cluster/command.go
+++ b/commands/delete/cluster/command.go
@@ -96,6 +96,7 @@ func printValidation(cmd *cobra.Command, args []string) {
 
 	err := validatePreconditions(dca)
 	if err != nil {
+		client.HandleErrors(err)
 		errors.HandleCommonErrors(err)
 
 		var headline = ""
@@ -145,8 +146,8 @@ func printResult(cmd *cobra.Command, args []string) {
 	dca := collectArguments(args)
 	deleted, err := deleteCluster(dca)
 	if err != nil {
-		errors.HandleCommonErrors(err)
 		client.HandleErrors(err)
+		errors.HandleCommonErrors(err)
 
 		var headline = ""
 		var subtext = ""

--- a/commands/delete/nodepool/command.go
+++ b/commands/delete/nodepool/command.go
@@ -132,8 +132,8 @@ func printValidation(cmd *cobra.Command, positionalArgs []string) {
 		return
 	}
 
-	errors.HandleCommonErrors(err)
 	client.HandleErrors(err)
+	errors.HandleCommonErrors(err)
 
 	headline := ""
 	subtext := ""
@@ -183,8 +183,8 @@ func printResult(cmd *cobra.Command, positionalArgs []string) {
 
 	deleted, err := deleteNodePool(args)
 	if err != nil {
-		errors.HandleCommonErrors(err)
 		client.HandleErrors(err)
+		errors.HandleCommonErrors(err)
 
 		headline := ""
 		subtext := ""

--- a/commands/info/command.go
+++ b/commands/info/command.go
@@ -85,6 +85,7 @@ func printValidation(cmd *cobra.Command, extraArgs []string) {
 	err := validatePreconditions(args)
 
 	if err != nil {
+		client.HandleErrors(err)
 		errors.HandleCommonErrors(err)
 	}
 }

--- a/commands/list/clusters/command.go
+++ b/commands/list/clusters/command.go
@@ -84,6 +84,7 @@ func printValidation(cmd *cobra.Command, cmdLineArgs []string) {
 		return
 	}
 
+	client.HandleErrors(err)
 	errors.HandleCommonErrors(err)
 }
 
@@ -107,8 +108,8 @@ func printResult(cmd *cobra.Command, cmdLineArgs []string) {
 
 	output, err := getClustersOutput(args)
 	if err != nil {
-		errors.HandleCommonErrors(err)
 		client.HandleErrors(err)
+		errors.HandleCommonErrors(err)
 
 		if clientErr, ok := err.(*clienterror.APIError); ok {
 			fmt.Println(color.RedString(clientErr.ErrorMessage))

--- a/commands/list/keypairs/command.go
+++ b/commands/list/keypairs/command.go
@@ -103,6 +103,7 @@ func printValidation(cmd *cobra.Command, extraArgs []string) {
 	args := collectArguments()
 	err := listKeypairsValidate(&args)
 	if err != nil {
+		client.HandleErrors(err)
 		errors.HandleCommonErrors(err)
 
 		fmt.Println(color.RedString(err.Error()))
@@ -149,8 +150,8 @@ func printResult(cmd *cobra.Command, extraArgs []string) {
 
 	// error output
 	if err != nil {
-		errors.HandleCommonErrors(err)
 		client.HandleErrors(err)
+		errors.HandleCommonErrors(err)
 
 		var headline string
 		var subtext string

--- a/commands/list/nodepools/command.go
+++ b/commands/list/nodepools/command.go
@@ -105,6 +105,7 @@ func printValidation(cmd *cobra.Command, positionalArgs []string) {
 		return
 	}
 
+	client.HandleErrors(err)
 	errors.HandleCommonErrors(err)
 }
 
@@ -156,9 +157,10 @@ func fetchNodePools(args Arguments) ([]*resultRow, error) {
 func printResult(cmd *cobra.Command, positionalArgs []string) {
 	args := collectArguments(positionalArgs)
 	nodePools, err := fetchNodePools(args)
+
 	if err != nil {
-		errors.HandleCommonErrors(err)
 		client.HandleErrors(err)
+		errors.HandleCommonErrors(err)
 
 		if clientErr, ok := err.(*clienterror.APIError); ok {
 			fmt.Println(color.RedString(clientErr.ErrorMessage))

--- a/commands/list/organizations/command.go
+++ b/commands/list/organizations/command.go
@@ -61,6 +61,7 @@ func printValidation(cmd *cobra.Command, cmdLineArgs []string) {
 		return
 	}
 
+	client.HandleErrors(err)
 	errors.HandleCommonErrors(err)
 }
 
@@ -80,8 +81,8 @@ func printResult(cmd *cobra.Command, extraArgs []string) {
 	args := collectArguments()
 	output, err := orgsTable(args)
 	if err != nil {
-		errors.HandleCommonErrors(err)
 		client.HandleErrors(err)
+		errors.HandleCommonErrors(err)
 
 		if clientErr, ok := err.(*clienterror.APIError); ok {
 			fmt.Println(color.RedString(clientErr.ErrorMessage))

--- a/commands/list/releases/command.go
+++ b/commands/list/releases/command.go
@@ -94,6 +94,7 @@ func printValidation(cmd *cobra.Command, extraArgs []string) {
 		return
 	}
 
+	client.HandleErrors(err)
 	errors.HandleCommonErrors(err)
 
 	fmt.Println(color.RedString(err.Error()))
@@ -120,8 +121,8 @@ func printResult(cmd *cobra.Command, extraArgs []string) {
 	releases, err := listReleases(args)
 
 	if err != nil {
-		errors.HandleCommonErrors(err)
 		client.HandleErrors(err)
+		errors.HandleCommonErrors(err)
 
 		if clientErr, ok := err.(*clienterror.APIError); ok {
 			fmt.Println(color.RedString(clientErr.ErrorMessage))

--- a/commands/login/command.go
+++ b/commands/login/command.go
@@ -190,8 +190,8 @@ func loginRunOutput(cmd *cobra.Command, args []string) {
 	result, err := login(loginArgs)
 
 	if err != nil {
-		errors.HandleCommonErrors(err)
 		client.HandleErrors(err)
+		errors.HandleCommonErrors(err)
 
 		var headline = ""
 		var subtext = ""

--- a/commands/logout/command.go
+++ b/commands/logout/command.go
@@ -75,8 +75,8 @@ func printResult(cmd *cobra.Command, extraArgs []string) {
 			os.Exit(0)
 		}
 
-		errors.HandleCommonErrors(err)
 		client.HandleErrors(err)
+		errors.HandleCommonErrors(err)
 
 		// handle non-common errors
 		fmt.Println(color.RedString(err.Error()))

--- a/commands/scale/cluster/command.go
+++ b/commands/scale/cluster/command.go
@@ -240,6 +240,7 @@ func printValidation(cmd *cobra.Command, positionalArgs []string) {
 		return
 	}
 
+	client.HandleErrors(err)
 	errors.HandleCommonErrors(err)
 
 	var headline string
@@ -260,6 +261,7 @@ func printValidation(cmd *cobra.Command, positionalArgs []string) {
 	case errors.IsCannotScaleCluster(err):
 		headline = "This cluster cannot be scaled as a whole."
 		subtext = microerror.Desc(err)
+
 	default:
 		headline = err.Error()
 	}
@@ -356,8 +358,8 @@ func scaleCluster(args Arguments) (*Result, error) {
 func printResult(cmd *cobra.Command, commandLineArgs []string) {
 	args, err := collectArguments(cmd, commandLineArgs)
 	if err != nil {
-		errors.HandleCommonErrors(err)
 		client.HandleErrors(err)
+		errors.HandleCommonErrors(err)
 
 		fmt.Println(color.RedString(err.Error()))
 		os.Exit(1)
@@ -366,8 +368,8 @@ func printResult(cmd *cobra.Command, commandLineArgs []string) {
 	// Actually make the scaling request to the API.
 	result, err := scaleCluster(args)
 	if err != nil {
-		errors.HandleCommonErrors(err)
 		client.HandleErrors(err)
+		errors.HandleCommonErrors(err)
 
 		var headline string
 		var subtext string

--- a/commands/show/cluster/command.go
+++ b/commands/show/cluster/command.go
@@ -85,6 +85,7 @@ func printValidation(cmd *cobra.Command, cmdLineArgs []string) {
 		return
 	}
 
+	client.HandleErrors(err)
 	errors.HandleCommonErrors(err)
 
 	// handle non-common errors
@@ -347,6 +348,7 @@ func printResult(cmd *cobra.Command, cmdLineArgs []string) {
 
 	clusterDetailsV4, clusterDetailsV5, nodePools, clusterStatus, credentialDetails, err := getClusterDetails(args)
 	if err != nil {
+		client.HandleErrors(err)
 		errors.HandleCommonErrors(err)
 
 		headline := ""

--- a/commands/show/nodepool/command.go
+++ b/commands/show/nodepool/command.go
@@ -103,6 +103,7 @@ func printValidation(cmd *cobra.Command, positionalArgs []string) {
 		return
 	}
 
+	client.HandleErrors(err)
 	errors.HandleCommonErrors(err)
 }
 
@@ -149,6 +150,7 @@ func printResult(cmd *cobra.Command, positionalArgs []string) {
 	args := collectArguments(positionalArgs)
 	data, err := fetchNodePool(args)
 	if err != nil {
+		client.HandleErrors(err)
 		errors.HandleCommonErrors(err)
 	}
 

--- a/commands/show/release/command.go
+++ b/commands/show/release/command.go
@@ -74,6 +74,7 @@ func printValidation(cmd *cobra.Command, cmdLineArgs []string) {
 		return
 	}
 
+	client.HandleErrors(err)
 	errors.HandleCommonErrors(err)
 
 	// handle non-common errors
@@ -132,8 +133,8 @@ func printResult(cmd *cobra.Command, cmdLineArgs []string) {
 
 	// error output
 	if err != nil {
-		errors.HandleCommonErrors(err)
 		client.HandleErrors(err)
+		errors.HandleCommonErrors(err)
 
 		var headline = ""
 		var subtext = ""

--- a/commands/update/cluster/command.go
+++ b/commands/update/cluster/command.go
@@ -103,8 +103,8 @@ func printValidation(cmd *cobra.Command, positionalArgs []string) {
 		return
 	}
 
-	errors.HandleCommonErrors(err)
 	client.HandleErrors(err)
+	errors.HandleCommonErrors(err)
 
 	headline := ""
 	subtext := ""
@@ -195,8 +195,8 @@ func printResult(cmd *cobra.Command, positionalArgs []string) {
 
 	_, err := updateCluster(args)
 	if err != nil {
-		errors.HandleCommonErrors(err)
 		client.HandleErrors(err)
+		errors.HandleCommonErrors(err)
 
 		headline := ""
 		subtext := ""

--- a/commands/update/nodepool/command.go
+++ b/commands/update/nodepool/command.go
@@ -124,6 +124,7 @@ func printValidation(cmd *cobra.Command, positionalArgs []string) {
 		return
 	}
 
+	client.HandleErrors(err)
 	errors.HandleCommonErrors(err)
 
 	headline := ""
@@ -182,8 +183,8 @@ func printResult(cmd *cobra.Command, positionalArgs []string) {
 
 	r, err := updateNodePool(args)
 	if err != nil {
-		errors.HandleCommonErrors(err)
 		client.HandleErrors(err)
+		errors.HandleCommonErrors(err)
 
 		headline := ""
 		subtext := ""

--- a/commands/update/organization/setcredentials/command.go
+++ b/commands/update/organization/setcredentials/command.go
@@ -131,6 +131,7 @@ func printValidation(cmd *cobra.Command, cmdLineArgs []string) {
 		return
 	}
 
+	client.HandleErrors(err)
 	errors.HandleCommonErrors(err)
 
 	// From here on we handle errors that can only occur in this command
@@ -279,8 +280,8 @@ func printResult(cmd *cobra.Command, cmdLineArgs []string) {
 	result, err := setOrgCredentials(args)
 
 	if err != nil {
-		errors.HandleCommonErrors(err)
 		client.HandleErrors(err)
+		errors.HandleCommonErrors(err)
 
 		// From here on we handle errors that can only occur in this command
 		headline := ""

--- a/commands/upgrade/cluster/command.go
+++ b/commands/upgrade/cluster/command.go
@@ -113,6 +113,7 @@ func upgradeClusterValidationOutput(cmd *cobra.Command, cmdLineArgs []string) {
 	err := validateUpgradeClusterPreconditions(args, cmdLineArgs)
 
 	if err != nil {
+		client.HandleErrors(err)
 		errors.HandleCommonErrors(err)
 
 		switch {
@@ -160,8 +161,8 @@ func upgradeClusterExecutionOutput(cmd *cobra.Command, cmdLineArgs []string) {
 	result, err := upgradeCluster(args)
 
 	if err != nil {
-		errors.HandleCommonErrors(err)
 		client.HandleErrors(err)
+		errors.HandleCommonErrors(err)
 
 		var headline = ""
 		var subtext = ""


### PR DESCRIPTION
This PR aligns the handling of Internal Server Errors (HTTP 500) in all commands.

- In the `clienterror` package we make sure the error "message" part is passed to the returned APIError object.
- In the `client.HandleErrors()` function we make sure to handle the internal error
- We apply `client.HandleErrors()` consistently in every command.

### Before

```
gsctl scale cluster ...
[GET /v4/clusters/{cluster_id}/][500] getCluster default  &{Code:INTERNAL_ERROR Message:Something bad happened which we'll explain somewhere else.}
```

### After

```
gsctl scale cluster ...
An internal error occurred.
Something bad happened which we'll explain somewhere else.
```