### PR TITLE
Attempt to fix release automation regex

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,6 @@ workflows:
       - dist:
           filters:
             tags:
-              only: ^[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)*$
+              only: /^[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)*$/
             branches:
               ignore: /.*/


### PR DESCRIPTION
The goal of this PR is to make release automation on tag pushes work again.

In PR https://github.com/giantswarm/gsctl/pull/459 I modified the regex and removed/forgot the slashes in the beginning and the end. This could be the reason why it's not working at all.