### PR TITLE
Improve error handling in 'create cluster' with YAML from standard input

### DIFF
--- a/commands/create/cluster/command.go
+++ b/commands/create/cluster/command.go
@@ -94,6 +94,8 @@ type creationResult struct {
 
 const (
 	createClusterActivityName = "create-cluster"
+
+	standardInputSpecialPath = "-"
 )
 
 var (
@@ -245,7 +247,7 @@ func printResult(cmd *cobra.Command, positionalArgs []string) {
 			}
 		case errors.IsYAMLNotParseable(err):
 			headline = "Could not parse YAML"
-			if args.InputYAMLFile == "-" {
+			if args.InputYAMLFile == standardInputSpecialPath {
 				subtext = "The YAML data given via STDIN could not be parsed into a cluster definition."
 			} else {
 				subtext = fmt.Sprintf("The YAML data read from file '%s' could not be parsed into a cluster definition.", args.InputYAMLFile)
@@ -401,7 +403,7 @@ func addCluster(args Arguments) (*creationResult, error) {
 
 	// Process YAML definition (if given), so we can take a 'release_version' key into consideration.
 	var definitionInterface interface{}
-	if args.InputYAMLFile == "-" {
+	if args.InputYAMLFile == standardInputSpecialPath {
 		definitionInterface, err = readDefinitionFromSTDIN()
 
 		if err != nil {

--- a/commands/create/cluster/command.go
+++ b/commands/create/cluster/command.go
@@ -253,8 +253,15 @@ func printResult(cmd *cobra.Command, positionalArgs []string) {
 				subtext = fmt.Sprintf("The YAML data read from file '%s' could not be parsed into a cluster definition.", args.InputYAMLFile)
 			}
 		case errors.IsYAMLFileNotReadable(err):
-			headline = "Could not read YAML file"
-			subtext = fmt.Sprintf("The file '%s' could not be read. Please make sure that it is readable and contains valid YAML.", args.InputYAMLFile)
+			if args.InputYAMLFile == standardInputSpecialPath {
+				headline = "Could not read YAML from STDIN"
+				subtext = "The YAML definition given via standard input could not be parsed.\n"
+				subtext += fmt.Sprintf("Details: %s", err.Error())
+			} else {
+				headline = "Could not read YAML file"
+				subtext = fmt.Sprintf("The file '%s' could not be read. Please make sure that it is readable and contains valid YAML.\n", args.InputYAMLFile)
+				subtext += fmt.Sprintf("Details: %s", err.Error())
+			}
 		case errors.IsIncompatibleSettings(err):
 			headline = "Incompatible settings"
 			subtext = "The provided cluster details/definition are not compatible with the capabilities of the installation and/or release.\n"


### PR DESCRIPTION
This PR should improve the error message shown if `gsctl create cluster` receives bad YAML via standard input.

1. We pay respect to the fact that `-` is not an actual file
2. We show what went wrong with parsing the YAML.

### Before

```
$ gsctl create cluster -f - <<EOF
> owner: acme
> name: Test marian org=acme release=9.0.0
> foo: 9.0.0
> EOF
Could not read YAML file
The file '-' could not be read. Please make sure that it is readable and contains valid YAML.
```

### After

```
$ gsctl create cluster -f - <<EOF
> owner: acme
> name: Test marian org=acme release=9.0.0
> foo: 9.0.0
> EOF
Could not read YAML from STDIN
The YAML definition given via standard input could not be parsed.
Details: yaml: unmarshal errors:
  line 3: field foo not found in type types.ClusterDefinitionV4: invalid definition yaml error: yaml file not readable error: yaml file not readable error
```