### PR TITLE
'gsctl show cluster': add some guidance for node pools clusters

### DIFF
--- a/commands/show/cluster/command.go
+++ b/commands/show/cluster/command.go
@@ -493,7 +493,7 @@ func printV5Result(args Arguments, details *models.V5ClusterDetailsResponse,
 			fmt.Println(columnize.SimpleFormat(clusterTable))
 
 			fmt.Println()
-			fmt.Printf("This cluster has node pools. For information on worker nodes, use\n\n")
+			fmt.Printf("This cluster has node pools. For details, use\n\n")
 			fmt.Printf("    %s\n\n", color.YellowString("gsctl list nodepools %s", details.ID))
 			fmt.Printf("For details on a specific node pool, use\n\n")
 			fmt.Printf("    %s\n\n", color.YellowString("gsctl show nodepool %s/<nodepool-id>", details.ID))

--- a/commands/show/cluster/command.go
+++ b/commands/show/cluster/command.go
@@ -486,11 +486,25 @@ func printV5Result(args Arguments, details *models.V5ClusterDetailsResponse,
 	// once KVM is supported in V5.
 
 	// Aggregate of node pools.
-	if nodePools != nil && len(*nodePools) > 0 {
-		clusterTable = append(clusterTable, formatNodePoolDetails(nodePools)...)
-	}
+	if nodePools != nil {
+		if len(*nodePools) > 0 {
+			clusterTable = append(clusterTable, formatNodePoolDetails(nodePools)...)
 
-	fmt.Println(columnize.SimpleFormat(clusterTable))
+			fmt.Println(columnize.SimpleFormat(clusterTable))
+
+			fmt.Println()
+			fmt.Printf("This cluster has node pools. For information on worker nodes, use\n\n")
+			fmt.Printf("    %s\n\n", color.YellowString("gsctl list nodepools %s", details.ID))
+			fmt.Printf("For details on a specific node pool, use\n\n")
+			fmt.Printf("    %s\n\n", color.YellowString("gsctl show nodepool %s/<nodepool-id>", details.ID))
+		} else {
+			fmt.Println(columnize.SimpleFormat(clusterTable))
+
+			fmt.Println()
+			fmt.Print("This cluster has no node pools. Find out how to add a node pool using\n\n")
+			fmt.Printf("    %s\n\n", color.YellowString("gsctl create nodepool --help"))
+		}
+	}
 }
 
 // formatDate takes a date/time string from the API and returns a formated version.


### PR DESCRIPTION
For https://github.com/giantswarm/giantswarm/issues/6447

This PR adds more output to the `gsctl show cluster` command in case it is a v5 (node pools) cluster which is supposed to guide users to the commands giving them more information (or for creating a new node pool if there are none).

### Preview

Before:

![image](https://user-images.githubusercontent.com/273727/70618829-0c545b00-1c14-11ea-80fd-ef0e5a7cae67.png)

After:

![image](https://user-images.githubusercontent.com/273727/70619028-73720f80-1c14-11ea-8559-cf9b70df4698.png)

