### PR TITLE
Improve readability of release docs

### DIFF
--- a/docs/Release.md
+++ b/docs/Release.md
@@ -2,20 +2,7 @@
 
 TL;DR: Releases are published automatically whenever a new tag of the format X.Y.Z is pushed to the GitHub repository.
 
-## Prerequisites
-
-CircleCI must be set up with certain environment variables:
-
-- `CODE_SIGNING_CERT_BUNDLE_BASE64` - Base64 encoded PKCS#12 key/cert bundle used for signing Windows binaries
-- `CODE_SIGNING_CERT_BUNDLE_PASSWORD` - Password for the above bundle
-- `RELEASE_TOKEN` - A GitHub token with the permission to write to repositories
-  - [giantswarm/gsctl](https://github.com/giantswarm/gsctl/)
-  - [giantswarm/scoop-bucket](https://github.com/giantswarm/scoop-bucket)
-  - [giantswarm/homebrew-giantswarm](https://github.com/giantswarm/homebrew-giantswarm)
-- `GITHUB_USER_EMAIL` - Email address of the github user owning the personal token above
-- `GITHUB_USER_NAME` - Username of the above github user
-
-## Create and push a new release
+## Create a tag and release draft
 
 All you have to do is create and push a new tag.
 
@@ -31,8 +18,21 @@ git push origin ${VERSION}
 
 Follow CircleCI's progress in https://circleci.com/gh/giantswarm/gsctl/.
 
-## Edit and publish the release
+## Edit the release draft and publish
 
 Open the [release draft](https://github.com/giantswarm/gsctl/releases/) on Github.
 
 Edit the description to inform about what has changed since the last release. Save and publish the release.
+
+## Prerequisites
+
+CircleCI must be set up with certain environment variables:
+
+- `CODE_SIGNING_CERT_BUNDLE_BASE64` - Base64 encoded PKCS#12 key/cert bundle used for signing Windows binaries
+- `CODE_SIGNING_CERT_BUNDLE_PASSWORD` - Password for the above bundle
+- `RELEASE_TOKEN` - A GitHub token with the permission to write to repositories
+  - [giantswarm/gsctl](https://github.com/giantswarm/gsctl/)
+  - [giantswarm/scoop-bucket](https://github.com/giantswarm/scoop-bucket)
+  - [giantswarm/homebrew-giantswarm](https://github.com/giantswarm/homebrew-giantswarm)
+- `GITHUB_USER_EMAIL` - Email address of the github user owning the personal token above
+- `GITHUB_USER_NAME` - Username of the above github user


### PR DESCRIPTION
- Moves prerequisites to the bottom, as they are normally met in CI.
- Improves the sub-headlines.