### PR TITLE
Fix cluster definition in 'create cluster' usage

### DIFF
--- a/commands/create/cluster/command.go
+++ b/commands/create/cluster/command.go
@@ -155,7 +155,7 @@ need for a file:
 gsctl create cluster -f - <<EOF
 owner: acme
 name: Test cluster using two AZs
-release: 8.2.0
+release_version: 8.2.0
 availability_zones: 2
 EOF
 


### PR DESCRIPTION
The usage example shows an attribute `release`, which should i fact be named `release_version`.