### PR TITLE
Improve 404 error handling for 'delete nodepool'

### DIFF
--- a/commands/delete/nodepool/command.go
+++ b/commands/delete/nodepool/command.go
@@ -170,6 +170,19 @@ func deleteNodePool(args Arguments) (bool, error) {
 	if clienterror.IsAccessForbiddenError(err) {
 		return false, microerror.Mask(errors.AccessForbiddenError)
 	} else if clienterror.IsNotFoundError(err) {
+		// Check whether the cluster exists
+		_, detailsErr := clientWrapper.GetClusterV5(args.ClusterID, auxParams)
+		if detailsErr == nil {
+			// Cluster exists, node pool does not exist.
+			return false, microerror.Mask(errors.NodePoolNotFoundError)
+		}
+
+		_, detailsErr = clientWrapper.GetClusterV4(args.ClusterID, auxParams)
+		if detailsErr == nil {
+			// Cluster exists, but is v4, so cannot have node pools.
+			// TODO: use errors.ClusterDoesNotSupportNodePoolsError when available
+		}
+
 		return false, microerror.Mask(errors.ClusterNotFoundError)
 	} else if err != nil {
 		return false, microerror.Mask(err)

--- a/commands/delete/nodepool/command.go
+++ b/commands/delete/nodepool/command.go
@@ -203,7 +203,13 @@ func printResult(cmd *cobra.Command, positionalArgs []string) {
 		subtext := ""
 
 		switch {
-		// If there are specific errors to handle, add them here.
+		case errors.IsClusterNotFoundError(err):
+			headline = "Cluster not found"
+			subtext = fmt.Sprintf("Could not find a cluster with ID %s. Please check the ID.", args.ClusterID)
+		case errors.IsNodePoolNotFound(err):
+			headline = "Node pool not found"
+			subtext = fmt.Sprintf("Could not find a node pool with ID %s in this cluster. ", args.NodePoolID)
+		// TODO: handle errors.ClusterDoesNotSupportNodePoolsError
 		default:
 			headline = err.Error()
 		}

--- a/commands/delete/nodepool/command.go
+++ b/commands/delete/nodepool/command.go
@@ -180,7 +180,7 @@ func deleteNodePool(args Arguments) (bool, error) {
 		_, detailsErr = clientWrapper.GetClusterV4(args.ClusterID, auxParams)
 		if detailsErr == nil {
 			// Cluster exists, but is v4, so cannot have node pools.
-			// TODO: use errors.ClusterDoesNotSupportNodePoolsError when available
+			return false, microerror.Mask(errors.ClusterDoesNotSupportNodePoolsError)
 		}
 
 		return false, microerror.Mask(errors.ClusterNotFoundError)
@@ -209,7 +209,9 @@ func printResult(cmd *cobra.Command, positionalArgs []string) {
 		case errors.IsNodePoolNotFound(err):
 			headline = "Node pool not found"
 			subtext = fmt.Sprintf("Could not find a node pool with ID %s in this cluster. ", args.NodePoolID)
-		// TODO: handle errors.ClusterDoesNotSupportNodePoolsError
+		case errors.IsClusterDoesNotSupportNodePools(err):
+			headline = "Bad cluster ID"
+			subtext = fmt.Sprint("You are trying to delete a node pool from a cluster that does not support node pools. Please check your cluster ID.")
 		default:
 			headline = err.Error()
 		}

--- a/commands/delete/nodepool/command_test.go
+++ b/commands/delete/nodepool/command_test.go
@@ -196,10 +196,10 @@ func TestSuccess(t *testing.T) {
 // TestExecuteWithError tests the error handling.
 func TestExecuteWithError(t *testing.T) {
 	var testCases = []struct {
-		args               Arguments
-		responseStatusCode int
-		responseBody       string
-		errorMatcher       func(error) bool
+		args                     Arguments
+		deleteResponseStatusCode int
+		deleteResponseBody       string
+		errorMatcher             func(error) bool
 	}{
 		{
 			Arguments{
@@ -227,7 +227,7 @@ func TestExecuteWithError(t *testing.T) {
 		},
 		{
 			Arguments{
-				ClusterID:   "clusterid",
+				ClusterID:   "bad-cluster-id",
 				NodePoolID:  "nodepoolid",
 				AuthToken:   "token",
 				APIEndpoint: "https://mock-url",
@@ -236,6 +236,18 @@ func TestExecuteWithError(t *testing.T) {
 			404,
 			`{"code": "RESOURCE_NOT_FOUND", "message": "Here is some error message"}`,
 			errors.IsClusterNotFoundError,
+		},
+		{
+			Arguments{
+				ClusterID:   "clusterid",
+				NodePoolID:  "bad-nodepool-id",
+				AuthToken:   "token",
+				APIEndpoint: "https://mock-url",
+				Force:       true,
+			},
+			404,
+			`{"code": "RESOURCE_NOT_FOUND", "message": "Here is some error message"}`,
+			errors.IsNodePoolNotFound,
 		},
 		{
 			Arguments{
@@ -262,10 +274,22 @@ func TestExecuteWithError(t *testing.T) {
 			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				if r.Method == "DELETE" && r.URL.Path == "/v5/clusters/clusterid/nodepools/nodepoolid/" {
-					w.WriteHeader(tc.responseStatusCode)
-					w.Write([]byte(tc.responseBody))
+					w.WriteHeader(tc.deleteResponseStatusCode)
+					w.Write([]byte(tc.deleteResponseBody))
+				} else if r.Method == "DELETE" && r.URL.Path == "/v5/clusters/bad-cluster-id/nodepools/nodepoolid/" {
+					w.WriteHeader(tc.deleteResponseStatusCode)
+					w.Write([]byte(tc.deleteResponseBody))
+				} else if r.Method == "DELETE" && r.URL.Path == "/v5/clusters/clusterid/nodepools/bad-nodepool-id/" {
+					w.WriteHeader(tc.deleteResponseStatusCode)
+					w.Write([]byte(tc.deleteResponseBody))
+				} else if r.Method == "GET" && r.URL.Path == "/v5/clusters/clusterid/" {
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte(`{
+						"id": "clusterid",
+						"owner": "acme"
+					}`))
 				} else {
-					t.Errorf("Unsupported operation %s %s called in mock server", r.Method, r.URL.Path)
+					t.Logf("Unsupported operation %s %s called in mock server", r.Method, r.URL.Path)
 					w.WriteHeader(http.StatusNotFound)
 					w.Write([]byte(`{"code": "RESOURCE_NOT_FOUND", "message": "Status for this cluster is not yet available."}`))
 				}

--- a/commands/errors/errors.go
+++ b/commands/errors/errors.go
@@ -128,6 +128,16 @@ func IsClusterNotFoundError(err error) bool {
 	return false
 }
 
+// NodePoolNotFoundError means that a node pool the user wants to interact with does not exist.
+var NodePoolNotFoundError = &microerror.Error{
+	Kind: "NodePoolNotFoundError",
+}
+
+// IsNodePoolNotFound asserts NodePoolNotFoundError.
+func IsNodePoolNotFound(err error) bool {
+	return microerror.Cause(err) == NodePoolNotFoundError
+}
+
 // ReleaseVersionMissingError means the required release version argument is missing
 var ReleaseVersionMissingError = &microerror.Error{
 	Kind: "ReleaseVersionMissingError",


### PR DESCRIPTION
For https://github.com/giantswarm/giantswarm/issues/6447

This PR improves the error reporting in case a deleteNodePool API request is responded with 404. We check whether it's the node pool or the cluster that does not exist and give specific error messages.

### TODO

- [x] After https://github.com/giantswarm/gsctl/pull/466 is merged, make use of `errors.ClusterDoesNotSupportNodePoolsError` and provide specific error message for that
- [x] fix tests