### PR TITLE
Show web UI URL in 'gsctl show cluster' output

### DIFF
--- a/commands/show/cluster/command.go
+++ b/commands/show/cluster/command.go
@@ -21,6 +21,7 @@ import (
 	"github.com/giantswarm/gsctl/flags"
 	"github.com/giantswarm/gsctl/nodespec"
 	"github.com/giantswarm/gsctl/util"
+	"github.com/giantswarm/gsctl/webui"
 )
 
 var (
@@ -398,10 +399,13 @@ func printV4Result(args Arguments, clusterDetails *models.V4ClusterDetailsRespon
 		}
 	}
 
+	webUIURL, _ := webui.ClusterDetailsURL(args.apiEndpoint, clusterDetails.ID, clusterDetails.Owner)
+
 	// print table
 	output := []string{}
 
 	output = append(output, color.YellowString("ID:")+"|"+clusterDetails.ID)
+
 	output = append(output, color.YellowString("Name:")+"|"+stringOrPlaceholder(clusterDetails.Name))
 	output = append(output, color.YellowString("Created:")+"|"+formatDate(clusterDetails.CreateDate))
 	output = append(output, color.YellowString("Organization:")+"|"+clusterDetails.Owner)
@@ -458,6 +462,10 @@ func printV4Result(args Arguments, clusterDetails *models.V4ClusterDetailsRespon
 		}
 	}
 
+	if webUIURL != "" {
+		output = append(output, color.YellowString("Web UI:")+"|"+webUIURL)
+	}
+
 	fmt.Println(columnize.SimpleFormat(output))
 }
 
@@ -465,6 +473,8 @@ func printV4Result(args Arguments, clusterDetails *models.V4ClusterDetailsRespon
 func printV5Result(args Arguments, details *models.V5ClusterDetailsResponse,
 	credentialDetails *models.V4GetCredentialResponse,
 	nodePools *models.V5GetNodePoolsResponse) {
+
+	webUIURL, _ := webui.ClusterDetailsURL(args.apiEndpoint, details.ID, details.Owner)
 
 	// clusterTable is the table for cluster information.
 	clusterTable := []string{}
@@ -480,6 +490,10 @@ func printV5Result(args Arguments, details *models.V5ClusterDetailsResponse,
 	// BYOC credentials.
 	if credentialDetails != nil && credentialDetails.ID != "" {
 		clusterTable = append(clusterTable, formatCredentialDetails(credentialDetails)...)
+	}
+
+	if webUIURL != "" {
+		clusterTable = append(clusterTable, color.YellowString("Web UI:")+"|"+webUIURL)
 	}
 
 	// TODO: Add KVM ingress port mappings here

--- a/webui/error.go
+++ b/webui/error.go
@@ -1,0 +1,22 @@
+package webui
+
+import "github.com/giantswarm/microerror"
+
+var unsupportedHostNameError = &microerror.Error{
+	Kind: "unsupportedHostNameError",
+	Desc: "The host name is of a format that we do not support",
+}
+
+// IsUnsupportedHostName asserts unsupportedHostNameError.
+func IsUnsupportedHostName(err error) bool {
+	return microerror.Cause(err) == unsupportedHostNameError
+}
+
+var missingArgumentError = &microerror.Error{
+	Kind: "missingArgumentError",
+}
+
+// IsMissingArgument asserts missingArgumentError.
+func IsMissingArgument(err error) bool {
+	return microerror.Cause(err) == missingArgumentError
+}

--- a/webui/webui.go
+++ b/webui/webui.go
@@ -1,0 +1,60 @@
+// Package webui provides a method to find the Web UI (happa) URL, based on the installations's API endpoint URL.
+package webui
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/giantswarm/microerror"
+)
+
+const (
+	apiStandardHostName = "api"
+
+	webUIStandardHostName = "happa"
+)
+
+// BaseURL returns the web UI base URL derived from an API URL.
+func BaseURL(apiEndpoint string) (string, error) {
+	parsed, err := url.Parse(apiEndpoint)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	hostNameParts := strings.Split(parsed.Hostname(), ".")
+
+	// replace first part with 'happa' if it is 'api'
+	if len(hostNameParts) < 2 {
+		return "", microerror.Mask(unsupportedHostNameError)
+	}
+
+	if hostNameParts[0] != apiStandardHostName {
+		return "", microerror.Maskf(unsupportedHostNameError, "host name must start with 'api'")
+	}
+
+	hostNameParts[0] = webUIStandardHostName
+
+	webUIFullHostName := strings.Join(hostNameParts, ".")
+
+	return "https://" + webUIFullHostName, nil
+}
+
+// ClusterDetailsURL returns the URL of a cluster details page in the web UI.
+func ClusterDetailsURL(apiEndpoint string, clusterID string, organization string) (string, error) {
+	if clusterID == "" {
+		return "", microerror.Maskf(missingArgumentError, "cluster ID must be given")
+	}
+	if organization == "" {
+		return "", microerror.Maskf(missingArgumentError, "organization ID must be given")
+	}
+
+	baseURL, err := BaseURL(apiEndpoint)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	url := fmt.Sprintf("%s/organizations/%s/clusters/%s", baseURL, organization, clusterID)
+
+	return url, nil
+}

--- a/webui/webui.go
+++ b/webui/webui.go
@@ -30,7 +30,7 @@ func BaseURL(apiEndpoint string) (string, error) {
 	}
 
 	if hostNameParts[0] != apiStandardHostName {
-		return "", microerror.Maskf(unsupportedHostNameError, "host name must start with 'api'")
+		return "", microerror.Maskf(unsupportedHostNameError, fmt.Sprintf("host name must start with '%s'", apiStandardHostName))
 	}
 
 	hostNameParts[0] = webUIStandardHostName

--- a/webui/webui_test.go
+++ b/webui/webui_test.go
@@ -1,0 +1,135 @@
+package webui
+
+import (
+	"testing"
+)
+
+func TestBaseURL(t *testing.T) {
+	type args struct {
+		apiEndpoint string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "format okay",
+			args:    args{apiEndpoint: "https://api.g8s.foobar.org"},
+			want:    "https://happa.g8s.foobar.org",
+			wantErr: false,
+		},
+		{
+			name:    "bad format",
+			args:    args{apiEndpoint: "https://api"},
+			wantErr: true,
+		},
+		{
+			name:    "control character in URL",
+			args:    args{apiEndpoint: "https://api.foo.bar" + string(byte(0x7f))},
+			wantErr: true,
+		},
+		{
+			name:    "bad format",
+			args:    args{apiEndpoint: "https://foo.g8s.foobar.org"},
+			wantErr: true,
+		},
+		{
+			name:    "not a valid URL",
+			args:    args{apiEndpoint: "this is not a URL"},
+			wantErr: true,
+		},
+		{
+			name:    "Only schema",
+			args:    args{apiEndpoint: "https://"},
+			wantErr: true,
+		},
+		{
+			name:    "Empty input",
+			args:    args{apiEndpoint: ""},
+			wantErr: true,
+		},
+		{
+			name:    "Port number given",
+			args:    args{apiEndpoint: "https://api.foo.bar:8080"},
+			want:    "https://happa.foo.bar",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := BaseURL(tt.args.apiEndpoint)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("BaseURL() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("BaseURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClusterDetailsURL(t *testing.T) {
+	type args struct {
+		apiEndpoint  string
+		clusterID    string
+		organization string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "normal case",
+			args: args{
+				apiEndpoint:  "https://api.g8s.mydomain.org",
+				clusterID:    "dah45",
+				organization: "acme",
+			},
+			want: "https://happa.g8s.mydomain.org/organizations/acme/clusters/dah45",
+		},
+		{
+			name: "error case",
+			args: args{
+				apiEndpoint:  "foo bar",
+				clusterID:    "dah45",
+				organization: "acme",
+			},
+			wantErr: true,
+		},
+		{
+			name: "error case",
+			args: args{
+				apiEndpoint:  "https://api.g8s.foo.bar",
+				clusterID:    "",
+				organization: "acme",
+			},
+			wantErr: true,
+		},
+		{
+			name: "error case",
+			args: args{
+				apiEndpoint:  "https://api.g8s.foo.bar",
+				clusterID:    "mycluster",
+				organization: "",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ClusterDetailsURL(tt.args.apiEndpoint, tt.args.clusterID, tt.args.organization)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ClusterDetailsURL() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("ClusterDetailsURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6058

This adds displaying the web UI URL for cluster details in the `gsctl show cluster` output.

### Preview

![image](https://user-images.githubusercontent.com/273727/70635031-7a5c4a80-1c33-11ea-9007-5cf3e6dddeea.png)

