### PR TITLE
Add v5 support to 'gsctl upgrade cluster'

### DIFF
--- a/capabilities/service_test.go
+++ b/capabilities/service_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/giantswarm/gsctl/client"
+
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/client/client.go
+++ b/client/client.go
@@ -350,8 +350,8 @@ func (w *Wrapper) CreateClusterV5(addClusterRequest *models.V5AddClusterRequest,
 	return response, nil
 }
 
-// ModifyCluster modifies a cluster using the gsclientgen client.
-func (w *Wrapper) ModifyCluster(clusterID string, body *models.V4ModifyClusterRequest, p *AuxiliaryParams) (*clusters.ModifyClusterOK, error) {
+// ModifyClusterV4 modifies a cluster using the gsclientgen client.
+func (w *Wrapper) ModifyClusterV4(clusterID string, body *models.V4ModifyClusterRequest, p *AuxiliaryParams) (*clusters.ModifyClusterOK, error) {
 	params := clusters.NewModifyClusterParams().WithClusterID(clusterID).WithBody(body)
 	setParams(p, w, params)
 

--- a/commands/scale/cluster/command.go
+++ b/commands/scale/cluster/command.go
@@ -343,7 +343,7 @@ func scaleCluster(args Arguments) (*Result, error) {
 	if args.Verbose {
 		fmt.Println(color.WhiteString("Sending API request to modify cluster"))
 	}
-	_, err = clientWrapper.ModifyCluster(args.ClusterID, reqBody, auxParams)
+	_, err = clientWrapper.ModifyClusterV4(args.ClusterID, reqBody, auxParams)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/commands/update/cluster/command.go
+++ b/commands/update/cluster/command.go
@@ -174,7 +174,7 @@ func updateCluster(args Arguments) (*result, error) {
 		if args.Verbose {
 			fmt.Println(color.WhiteString("Sending cluster modification request to v4 endpoint."))
 		}
-		response, err := clientWrapper.ModifyCluster(args.ClusterID, requestBody, auxParams)
+		response, err := clientWrapper.ModifyClusterV4(args.ClusterID, requestBody, auxParams)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}

--- a/commands/upgrade/cluster/command.go
+++ b/commands/upgrade/cluster/command.go
@@ -86,7 +86,7 @@ func collectArguments(cmdLineArgs []string) Arguments {
 		apiEndpoint:       endpoint,
 		authToken:         token,
 		clusterID:         clusterID,
-		force:             false,
+		force:             flags.Force,
 		userProvidedToken: flags.Token,
 		verbose:           flags.Verbose,
 	}

--- a/commands/upgrade/cluster/command_test.go
+++ b/commands/upgrade/cluster/command_test.go
@@ -13,25 +13,25 @@ import (
 	"github.com/giantswarm/gsctl/testutils"
 )
 
-var successorVersionTests = []struct {
-	myVersion        string
-	allVersions      []string
-	successorVersion string
-}{
-	{
-		"1.2.3",
-		[]string{"1.2.3", "1.2.4", "1.2.5", "10.2.3", "2.0.0", "0.1.0"},
-		"1.2.4",
-	},
-	// none of the versions in the slice is higher
-	{
-		"4.5.2",
-		[]string{"3.2.1", "0.5.1", "0.5.0", "0.6.0", "4.5.2"},
-		"",
-	},
-}
+func Test_successorReleaseVersion(t *testing.T) {
+	var successorVersionTests = []struct {
+		myVersion        string
+		allVersions      []string
+		successorVersion string
+	}{
+		{
+			"1.2.3",
+			[]string{"1.2.3", "1.2.4", "1.2.5", "10.2.3", "2.0.0", "0.1.0"},
+			"1.2.4",
+		},
+		// none of the versions in the slice is higher
+		{
+			"4.5.2",
+			[]string{"3.2.1", "0.5.1", "0.5.0", "0.6.0", "4.5.2"},
+			"",
+		},
+	}
 
-func TestSuccessorReleaseVersion(t *testing.T) {
 	for i, tc := range successorVersionTests {
 		v := successorReleaseVersion(tc.myVersion, tc.allVersions)
 		if v != tc.successorVersion {

--- a/commands/upgrade/cluster/command_test.go
+++ b/commands/upgrade/cluster/command_test.go
@@ -8,10 +8,11 @@ import (
 
 	"github.com/Jeffail/gabs"
 	"github.com/giantswarm/gscliauth/config"
-	"github.com/giantswarm/gsctl/commands/errors"
-	"github.com/giantswarm/gsctl/testutils"
 	"github.com/google/go-cmp/cmp"
 	"github.com/spf13/afero"
+
+	"github.com/giantswarm/gsctl/commands/errors"
+	"github.com/giantswarm/gsctl/testutils"
 )
 
 func Test_successorReleaseVersion(t *testing.T) {


### PR DESCRIPTION
For https://github.com/giantswarm/giantswarm/issues/6447

This enables support for v5 clusters to the `gsctl upgrade cluster` command.

Also contains a bugfix: Make use of the `--force` flag that didn't have any effect previously.

### Preview

```
$ ./gsctl show cluster 87bcq
Cluster ID:                87bcq
Name:                      marian upgrade v5 test
Created:                   2019 Nov 26, 11:22 UTC
Organization:              nodepools
Kubernetes API endpoint:   https://api.87bcq.k8s.gauss.eu-central-1.aws.gigantic.io
Master availability zone:  eu-central-1a
Release version:           10.0.0

$ ./gsctl upgrade cluster 87bcq
Cluster '87bcq' will be upgraded from version 10.0.0 to 10.0.1.

Changelog:

    - cloudformation: Add IAMManager IAM role for kiam managed app.
    - cloudformation: Add Route53Manager IAM role for external-dns managed app.
    - kubernetes: Updated from v1.14.6 to v1.15.5.
    - clusterapi: Add cleanuprecordsets resource to cleanup non-managed route53 records.
    - cluster-autoscaler: Updated to version 1.16.2.
    - coredns: Updated to version 1.6.5.
    - net-exporter: Updated to version 1.4.0.
    - node-exporter: Updated to version 0.18.1.

NOTE: Upgrading may impact your running workloads and will make the cluster's
Kubernetes API unavailable temporarily. Before upgrading, please acknowledge the
details described in

    https://docs.giantswarm.io/reference/cluster-upgrades/

Do you want to start the upgrade now? [y/n]: y
Starting to upgrade cluster '87bcq' to release version 10.0.1
```
