### PR TITLE
Improve handling of "malformed response" error

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -503,7 +503,7 @@ func TestMalformedResponse(t *testing.T) {
 	}
 
 	_, err = gsClient.GetClusterV4("cluster-id", nil)
-	if !clienterror.IsMalformedResponseError(err) {
+	if !clienterror.IsMalformedResponse(err) {
 		t.Errorf("Expected 'Malformed response' error, got %s", err.Error())
 	}
 }

--- a/client/clienterror/matcher.go
+++ b/client/clienterror/matcher.go
@@ -7,9 +7,9 @@ import (
 	"github.com/giantswarm/microerror"
 )
 
-// IsMalformedResponseError checks whether the error is
+// IsMalformedResponse checks whether the error is
 // "Malformed response", which can mean several things.
-func IsMalformedResponseError(err error) bool {
+func IsMalformedResponse(err error) bool {
 	return err.Error() == "Malformed response"
 }
 

--- a/client/error.go
+++ b/client/error.go
@@ -76,6 +76,11 @@ func HandleErrors(err error) {
 		httpStatusCode = convertedErr.HTTPStatusCode
 		message = convertedErr.ErrorMessage
 		details = convertedErr.ErrorDetails
+
+		if clienterror.IsMalformedResponse(err) {
+			message = "Malformed response - No API access?"
+			subtext = convertedErr.ErrorDetails
+		}
 	} else if convertedErr, ok := err.(*clienterror.APIError); ok {
 		httpStatusCode = convertedErr.HTTPStatusCode
 		message = convertedErr.ErrorMessage

--- a/commands/info/command.go
+++ b/commands/info/command.go
@@ -192,8 +192,15 @@ func printInfo(cmd *cobra.Command, args []string) {
 
 	if err != nil {
 		fmt.Println()
+
+		// if this is a common error, handle it in the standard way and exit.
+		client.HandleErrors(err)
+		errors.HandleCommonErrors(err)
+
+		// handle non-standard errors.
 		fmt.Println(color.RedString("Some error occurred:"))
 		fmt.Println(err.Error())
+		os.Exit(1)
 	}
 }
 

--- a/commands/show/cluster/command.go
+++ b/commands/show/cluster/command.go
@@ -243,7 +243,7 @@ func getClusterDetails(args Arguments) (
 		// If this is a "Malformed response" error, we assume the API is not capable of
 		// handling V5 yet. TODO: This can be phased out once the API is up-to-date.
 		// In both these case we continue below, otherwise we return the error.
-		if !errors.IsClusterNotFoundError(v5Err) && !clienterror.IsMalformedResponseError(v5Err) && !clienterror.IsBadRequestError(v5Err) {
+		if !errors.IsClusterNotFoundError(v5Err) && !clienterror.IsMalformedResponse(v5Err) && !clienterror.IsBadRequestError(v5Err) {
 			return nil, nil, nil, nil, nil, microerror.Mask(v5Err)
 		}
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/4430

This PR attempts to handle the `Malformed response` error consistently in all commands (with the exception of `gsctl ping` as that one is using a different client.

The error's cause is usually that some Ingress controller responds with an HTML page showing some "forbidden" message. The cause here is often that a VPN connection is not set up and the client is connecting from a network that has no permission to access the API.

Before:

![image](https://user-images.githubusercontent.com/273727/70605696-45340600-1bfb-11ea-8419-fe5f0e4e97dd.png)

After:

![image](https://user-images.githubusercontent.com/273727/70605722-52e98b80-1bfb-11ea-9acf-90e2ce1bfe78.png)
