### PR TITLE
Add tab completion to select endpoint command

### DIFF
--- a/commands/root.go
+++ b/commands/root.go
@@ -76,7 +76,7 @@ func init() {
 		FnName:   "__gsctl_get_endpoints",
 		FnBody:   getEndpointsFunc,
 	})
-	util.RegisterBashCompletionFn(RootCommand, "__gsctl_custom_func", util.GetCustomCommandCompletionFn())
+	util.RegisterBashCompletionFn(RootCommand, "__gsctl_custom_func", util.GetCustomCommandCompletionFnBody())
 }
 
 // initConfig calls the config.Initialize() function

--- a/commands/root.go
+++ b/commands/root.go
@@ -25,13 +25,11 @@ import (
 )
 
 const (
-	bash_completion_func = `function __gsctl_get_endpoints {
+	bash_completion_func = `__gsctl_get_endpoints() {
 	local gsctl_out
 	if gsctl_out=$(gsctl list endpoints | awk 'FNR > 1 {print $1}'); then
 					COMPREPLY=( $( compgen -W "${gsctl_out}" -- "${cur}" ) )
 	fi
-
-	COMPREPLY=("hi")
 }`
 )
 
@@ -45,7 +43,7 @@ var RootCommand = &cobra.Command{
 
 func init() {
 	RootCommand.PersistentFlags().StringVarP(&flags.APIEndpoint, "endpoint", "e", "", "The API endpoint to use")
-	RootCommand.MarkFlagCustom("endpoint", "__gsctl_get_endpoints")
+	RootCommand.PersistentFlags().SetAnnotation("endpoint", cobra.BashCompCustom, []string{"__gsctl_get_endpoints"})
 
 	RootCommand.PersistentFlags().StringVarP(&flags.Token, "auth-token", "", "", "Authorization token to use")
 	RootCommand.PersistentFlags().StringVarP(&flags.ConfigDirPath, "config-dir", "", config.DefaultConfigDirPath, "Configuration directory path to use")

--- a/commands/root.go
+++ b/commands/root.go
@@ -24,15 +24,29 @@ import (
 	"github.com/giantswarm/gsctl/flags"
 )
 
+const (
+	bash_completion_func = `function __gsctl_get_endpoints {
+	local gsctl_out
+	if gsctl_out=$(gsctl list endpoints | awk 'FNR > 1 {print $1}'); then
+					COMPREPLY=( $( compgen -W "${gsctl_out}" -- "${cur}" ) )
+	fi
+
+	COMPREPLY=("hi")
+}`
+)
+
 // RootCommand is the main command of the CLI
 var RootCommand = &cobra.Command{
 	Use: config.ProgramName,
 	// this is inherited by all child commands
-	PersistentPreRunE: initConfig,
+	PersistentPreRunE:      initConfig,
+	BashCompletionFunction: bash_completion_func,
 }
 
 func init() {
 	RootCommand.PersistentFlags().StringVarP(&flags.APIEndpoint, "endpoint", "e", "", "The API endpoint to use")
+	RootCommand.MarkFlagCustom("endpoint", "__gsctl_get_endpoints")
+
 	RootCommand.PersistentFlags().StringVarP(&flags.Token, "auth-token", "", "", "Authorization token to use")
 	RootCommand.PersistentFlags().StringVarP(&flags.ConfigDirPath, "config-dir", "", config.DefaultConfigDirPath, "Configuration directory path to use")
 	RootCommand.PersistentFlags().BoolVarP(&flags.Verbose, "verbose", "v", false, "Print more information")

--- a/commands/select/endpoint/command.go
+++ b/commands/select/endpoint/command.go
@@ -10,7 +10,14 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/giantswarm/gsctl/commands/errors"
+	"github.com/giantswarm/gsctl/util"
 )
+
+const selectEndpointsCompletionFn = `
+if [[ ${last_command} -eq "gsctl_select_endpoint" ]]; then
+	__gsctl_get_endpoints;
+fi
+`
 
 var (
 	// Command performs the "select endpoint" function
@@ -30,6 +37,12 @@ command.
 		Run:    selectEndpointRunOutput,
 	}
 )
+
+func init() {
+	util.SetCommandBashCompletion(&util.BashCompletionFunc{
+		FnBody: selectEndpointsCompletionFn,
+	})
+}
 
 // selectEndpointPreRunOutput does some pre-checks and, if necessary,
 // shows output and exits.

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/skratchdot/open-golang v0.0.0-20190402232053-79abb63cd66e // indirect
 	github.com/spf13/afero v1.2.2
 	github.com/spf13/cobra v0.0.6-0.20190724161051-1c9c46d5c1cc
-	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/spf13/pflag v1.0.5
 	go.mongodb.org/mongo-driver v1.0.4 // indirect
 	golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413 // indirect
 	golang.org/x/sys v0.0.0-20191210023423-ac6580df4449 // indirect

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/skratchdot/open-golang v0.0.0-20190402232053-79abb63cd66e // indirect
 	github.com/spf13/afero v1.2.2
 	github.com/spf13/cobra v0.0.6-0.20190724161051-1c9c46d5c1cc
-	github.com/spf13/pflag v1.0.5
+	github.com/spf13/pflag v1.0.5 // indirect
 	go.mongodb.org/mongo-driver v1.0.4 // indirect
 	golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413 // indirect
 	golang.org/x/sys v0.0.0-20191210023423-ac6580df4449 // indirect

--- a/util/completion.go
+++ b/util/completion.go
@@ -23,25 +23,39 @@ type BashCompletionFunc struct {
 
 var customCompletionFn string
 
+// GenBashCompletionFn generates a bash function
+// that can be used for auto-completion of
+// command-line commands or flags
 func GetBashCompletionFn(fName, fBody string) string {
 	return fmt.Sprintf(template, fName, fBody)
 }
 
+// RegisterBashCompletionFn adds a custom completion
+// function to the root command config
 func RegisterBashCompletionFn(command *cobra.Command, fName, fBody string) {
 	if !strings.Contains(command.Root().BashCompletionFunction, fName) {
 		command.Root().BashCompletionFunction += GetBashCompletionFn(fName, fBody)
 	}
 }
 
+// SetFlagBashCompletionFn sets a custom completion
+// function for a given command-line flag
 func SetFlagBashCompletionFn(completionFn *BashCompletionFunc) {
 	completionFn.Flags.SetAnnotation(completionFn.FlagName, cobra.BashCompCustom, []string{completionFn.FnName})
 	RegisterBashCompletionFn(completionFn.Command, completionFn.FnName, completionFn.FnBody)
 }
 
+// SetCommandBashCompletion adds functionality
+// to the global custom command-line completion function
+//
+// Due to `cobra` limitations, this is currently the
+// only way of adding auto-completion for commands
 func SetCommandBashCompletion(completionFn *BashCompletionFunc) {
 	customCompletionFn += completionFn.FnBody + "\n"
 }
 
-func GetCustomCommandCompletionFn() string {
+// GetCustomCommandCompletionFnBody returns the
+// global custom command-line completion function body
+func GetCustomCommandCompletionFnBody() string {
 	return customCompletionFn
 }

--- a/util/completion.go
+++ b/util/completion.go
@@ -1,0 +1,37 @@
+package util
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+const template = `
+%s() {
+	%s
+}`
+
+type BashCompletionFunc struct {
+	Command  *cobra.Command
+	Flags    *pflag.FlagSet
+	FlagName string
+	FnName   string
+	FnBody   string
+}
+
+func GetBashCompletionFunction(fName, fBody string) string {
+	return fmt.Sprintf(template, fName, fBody)
+}
+
+func RegisterBashCompletionFunction(command *cobra.Command, fName, fBody string) {
+	if !strings.Contains(command.Root().BashCompletionFunction, fName) {
+		command.Root().BashCompletionFunction += GetBashCompletionFunction(fName, fBody)
+	}
+}
+
+func SetBashCompletionFunction(completionFunc BashCompletionFunc) {
+	completionFunc.Flags.SetAnnotation(completionFunc.FlagName, cobra.BashCompCustom, []string{completionFunc.FnName})
+	RegisterBashCompletionFunction(completionFunc.Command, completionFunc.FnName, completionFunc.FnBody)
+}

--- a/util/completion.go
+++ b/util/completion.go
@@ -21,17 +21,27 @@ type BashCompletionFunc struct {
 	FnBody   string
 }
 
-func GetBashCompletionFunction(fName, fBody string) string {
+var customCompletionFn string
+
+func GetBashCompletionFn(fName, fBody string) string {
 	return fmt.Sprintf(template, fName, fBody)
 }
 
-func RegisterBashCompletionFunction(command *cobra.Command, fName, fBody string) {
+func RegisterBashCompletionFn(command *cobra.Command, fName, fBody string) {
 	if !strings.Contains(command.Root().BashCompletionFunction, fName) {
-		command.Root().BashCompletionFunction += GetBashCompletionFunction(fName, fBody)
+		command.Root().BashCompletionFunction += GetBashCompletionFn(fName, fBody)
 	}
 }
 
-func SetBashCompletionFunction(completionFunc BashCompletionFunc) {
-	completionFunc.Flags.SetAnnotation(completionFunc.FlagName, cobra.BashCompCustom, []string{completionFunc.FnName})
-	RegisterBashCompletionFunction(completionFunc.Command, completionFunc.FnName, completionFunc.FnBody)
+func SetFlagBashCompletionFn(completionFn *BashCompletionFunc) {
+	completionFn.Flags.SetAnnotation(completionFn.FlagName, cobra.BashCompCustom, []string{completionFn.FnName})
+	RegisterBashCompletionFn(completionFn.Command, completionFn.FnName, completionFn.FnBody)
+}
+
+func SetCommandBashCompletion(completionFn *BashCompletionFunc) {
+	customCompletionFn += completionFn.FnBody + "\n"
+}
+
+func GetCustomCommandCompletionFn() string {
+	return customCompletionFn
 }

--- a/util/completion_test.go
+++ b/util/completion_test.go
@@ -16,9 +16,9 @@ var getCompletionFnTests = []struct {
 	output string
 }{
 	{
-		"test",
-		"ls",
-		`
+		fName: "test",
+		fBody: "ls",
+		output: `
 test() {
 	ls
 }`,
@@ -41,17 +41,17 @@ var setFlagCompletionFnTests = []struct {
 	output string
 }{
 	{
-		"test",
-		"ls",
-		`
+		fName: "test",
+		fBody: "ls",
+		output: `
 test() {
 	ls
 }`,
 	},
 	{
-		"test2",
-		"ls",
-		`
+		fName: "test2",
+		fBody: "ls",
+		output: `
 test() {
 	ls
 }
@@ -60,9 +60,9 @@ test2() {
 }`,
 	},
 	{
-		"test",
-		"ls",
-		`
+		fName: "test",
+		fBody: "ls",
+		output: `
 test() {
 	ls
 }
@@ -96,13 +96,13 @@ var customCommandCompletionTests = []struct {
 	output string
 }{
 	{
-		"ls",
-		`ls
+		fBody: "ls",
+		output: `ls
 `,
 	},
 	{
-		"pwd",
-		`ls
+		fBody: "pwd",
+		output: `ls
 pwd
 `,
 	},

--- a/util/completion_test.go
+++ b/util/completion_test.go
@@ -1,0 +1,122 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+var testCommand = &cobra.Command{
+	Use: "test-command",
+}
+
+var getCompletionFnTests = []struct {
+	fName  string
+	fBody  string
+	output string
+}{
+	{
+		"test",
+		"ls",
+		`
+test() {
+	ls
+}`,
+	},
+}
+
+func TestGetBashCompletionFn(t *testing.T) {
+	for i, test := range getCompletionFnTests {
+		out := GetBashCompletionFn(test.fName, test.fBody)
+
+		if out != test.output {
+			t.Errorf("#%d: TestGetBashCompletionFn(%s, %s) = '%s'; want '%s'", i, test.fName, test.fBody, out, test.output)
+		}
+	}
+}
+
+var setFlagCompletionFnTests = []struct {
+	fName  string
+	fBody  string
+	output string
+}{
+	{
+		"test",
+		"ls",
+		`
+test() {
+	ls
+}`,
+	},
+	{
+		"test2",
+		"ls",
+		`
+test() {
+	ls
+}
+test2() {
+	ls
+}`,
+	},
+	{
+		"test",
+		"ls",
+		`
+test() {
+	ls
+}
+test2() {
+	ls
+}`,
+	},
+}
+
+func TestSetFlagBashCompletionFn(t *testing.T) {
+	for i, test := range setFlagCompletionFnTests {
+		SetFlagBashCompletionFn(&BashCompletionFunc{
+			Command:  testCommand,
+			Flags:    testCommand.PersistentFlags(),
+			FlagName: "test-flag",
+			FnName:   test.fName,
+			FnBody:   test.fBody,
+		})
+		out := testCommand.Root().BashCompletionFunction
+
+		if out != test.output {
+			t.Errorf("#%d: SetFlagBashCompletionFn(%s, %s) = '%s'; want '%s'", i, test.fName, test.fBody, out, test.output)
+		}
+	}
+
+	testCommand.Root().BashCompletionFunction = ""
+}
+
+var customCommandCompletionTests = []struct {
+	fBody  string
+	output string
+}{
+	{
+		"ls",
+		`ls
+`,
+	},
+	{
+		"pwd",
+		`ls
+pwd
+`,
+	},
+}
+
+func TestCustomCommandCompletion(t *testing.T) {
+	for i, test := range customCommandCompletionTests {
+		SetCommandBashCompletion(&BashCompletionFunc{
+			FnBody: test.fBody,
+		})
+		out := GetCustomCommandCompletionFnBody()
+
+		if out != test.output {
+			t.Errorf("#%d: TestCustomCommandCompletion(%s) = '%s'; want '%s'", i, test.fBody, out, test.output)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #159 

This introduces bash auto-completion for the `select endpoint` command, and the `--endpoint` flag. Pressing `TAB` will un-fold the list of existing endpoints.

Unfortunately, this doesn't work in `zsh` due to `cobra` limitations.

**Preview**

![image](https://user-images.githubusercontent.com/13508038/74347202-05330000-4db1-11ea-85e4-568f9f94fc3a.png)

![image](https://user-images.githubusercontent.com/13508038/74347231-12e88580-4db1-11ea-8239-ae09300fb0a8.png)
