### PR TITLE
Fix release automation - 'make prebuild' 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,24 +61,6 @@ jobs:
           name: Update scoop bucket
           command: ./.circleci/update-scoop.sh $CIRCLE_TAG
 
-
-  # TODO: remove when this is working.
-  fixdist:
-    machine: true
-    steps:
-      - checkout
-      - run:
-          name: Create VERSION file
-          command: echo "100.0.0" > ./VERSION
-      - run:
-          name: Store code signing certificate
-          command: |
-            mkdir -p certs
-            echo $CODE_SIGNING_CERT_BUNDLE_BASE64 | base64 -d > certs/code-signing.p12
-      - run:
-          name: Create binary distribution for all platforms
-          command: make bin-dist
-
 workflows:
   version: 2
   build:
@@ -92,8 +74,3 @@ workflows:
               only: /^[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)*$/
             branches:
               ignore: /.*/
-      # TODO: remove when this is working.
-      - fixdist:
-          filters:
-            branches:
-              only: fix-make-prebuild

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,24 @@ jobs:
           name: Update scoop bucket
           command: ./.circleci/update-scoop.sh $CIRCLE_TAG
 
+
+  # TODO: remove when this is working.
+  fixdist:
+    machine: true
+    steps:
+      - checkout
+      - run:
+          name: Create VERSION file
+          command: echo "100.0.0" > ./VERSION
+      - run:
+          name: Store code signing certificate
+          command: |
+            mkdir -p certs
+            echo $CODE_SIGNING_CERT_BUNDLE_BASE64 | base64 -d > certs/code-signing.p12
+      - run:
+          name: Create binary distribution for all platforms
+          command: make bin-dist
+
 workflows:
   version: 2
   build:
@@ -74,3 +92,8 @@ workflows:
               only: /^[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)*$/
             branches:
               ignore: /.*/
+      # TODO: remove when this is working.
+      - fixdist:
+          filters:
+            branches:
+              only: fix-make-prebuild

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ all: build
 
 # install and execute packr in a way that works both locally and in CI
 prebuild:
+	mkdir -p $(shell pwd)/go-build-cache
+	chown -R ${USERID}:${GROUPID} $(shell pwd)/go-build-cache
 	docker run --rm \
 		-v $(shell pwd):/go/src/github.com/$(ORGANISATION)/$(PROJECT) \
 		-v $(shell pwd)/go-build-cache:/.cache \


### PR DESCRIPTION
Previously the `make prebuild` target failed in CI with this error:

    failed to initialize build cache at /.cache/go-build: mkdir /.cache/go-build: permission denied

Here is the attempt to fix this.