### PR TITLE
Actually check for bad request instead of not supported

### DIFF
--- a/commands/scale/cluster/command.go
+++ b/commands/scale/cluster/command.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/giantswarm/gsctl/client"
+	"github.com/giantswarm/gsctl/client/clienterror"
 	"github.com/giantswarm/gsctl/commands/errors"
 	"github.com/giantswarm/gsctl/confirm"
 	"github.com/giantswarm/gsctl/flags"
@@ -171,7 +172,7 @@ func verifyPreconditions(args Arguments) error {
 		}
 
 		_, err = clientWrapper.GetClusterV5(args.ClusterID, auxParams)
-		if errors.IsClusterNotFoundError(err) || errors.IsBadRequestError(err) {
+		if errors.IsClusterNotFoundError(err) || clienterror.IsBadRequestError(err) {
 			// The cluster is not a v5 cluster. So do nothing.
 		} else if err != nil {
 			return microerror.Mask(err)

--- a/commands/scale/cluster/command.go
+++ b/commands/scale/cluster/command.go
@@ -171,7 +171,7 @@ func verifyPreconditions(args Arguments) error {
 		}
 
 		_, err = clientWrapper.GetClusterV5(args.ClusterID, auxParams)
-		if errors.IsClusterNotFoundError(err) || errors.IsProviderNotSupportedError(err) {
+		if errors.IsClusterNotFoundError(err) || errors.IsBadRequestError(err) {
 			// The cluster is not a v5 cluster. So do nothing.
 		} else if err != nil {
 			return microerror.Mask(err)


### PR DESCRIPTION
Apparently I was testing the wrong thing manually. It actually needs to match against a bad request error to work. 

Example here: https://github.com/giantswarm/gsctl/blob/11c2ebd40ad6c38a8fe0932ef4be2e206a58f879/commands/create/kubeconfig/command.go#L375