### PR TITLE
improve output format

### DIFF
--- a/commands/create/nodepool/command.go
+++ b/commands/create/nodepool/command.go
@@ -371,4 +371,5 @@ func printResult(cmd *cobra.Command, positionalArgs []string) {
 	fmt.Println(color.GreenString("New node pool '%s' (ID '%s') in cluster '%s' is launching.", r.nodePoolName, r.nodePoolID, arguments.ClusterID))
 	fmt.Printf("Use this command to inspect details for the new node pool:\n\n")
 	fmt.Println(color.YellowString("    gsctl show nodepool %s/%s", arguments.ClusterID, r.nodePoolID))
+	fmt.Printf("\n")
 }


### PR DESCRIPTION
I found it unfortunate that the indented block has no padding to the new command line line in the terminal. It looks like this right now. 

```
$ gsctl create nodepool z2w63
New node pool 'Unnamed node pool' (ID '7y236') in cluster 'z2w63' is launching.
Use this command to inspect details for the new node pool:

    gsctl show nodepool z2w63/7y236
$ new command foo bar
```

With this PR there is padding of one additional empty line at the end of the command output, which makes me very happy. 

```
$ gsctl create nodepool z2w63
New node pool 'Unnamed node pool' (ID '7y236') in cluster 'z2w63' is launching.
Use this command to inspect details for the new node pool:

    gsctl show nodepool z2w63/7y236

$ new command foo bar
```