### PR TITLE
Check for provider not supported when scaling

### DIFF
--- a/commands/scale/cluster/command.go
+++ b/commands/scale/cluster/command.go
@@ -171,7 +171,7 @@ func verifyPreconditions(args Arguments) error {
 		}
 
 		_, err = clientWrapper.GetClusterV5(args.ClusterID, auxParams)
-		if errors.IsClusterNotFoundError(err) {
+		if errors.IsClusterNotFoundError(err) || errors.IsProviderNotSupportedError(err) {
 			// The cluster is not a v5 cluster. So do nothing.
 		} else if err != nil {
 			return microerror.Mask(err)


### PR DESCRIPTION
We noticed while testing, that the API returns `not supported` for g8s versions greater than 10 - this breaks the behaviour here for providers other than AWS.

related slack thread: https://gigantic.slack.com/archives/CHAHY6VMF/p1579081042011500