### PR TITLE
Add support for using cluster name for the delete cluster command

### DIFF
--- a/clustercache/clustercache.go
+++ b/clustercache/clustercache.go
@@ -22,31 +22,31 @@ const (
 	listClustersActivityName = "list-clusters"
 	clusterCacheFileName     = "clustercache.yaml"
 
-	cacheDuration = time.Hour * 24 * 7 // 7 days
+	cacheDuration = time.Hour * 24 * 7 // 7 days.
 	timeLayout    = time.RFC3339
 )
 
 // EndpointCache stores the IDs stored in an
-// endpoint-specific cache, and also its expiry date
+// endpoint-specific cache, and also its expiry date.
 type EndpointCache struct {
 	Expiry string   `yaml:"expiry"`
 	IDs    []string `yaml:"ids"`
 }
 
 // Endpoints stores a map with the keys being API endpoints,
-// and the values being caches
+// and the values being caches.
 type Endpoints map[string]EndpointCache
 
-// Cache is the file structure of the cluster cache file
+// Cache is the file structure of the cluster cache file.
 type Cache struct {
 	Endpoints Endpoints `yaml:"endpoints"`
 }
 
 // GetID gets the cluster ID for a provided name/ID
-// by checking in both the user cache and on the API
+// by checking in both the user cache and on the API.
 func GetID(endpoint string, clusterNameOrID string, clientWrapper *client.Wrapper) (string, error) {
 	// Check if the cluster ID is already in the cache,
-	// and skip the API request if it is
+	// and skip the API request if it is.
 	isInCache := IsInCache(endpoint, clusterNameOrID)
 	if isInCache {
 		return clusterNameOrID, nil
@@ -55,7 +55,7 @@ func GetID(endpoint string, clusterNameOrID string, clientWrapper *client.Wrappe
 	auxParams := clientWrapper.DefaultAuxiliaryParams()
 	auxParams.ActivityName = listClustersActivityName
 
-	// Get a list of all clusters
+	// Get a list of all clusters.
 	response, err := clientWrapper.GetClusters(auxParams)
 	if err != nil {
 		switch {
@@ -71,14 +71,14 @@ func GetID(endpoint string, clusterNameOrID string, clientWrapper *client.Wrappe
 	}
 
 	var (
-		// IDs that correspond to the same cluster name
+		// IDs that correspond to the same cluster name.
 		matchingIDs []string
-		// All IDs returned from the response
+		// All IDs returned from the response.
 		allClusterIDs = make([]string, 0, len(response.Payload))
 	)
 	for _, cluster := range response.Payload {
 		allClusterIDs = append(allClusterIDs, cluster.ID)
-		// Check if this is the cluster we're looking for
+		// Check if this is the cluster we're looking for.
 		if matchesValidation(clusterNameOrID, cluster) {
 			matchingIDs = append(matchingIDs, cluster.ID)
 		}
@@ -90,8 +90,8 @@ func GetID(endpoint string, clusterNameOrID string, clientWrapper *client.Wrappe
 		// There are no IDs that correspond to that cluster name
 		return "", microerror.Mask(errors.ClusterNotFoundError)
 	} else if len(matchingIDs) > 1 {
-		// There are multiple IDs that correspond to that cluster name
-		// Help the user decide which cluster to pick
+		// There are multiple IDs that correspond to that cluster name.
+		// Help the user decide which one to pick.
 		_, id := handleNameCollision(clusterNameOrID, response.Payload)
 
 		return id, nil
@@ -100,7 +100,7 @@ func GetID(endpoint string, clusterNameOrID string, clientWrapper *client.Wrappe
 	return matchingIDs[0], nil
 }
 
-// New creates a new Cache object
+// New creates a new Cache object.
 func New() *Cache {
 	c := &Cache{}
 	c.Endpoints = Endpoints{}
@@ -109,7 +109,7 @@ func New() *Cache {
 }
 
 // IsInCache checks if a cluster ID is present in the
-// persistent cluster cache
+// persistent cluster cache.
 func IsInCache(endpoint string, ID string) bool {
 	var (
 		err                error
@@ -117,7 +117,7 @@ func IsInCache(endpoint string, ID string) bool {
 
 		now = time.Now()
 	)
-	// Read the existing cache file
+	// Read the existing cache file.
 	existing, err := read(config.FileSystem)
 	if err != nil {
 		return false
@@ -125,12 +125,12 @@ func IsInCache(endpoint string, ID string) bool {
 
 	c := existing.Endpoints[endpoint]
 	for _, cID := range c.IDs {
-		// Check if the cache is expired
+		// Check if the cache is expired.
 		endpointExpiration, err = time.Parse(timeLayout, c.Expiry)
 		if err != nil || now.After(endpointExpiration) {
 			return false
 		}
-		// This is the one we're looking for
+		// This is the one we're looking for.
 		if cID == ID {
 			return true
 		}
@@ -141,9 +141,9 @@ func IsInCache(endpoint string, ID string) bool {
 
 // CacheIDs adds cluster IDs to a persistent cache,
 // which can be used for decreasing timeout in getting
-// cluster IDs, for commands that take both cluster names and IDs
+// cluster IDs, for commands that take both cluster names and IDs.
 func CacheIDs(endpoint string, c []string) {
-	// Let's not store an empty list
+	// Let's not store an empty list.
 	if len(c) == 0 {
 		return
 	}
@@ -152,20 +152,20 @@ func CacheIDs(endpoint string, c []string) {
 
 	var cache *Cache
 	{
-		// Create a new Cache object if there is no file there yet
+		// Create a new Cache object if there is no file there yet.
 		cache, _ = read(fs)
 		if cache == nil {
 			cache = New()
 		}
 	}
 
-	// Add the cache to a certain endpoint
+	// Add the cache to a certain endpoint.
 	cache.Endpoints[endpoint] = EndpointCache{
 		Expiry: time.Now().Add(cacheDuration).Format(timeLayout),
 		IDs:    c,
 	}
 
-	// Write the cache file
+	// Write the cache file.
 	_ = write(fs, cache)
 }
 

--- a/clustercache/clustercache.go
+++ b/clustercache/clustercache.go
@@ -106,7 +106,10 @@ func IsInCache(endpoint string, ID string) bool {
 
 		now = time.Now()
 	)
-	existing, _ := read(config.FileSystem)
+	existing, err := read(config.FileSystem)
+	if err != nil {
+		return false
+	}
 
 	c := existing.Endpoints[endpoint]
 	for _, cID := range c.IDs {
@@ -126,6 +129,10 @@ func IsInCache(endpoint string, ID string) bool {
 // which can be used for decreasing timeout in getting
 // cluster IDs, for commands that take both cluster names and IDs
 func CacheIDs(endpoint string, c []string) {
+	if len(c) == 0 {
+		return
+	}
+
 	fs := config.FileSystem
 
 	var cache *Cache = New()
@@ -136,12 +143,9 @@ func CacheIDs(endpoint string, c []string) {
 		}
 	}
 
-	allIDs := make([]string, 0, len(c))
-	allIDs = append(allIDs, c...)
-
 	cache.Endpoints[endpoint] = EndpointCache{
 		Expiry: time.Now().Add(cacheDuration).Format(timeLayout),
-		IDs:    allIDs,
+		IDs:    c,
 	}
 
 	_ = write(fs, cache)

--- a/clustercache/clustercache.go
+++ b/clustercache/clustercache.go
@@ -13,6 +13,7 @@ import (
 	"github.com/giantswarm/gsctl/client/clienterror"
 	"github.com/giantswarm/gsctl/commands/errors"
 	"github.com/giantswarm/gsctl/confirm"
+	"github.com/giantswarm/gsctl/util"
 	"github.com/giantswarm/microerror"
 	"github.com/spf13/afero"
 	yaml "gopkg.in/yaml.v2"
@@ -178,15 +179,23 @@ func matchesValidation(nameOrID string, cluster *models.V4ClusterListItem) bool 
 
 func handleNameCollision(nameOrID string, clusters []*models.V4ClusterListItem) string {
 	var (
-		clusterIDs []string
+		clusterIDs     []string
+		createdDate    string
+		releaseVersion string
 
-		table = []string{color.CyanString("ID | ORGANIZATION | NAME")}
+		table = []string{color.CyanString("ID | ORGANIZATION | RELEASE | CREATED")}
 	)
 
 	for _, cluster := range clusters {
 		if matchesValidation(nameOrID, cluster) {
 			clusterIDs = append(clusterIDs, cluster.ID)
-			table = append(table, fmt.Sprintf("%5s | %5s | %5s\n", cluster.ID, cluster.Owner, cluster.Name))
+			createdDate = util.ShortDate(util.ParseDate(cluster.CreateDate))
+			releaseVersion = cluster.ReleaseVersion
+			if releaseVersion == "" {
+				releaseVersion = "n/a"
+			}
+			
+			table = append(table, fmt.Sprintf("%5s | %5s | %5s | %5s\n", cluster.ID, cluster.Owner, releaseVersion, createdDate))
 		}
 	}
 

--- a/clustercache/clustercache.go
+++ b/clustercache/clustercache.go
@@ -166,7 +166,7 @@ func CacheIDs(endpoint string, c []string) {
 	}
 
 	// Write the cache file.
-	err = write(fs, cache)
+	err := write(fs, cache)
 	if err != nil {
 		return
 	}

--- a/clustercache/clustercache.go
+++ b/clustercache/clustercache.go
@@ -194,18 +194,15 @@ func handleNameCollision(nameOrID string, clusters []*models.V4ClusterListItem) 
 			if releaseVersion == "" {
 				releaseVersion = "n/a"
 			}
-			
+
 			table = append(table, fmt.Sprintf("%5s | %5s | %5s | %5s\n", cluster.ID, cluster.Owner, releaseVersion, createdDate))
 		}
 	}
 
-	printNameCollisionTable(table)
+	printNameCollisionTable(nameOrID, table)
 
 	confirmed, id := confirm.AskStrictOneOf(
-		fmt.Sprintf(
-			"Found more than one cluster called '%s', please type the ID of the cluster that you would like to delete",
-			nameOrID,
-		),
+		"Please type the ID of the cluster that you would like to delete",
 		clusterIDs,
 	)
 	if !confirmed {
@@ -214,9 +211,9 @@ func handleNameCollision(nameOrID string, clusters []*models.V4ClusterListItem) 
 	return id
 }
 
-func printNameCollisionTable(table []string) {
+func printNameCollisionTable(name string, table []string) {
 	// Print output
-	fmt.Println("Multiple clusters found")
+	fmt.Println(fmt.Sprintf("Multiple clusters found with the name '%s'.", name))
 	fmt.Printf("\n")
 	fmt.Println(columnize.SimpleFormat(table))
 	fmt.Printf("\n")

--- a/clustercache/clustercache.go
+++ b/clustercache/clustercache.go
@@ -92,7 +92,7 @@ func GetID(endpoint string, clusterNameOrID string, clientWrapper *client.Wrappe
 	} else if len(matchingIDs) > 1 {
 		// There are multiple IDs that correspond to that cluster name.
 		// Help the user decide which one to pick.
-		_, id := handleNameCollision(clusterNameOrID, response.Payload)
+		id := handleNameCollision(clusterNameOrID, response.Payload)
 
 		return id, nil
 	}
@@ -173,7 +173,7 @@ func matchesValidation(nameOrID string, cluster *models.V4ClusterListItem) bool 
 	return cluster.DeleteDate == nil && (cluster.ID == nameOrID || cluster.Name == nameOrID)
 }
 
-func handleNameCollision(nameOrID string, clusters []*models.V4ClusterListItem) (bool, string) {
+func handleNameCollision(nameOrID string, clusters []*models.V4ClusterListItem) string {
 	var (
 		clusterIDs []string
 
@@ -197,9 +197,9 @@ func handleNameCollision(nameOrID string, clusters []*models.V4ClusterListItem) 
 		clusterIDs,
 	)
 	if !confirmed {
-		return false, ""
+		return ""
 	}
-	return true, id
+	return id
 }
 
 func printNameCollisionTable(table []string) {

--- a/clustercache/clustercache.go
+++ b/clustercache/clustercache.go
@@ -166,7 +166,10 @@ func CacheIDs(endpoint string, c []string) {
 	}
 
 	// Write the cache file.
-	_ = write(fs, cache)
+	err = write(fs, cache)
+	if err != nil {
+		return
+	}
 }
 
 func matchesValidation(nameOrID string, cluster *models.V4ClusterListItem) bool {

--- a/clustercache/clustercache.go
+++ b/clustercache/clustercache.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	listClustersActivityName = "list-clusters"
-	clusterCacheFileName     = "clustercache"
+	clusterCacheFileName     = "clustercache.yaml"
 
 	// cacheDuration = time.Hour * 24 * 7 // 7 days
 	cacheDuration = time.Second * 30

--- a/clustercache/clustercache_test.go
+++ b/clustercache/clustercache_test.go
@@ -189,20 +189,22 @@ func Test_matchesValidation(t *testing.T) {
 
 func Test_printNameCollisionTable(t *testing.T) {
 	testCases := []struct {
+		nameOrID       string
 		tableLines     []string
 		expectedResult string
 	}{
 		{
+			nameOrID: "Cluster name",
 			tableLines: []string{
-				"ID | ORGANIZATION | NAME",
-				"1asd1 | giantswarm | Cluster name",
-				"asd1sd | giantswarm | Other cluster name",
+				"ID | ORGANIZATION | RELEASE | CREATED",
+				"1asd1 | giantswarm | 11.0.1 | 2020 Mar 04, 09:11 UTC",
+				"asd1sd | giantswarm | 11.0.1 | 2020 Mar 04, 09:11 UTC",
 			},
-			expectedResult: `Multiple clusters found
+			expectedResult: `Multiple clusters found with the name 'Cluster name'.
 
-ID      ORGANIZATION  NAME
-1asd1   giantswarm    Cluster name
-asd1sd  giantswarm    Other cluster name
+ID      ORGANIZATION  RELEASE  CREATED
+1asd1   giantswarm    11.0.1   2020 Mar 04, 09:11 UTC
+asd1sd  giantswarm    11.0.1   2020 Mar 04, 09:11 UTC
 
 `,
 		},
@@ -211,7 +213,7 @@ asd1sd  giantswarm    Other cluster name
 	for i, tc := range testCases {
 		output := testutils.CaptureOutput(func() {
 			// output
-			printNameCollisionTable(tc.tableLines)
+			printNameCollisionTable(tc.nameOrID, tc.tableLines)
 		})
 
 		if diff := cmp.Diff(tc.expectedResult, output); diff != "" {

--- a/clustercache/clustercache_test.go
+++ b/clustercache/clustercache_test.go
@@ -1,4 +1,4 @@
-package util
+package clustercache
 
 import (
 	"net/http"
@@ -16,7 +16,7 @@ import (
 	"github.com/spf13/afero"
 )
 
-func TestGetClusterID(t *testing.T) {
+func Test_GetClusterID(t *testing.T) {
 	testCases := []struct {
 		clusterNameOrID string
 		expectedID      string
@@ -111,7 +111,7 @@ func TestGetClusterID(t *testing.T) {
 			}
 
 			// output
-			id, err := GetClusterID(tc.clusterNameOrID, clientWrapper)
+			id, err := GetID(tc.clusterNameOrID, clientWrapper)
 
 			switch {
 
@@ -129,7 +129,7 @@ func TestGetClusterID(t *testing.T) {
 	}
 }
 
-func TestmatchesValidation(t *testing.T) {
+func Test_matchesValidation(t *testing.T) {
 	dd := strfmt.NewDateTime()
 	deleteDate := &dd
 
@@ -185,7 +185,7 @@ func TestmatchesValidation(t *testing.T) {
 	}
 }
 
-func TestprintNameCollisionTable(t *testing.T) {
+func Test_printNameCollisionTable(t *testing.T) {
 	testCases := []struct {
 		tableLines     []string
 		expectedResult string
@@ -218,7 +218,7 @@ asd1sd  giantswarm    Other cluster name
 	}
 }
 
-func TestIsInClusterCache(t *testing.T) {
+func Test_IsInClusterCache(t *testing.T) {
 	testCases := []struct {
 		clusterNameOrID string
 		cacheContents   string
@@ -245,7 +245,7 @@ func TestIsInClusterCache(t *testing.T) {
 			}
 
 			// output
-			isInCache := IsInClusterCache(tc.clusterNameOrID)
+			isInCache := IsInCache(tc.clusterNameOrID)
 
 			if isInCache != tc.expectedResult {
 				t.Errorf("Case %d - Result did not match ", i)
@@ -254,7 +254,7 @@ func TestIsInClusterCache(t *testing.T) {
 	}
 }
 
-func TestCacheClusterIDs(t *testing.T) {
+func Test_CacheClusterIDs(t *testing.T) {
 	testCases := []struct {
 		clusterIDs    []string
 		cacheContents string
@@ -295,7 +295,7 @@ func TestCacheClusterIDs(t *testing.T) {
 			defer fs.Remove(clusterCacheFilePath)
 
 			// output
-			CacheClusterIDs(tc.clusterIDs...)
+			CacheIDs(tc.clusterIDs...)
 			cacheContent, _ := afero.ReadFile(fs, clusterCacheFilePath)
 
 			if string(cacheContent) != tc.cacheContents {

--- a/clustercache/clustercache_test.go
+++ b/clustercache/clustercache_test.go
@@ -111,7 +111,7 @@ func Test_GetClusterID(t *testing.T) {
 			}
 
 			// output
-			id, err := GetID(tc.clusterNameOrID, clientWrapper)
+			id, err := GetID("mockEndpoint", tc.clusterNameOrID, clientWrapper)
 
 			switch {
 

--- a/commands/create/keypair/command.go
+++ b/commands/create/keypair/command.go
@@ -171,7 +171,7 @@ func verifyPreconditions(args Arguments) error {
 		return microerror.Mask(errors.NotLoggedInError)
 	}
 	if args.clusterID == "" {
-		return microerror.Mask(errors.ClusterIDMissingError)
+		return microerror.Mask(errors.ClusterNameOrIDMissingError)
 	}
 
 	// validate CN prefix character set

--- a/commands/create/kubeconfig/command.go
+++ b/commands/create/kubeconfig/command.go
@@ -253,7 +253,7 @@ func verifyCreateKubeconfigPreconditions(args Arguments, cmdLineArgs []string) e
 		return microerror.Mask(errors.NotLoggedInError)
 	}
 	if args.clusterID == "" {
-		return microerror.Mask(errors.ClusterIDMissingError)
+		return microerror.Mask(errors.ClusterNameOrIDMissingError)
 	}
 
 	// validate CN prefix character set

--- a/commands/create/nodepool/command.go
+++ b/commands/create/nodepool/command.go
@@ -211,7 +211,7 @@ func verifyPreconditions(args Arguments) error {
 	}
 
 	if args.ClusterID == "" {
-		return microerror.Mask(errors.ClusterIDMissingError)
+		return microerror.Mask(errors.ClusterNameOrIDMissingError)
 	}
 
 	// AZ flags plausibility

--- a/commands/create/nodepool/command_test.go
+++ b/commands/create/nodepool/command_test.go
@@ -306,7 +306,7 @@ func TestVerifyPreconditions(t *testing.T) {
 				APIEndpoint: "https://mock-url",
 				ClusterID:   "",
 			},
-			errors.IsClusterIDMissingError,
+			errors.IsClusterNameOrIDMissingError,
 		},
 		// Availability zones flags are conflicting.
 		{

--- a/commands/delete/cluster/command.go
+++ b/commands/delete/cluster/command.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/giantswarm/gscliauth/config"
-	"github.com/giantswarm/gsctl/util"
+	"github.com/giantswarm/gsctl/clustercache"
 	"github.com/giantswarm/microerror"
 	"github.com/spf13/cobra"
 
@@ -199,7 +199,7 @@ func deleteCluster(args Arguments) (bool, error) {
 	// Accept legacy cluster ID for a while, but real one takes precedence.
 	clusterID := args.legacyClusterID
 	if args.clusterNameOrID != "" {
-		clusterID, err = util.GetClusterID(args.clusterNameOrID, clientWrapper)
+		clusterID, err = clustercache.GetID(args.clusterNameOrID, clientWrapper)
 		if err != nil {
 			return false, microerror.Mask(err)
 		}

--- a/commands/delete/cluster/command.go
+++ b/commands/delete/cluster/command.go
@@ -111,7 +111,7 @@ func printValidation(cmd *cobra.Command, args []string) {
 			subtext = "Please specify the cluster to be used as a positional argument, avoid -c/--cluster."
 			subtext += "See --help for details."
 		case errors.IsClusterNameOrIDMissingError(err):
-			headline = "No cluster ID or Name specified"
+			headline = "No cluster ID or name specified"
 			subtext = "See --help for usage details."
 		case errors.IsCouldNotDeleteClusterError(err):
 			headline = "The cluster could not be deleted."
@@ -234,7 +234,10 @@ func deleteCluster(args Arguments) (bool, error) {
 
 	// confirmation
 	if !args.force {
-		confirmed := confirm.AskStrict("Do you really want to delete cluster '"+clusterID+"'? Please type the cluster ID to confirm", clusterID)
+		confirmed := confirm.AskStrict(
+			fmt.Sprintf("Do you really want to delete cluster '%s'? Please type '%s' to confirm", args.clusterNameOrID, args.clusterNameOrID),
+			args.clusterNameOrID,
+		)
 		if !confirmed {
 			return false, nil
 		}
@@ -244,7 +247,7 @@ func deleteCluster(args Arguments) (bool, error) {
 	auxParams.ActivityName = deleteClusterActivityName
 
 	// perform API call
-	// _, err = clientWrapper.DeleteCluster(clusterID, auxParams)
+	_, err = clientWrapper.DeleteCluster(clusterID, auxParams)
 	if err != nil {
 		// create specific error types for cases we care about
 		if clienterror.IsAccessForbiddenError(err) {

--- a/commands/delete/cluster/command.go
+++ b/commands/delete/cluster/command.go
@@ -199,7 +199,7 @@ func deleteCluster(args Arguments) (bool, error) {
 	// Accept legacy cluster ID for a while, but real one takes precedence.
 	clusterID := args.legacyClusterID
 	if args.clusterNameOrID != "" {
-		clusterID, err = clustercache.GetID(args.clusterNameOrID, clientWrapper)
+		clusterID, err = clustercache.GetID(args.apiEndpoint, args.clusterNameOrID, clientWrapper)
 		if err != nil {
 			return false, microerror.Mask(err)
 		}

--- a/commands/delete/cluster/command.go
+++ b/commands/delete/cluster/command.go
@@ -223,7 +223,7 @@ func deleteCluster(args Arguments) (bool, error) {
 	auxParams.ActivityName = deleteClusterActivityName
 
 	// perform API call
-	_, err = clientWrapper.DeleteCluster(clusterID, auxParams)
+	// _, err = clientWrapper.DeleteCluster(clusterID, auxParams)
 	if err != nil {
 		// create specific error types for cases we care about
 		if clienterror.IsAccessForbiddenError(err) {

--- a/commands/delete/cluster/command.go
+++ b/commands/delete/cluster/command.go
@@ -223,7 +223,7 @@ func deleteCluster(args Arguments) (bool, error) {
 	auxParams.ActivityName = deleteClusterActivityName
 
 	// perform API call
-	// _, err = clientWrapper.DeleteCluster(clusterID, auxParams)
+	_, err = clientWrapper.DeleteCluster(clusterID, auxParams)
 	if err != nil {
 		// create specific error types for cases we care about
 		if clienterror.IsAccessForbiddenError(err) {

--- a/commands/delete/cluster/command_test.go
+++ b/commands/delete/cluster/command_test.go
@@ -28,7 +28,7 @@ func TestDeleteClusterSuccess(t *testing.T) {
 			},
 			{
 				"create_date": "2017-05-16T09:30:31.192170835Z",
-				"id": "somecluster",
+				"id": "someothercluster",
 				"name": "My dearest production cluster",
 				"owner": "acme",
 				"path": "/v4/clusters/somecluster/"

--- a/commands/delete/cluster/command_test.go
+++ b/commands/delete/cluster/command_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/giantswarm/gsctl/commands/errors"
 	"github.com/giantswarm/gsctl/testutils"
+	"github.com/spf13/afero"
 )
 
 // TestDeleteClusterSuccess runs test case that are supposed to succeed
@@ -50,6 +51,12 @@ func TestDeleteClusterSuccess(t *testing.T) {
 		},
 	}
 
+	fs := afero.NewMemMapFs()
+	_, err := testutils.TempConfig(fs, "")
+	if err != nil {
+		t.Error(err)
+	}
+
 	for i, testCase := range testCases {
 
 		args := testCase
@@ -88,6 +95,12 @@ func TestDeleteClusterFailures(t *testing.T) {
 			},
 			expectedError: errors.ClusterNameOrIDMissingError,
 		},
+	}
+
+	fs := afero.NewMemMapFs()
+	_, err := testutils.TempConfig(fs, "")
+	if err != nil {
+		t.Error(err)
 	}
 
 	for i, ftc := range failTestCases {

--- a/commands/delete/nodepool/command.go
+++ b/commands/delete/nodepool/command.go
@@ -118,7 +118,7 @@ func verifyPreconditions(args *Arguments) error {
 		return microerror.Mask(errors.NotLoggedInError)
 	}
 	if args.ClusterID == "" {
-		return microerror.Mask(errors.ClusterIDMissingError)
+		return microerror.Mask(errors.ClusterNameOrIDMissingError)
 	}
 	if args.NodePoolID == "" {
 		return microerror.Mask(errors.NodePoolIDMissingError)

--- a/commands/delete/nodepool/command_test.go
+++ b/commands/delete/nodepool/command_test.go
@@ -115,7 +115,7 @@ func Test_verifyPreconditions(t *testing.T) {
 				APIEndpoint: "https://mock-url",
 				NodePoolID:  "abc",
 			},
-			errors.IsClusterIDMissingError,
+			errors.IsClusterNameOrIDMissingError,
 		},
 		// Node pool ID is missing.
 		{

--- a/commands/errors/errors.go
+++ b/commands/errors/errors.go
@@ -80,14 +80,14 @@ func IsDesiredEqualsCurrentStateError(err error) bool {
 	return microerror.Cause(err) == DesiredEqualsCurrentStateError
 }
 
-// ClusterIDMissingError means a required cluster ID has not been given as input
-var ClusterIDMissingError = &microerror.Error{
-	Kind: "ClusterIDMissingError",
+// ClusterNameOrIDMissingError means a required cluster ID has not been given as input
+var ClusterNameOrIDMissingError = &microerror.Error{
+	Kind: "ClusterNameOrIDMissingError",
 }
 
-// IsClusterIDMissingError asserts ClusterIDMissingError.
-func IsClusterIDMissingError(err error) bool {
-	return microerror.Cause(err) == ClusterIDMissingError
+// IsClusterNameOrIDMissingError asserts ClusterNameOrIDMissingError.
+func IsClusterNameOrIDMissingError(err error) bool {
+	return microerror.Cause(err) == ClusterNameOrIDMissingError
 }
 
 // NodePoolIDMissingError means a required node pool ID has not been given as input

--- a/commands/errors/handling.go
+++ b/commands/errors/handling.go
@@ -53,8 +53,8 @@ func HandleCommonErrors(err error) {
 			subtext = "The API server complains about the password provided."
 			subtext += " Please make sure to provide a string with more than white space characters."
 		case IsClusterNameOrIDMissingError(err):
-			headline = "No cluster ID specified."
-			subtext = "Please specify a cluster ID. Use --help for details."
+			headline = "No cluster name or ID specified."
+			subtext = "Please specify a cluster name or ID. Use --help for details."
 		case IsNodePoolIDMissingError(err):
 			headline = "No node pool ID specified."
 			subtext = "Please specify a node pool ID. Use --help for details."

--- a/commands/errors/handling.go
+++ b/commands/errors/handling.go
@@ -52,7 +52,7 @@ func HandleCommonErrors(err error) {
 			headline = "Empty password submitted"
 			subtext = "The API server complains about the password provided."
 			subtext += " Please make sure to provide a string with more than white space characters."
-		case IsClusterIDMissingError(err):
+		case IsClusterNameOrIDMissingError(err):
 			headline = "No cluster ID specified."
 			subtext = "Please specify a cluster ID. Use --help for details."
 		case IsNodePoolIDMissingError(err):

--- a/commands/list/clusters/command.go
+++ b/commands/list/clusters/command.go
@@ -249,7 +249,7 @@ func getClustersOutput(args Arguments) (string, error) {
 		table = append(table, strings.Join(fields, "|"))
 	}
 
-	clustercache.CacheIDs(clusterIDs...)
+	clustercache.CacheIDs(args.apiEndpoint, clusterIDs)
 
 	// This function's output string.
 	output := ""

--- a/commands/list/clusters/command.go
+++ b/commands/list/clusters/command.go
@@ -12,6 +12,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/giantswarm/columnize"
 	"github.com/giantswarm/gscliauth/config"
+	"github.com/giantswarm/gsctl/clustercache"
 	"github.com/giantswarm/microerror"
 	"github.com/spf13/cobra"
 
@@ -248,7 +249,7 @@ func getClustersOutput(args Arguments) (string, error) {
 		table = append(table, strings.Join(fields, "|"))
 	}
 
-	util.CacheClusterIDs(clusterIDs...)
+	clustercache.CacheIDs(clusterIDs...)
 
 	// This function's output string.
 	output := ""

--- a/commands/list/clusters/command.go
+++ b/commands/list/clusters/command.go
@@ -198,6 +198,7 @@ func getClustersOutput(args Arguments) (string, error) {
 
 	numDeletedClusters := 0
 	numOtherClusters := 0
+	clusterIDs := make([]string, 0, len(response.Payload))
 
 	for _, cluster := range response.Payload {
 		created := util.ShortDate(util.ParseDate(cluster.CreateDate))
@@ -216,6 +217,8 @@ func getClustersOutput(args Arguments) (string, error) {
 			deleteTime := time.Time(*cluster.DeleteDate)
 			secondsSinceDelete = time.Now().Sub(deleteTime).Seconds()
 		} else {
+			clusterIDs = append(clusterIDs, cluster.ID)
+
 			numOtherClusters++
 		}
 
@@ -244,6 +247,8 @@ func getClustersOutput(args Arguments) (string, error) {
 
 		table = append(table, strings.Join(fields, "|"))
 	}
+
+	util.CacheClusterIDs(clusterIDs...)
 
 	// This function's output string.
 	output := ""

--- a/commands/list/clusters/command_test.go
+++ b/commands/list/clusters/command_test.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/giantswarm/gsctl/commands/errors"
+	"github.com/giantswarm/gsctl/testutils"
+	"github.com/spf13/afero"
 )
 
 func init() {
@@ -70,13 +72,19 @@ func Test_ListClusters(t *testing.T) {
 	}))
 	defer mockServer.Close()
 
+	fs := afero.NewMemMapFs()
+	_, err := testutils.TempConfig(fs, "")
+	if err != nil {
+		t.Error(err)
+	}
+
 	args := Arguments{
 		apiEndpoint:  mockServer.URL,
 		authToken:    "testtoken",
 		outputFormat: "table",
 	}
 
-	err := verifyListClusterPreconditions(args)
+	err = verifyListClusterPreconditions(args)
 	if err != nil {
 		t.Error(err)
 	}
@@ -98,13 +106,19 @@ func Test_ListClustersEmpty(t *testing.T) {
 	}))
 	defer mockServer.Close()
 
+	fs := afero.NewMemMapFs()
+	_, err := testutils.TempConfig(fs, "")
+	if err != nil {
+		t.Error(err)
+	}
+
 	args := Arguments{
 		apiEndpoint:  mockServer.URL,
 		authToken:    "testtoken",
 		outputFormat: "table",
 	}
 
-	err := verifyListClusterPreconditions(args)
+	err = verifyListClusterPreconditions(args)
 	if err != nil {
 		t.Error(err)
 	}
@@ -128,13 +142,19 @@ func Test_ListClustersUnauthorized(t *testing.T) {
 	}))
 	defer mockServer.Close()
 
+	fs := afero.NewMemMapFs()
+	_, err := testutils.TempConfig(fs, "")
+	if err != nil {
+		t.Error(err)
+	}
+
 	args := Arguments{
 		apiEndpoint:  mockServer.URL,
 		authToken:    "testtoken",
 		outputFormat: "table",
 	}
 
-	err := verifyListClusterPreconditions(args)
+	err = verifyListClusterPreconditions(args)
 	if err != nil {
 		t.Error(err)
 	}

--- a/commands/list/keypairs/command.go
+++ b/commands/list/keypairs/command.go
@@ -140,7 +140,7 @@ func listKeypairsValidate(args *Arguments) error {
 		if clusterID != "" {
 			flags.ClusterID = clusterID
 		} else {
-			return microerror.Mask(errors.ClusterIDMissingError)
+			return microerror.Mask(errors.ClusterNameOrIDMissingError)
 		}
 	}
 

--- a/commands/scale/cluster/command.go
+++ b/commands/scale/cluster/command.go
@@ -121,7 +121,7 @@ func getConfirmation(args Arguments, maxBefore int, minBefore int, currentWorker
 
 func collectArguments(cmd *cobra.Command, positionalArgs []string) (Arguments, error) {
 	if len(positionalArgs) == 0 {
-		return Arguments{}, microerror.Mask(errors.ClusterIDMissingError)
+		return Arguments{}, microerror.Mask(errors.ClusterNameOrIDMissingError)
 	}
 
 	endpoint := config.Config.ChooseEndpoint(flags.APIEndpoint)
@@ -160,7 +160,7 @@ func verifyPreconditions(args Arguments) error {
 		return microerror.Mask(errors.NotLoggedInError)
 	}
 	if args.ClusterID == "" {
-		return microerror.Mask(errors.ClusterIDMissingError)
+		return microerror.Mask(errors.ClusterNameOrIDMissingError)
 	}
 
 	// Check if the cluster is v5, so we can provide helpful details.

--- a/commands/show/cluster/command.go
+++ b/commands/show/cluster/command.go
@@ -104,7 +104,7 @@ func verifyPreconditions(args Arguments, cmdLineArgs []string) error {
 		return microerror.Mask(errors.NotLoggedInError)
 	}
 	if len(cmdLineArgs) == 0 {
-		return microerror.Mask(errors.ClusterIDMissingError)
+		return microerror.Mask(errors.ClusterNameOrIDMissingError)
 	}
 	return nil
 }

--- a/commands/show/cluster/command_test.go
+++ b/commands/show/cluster/command_test.go
@@ -358,7 +358,7 @@ func TestShowClusterMissingID(t *testing.T) {
 	}
 
 	err := verifyPreconditions(testArgs, []string{})
-	if !errors.IsClusterIDMissingError(err) {
+	if !errors.IsClusterNameOrIDMissingError(err) {
 		t.Errorf("Expected clusterIdMissingError, got '%s'", err.Error())
 	}
 

--- a/commands/show/nodepool/command.go
+++ b/commands/show/nodepool/command.go
@@ -93,7 +93,7 @@ func verifyPreconditions(args *Arguments) error {
 	}
 
 	if args.clusterID == "" {
-		return microerror.Mask(errors.ClusterIDMissingError)
+		return microerror.Mask(errors.ClusterNameOrIDMissingError)
 	}
 	if args.nodePoolID == "" {
 		return microerror.Mask(errors.NodePoolIDMissingError)

--- a/commands/update/cluster/command.go
+++ b/commands/update/cluster/command.go
@@ -92,7 +92,7 @@ func verifyPreconditions(args Arguments) error {
 	if args.AuthToken == "" && args.UserProvidedToken == "" {
 		return microerror.Mask(errors.NotLoggedInError)
 	} else if args.ClusterID == "" {
-		return microerror.Mask(errors.ClusterIDMissingError)
+		return microerror.Mask(errors.ClusterNameOrIDMissingError)
 	} else if args.Name == "" {
 		return microerror.Mask(errors.NoOpError)
 	}

--- a/commands/update/cluster/command_test.go
+++ b/commands/update/cluster/command_test.go
@@ -89,7 +89,7 @@ func Test_verifyPreconditions(t *testing.T) {
 				AuthToken:   "token",
 				APIEndpoint: "https://mock-url",
 			},
-			errors.IsClusterIDMissingError,
+			errors.IsClusterNameOrIDMissingError,
 		},
 		// No token provided.
 		{

--- a/commands/update/nodepool/command.go
+++ b/commands/update/nodepool/command.go
@@ -107,7 +107,7 @@ func verifyPreconditions(args Arguments) error {
 	if args.AuthToken == "" && args.UserProvidedToken == "" {
 		return microerror.Mask(errors.NotLoggedInError)
 	} else if args.ClusterID == "" {
-		return microerror.Mask(errors.ClusterIDMissingError)
+		return microerror.Mask(errors.ClusterNameOrIDMissingError)
 	} else if args.NodePoolID == "" {
 		return microerror.Mask(errors.NodePoolIDMissingError)
 	} else if args.ScalingMin == 0 && args.ScalingMax == 0 && args.Name == "" {

--- a/commands/update/nodepool/command_test.go
+++ b/commands/update/nodepool/command_test.go
@@ -97,7 +97,7 @@ func Test_verifyPreconditions(t *testing.T) {
 				APIEndpoint: "https://mock-url",
 				NodePoolID:  "abc",
 			},
-			errors.IsClusterIDMissingError,
+			errors.IsClusterNameOrIDMissingError,
 		},
 		// Node pool ID is missing.
 		{

--- a/commands/upgrade/cluster/command.go
+++ b/commands/upgrade/cluster/command.go
@@ -130,7 +130,7 @@ func upgradeClusterValidationOutput(cmd *cobra.Command, cmdLineArgs []string) {
 		case errors.IsNotLoggedInError(err):
 			headline = "You are not logged in."
 			subtext = fmt.Sprintf("Use '%s login' to login or '--auth-token' to pass a valid auth token.", config.ProgramName)
-		case errors.IsClusterIDMissingError(err):
+		case errors.IsClusterNameOrIDMissingError(err):
 			headline = "No cluster ID specified."
 			subtext = "Please specify which cluster to upgrade by using the cluster ID as an argument."
 		default:
@@ -159,7 +159,7 @@ func validateUpgradeClusterPreconditions(args Arguments, cmdLineArgs []string) e
 
 	// cluster ID is present
 	if args.ClusterID == "" {
-		return microerror.Mask(errors.ClusterIDMissingError)
+		return microerror.Mask(errors.ClusterNameOrIDMissingError)
 	}
 
 	return nil

--- a/commands/upgrade/cluster/command_test.go
+++ b/commands/upgrade/cluster/command_test.go
@@ -238,7 +238,7 @@ func Test_validateUpgradeClusterPreconditions(t *testing.T) {
 				},
 				[]string{},
 			},
-			wantErr: errors.IsClusterIDMissingError,
+			wantErr: errors.IsClusterNameOrIDMissingError,
 		},
 	}
 	for index, tt := range tests {

--- a/confirm/confirm.go
+++ b/confirm/confirm.go
@@ -89,7 +89,7 @@ func AskStrictOneOf(s string, c []string) (bool, string) {
 		case "n", "no":
 			return false, ""
 		default:
-			fmt.Printf(color.YellowString("The input entered does not match. "))
+			fmt.Printf(color.YellowString("The input entered does not match any of the provided options. "))
 			fmt.Printf(color.YellowString("Try again or abort by typing 'n' or 'no': "))
 		}
 	}

--- a/confirm/confirm.go
+++ b/confirm/confirm.go
@@ -63,3 +63,34 @@ func AskStrict(s string, c string) bool {
 		}
 	}
 }
+
+// AskStrictOneOf asks the user for confirmation. A user must type one of
+// the expected confirmation values and then press enter.
+func AskStrictOneOf(s string, c []string) (bool, string) {
+	reader := bufio.NewReader(os.Stdin)
+
+	fmt.Printf("%s: ", color.YellowString(s))
+
+	for {
+		response, err := reader.ReadString('\n')
+		if err != nil {
+			log.Fatal(microerror.Mask(err))
+		}
+		response = strings.TrimSuffix(response, "\n")
+		response = strings.ToLower(strings.TrimSpace(response))
+
+		for _, v := range c {
+			if strings.ToLower(v) == response {
+				return true, response
+			}
+		}
+
+		switch response {
+		case "n", "no":
+			return false, ""
+		default:
+			fmt.Printf(color.YellowString("The input entered does not match. "))
+			fmt.Printf(color.YellowString("Try again or abort by typing 'n' or 'no': "))
+		}
+	}
+}

--- a/confirm/confirm.go
+++ b/confirm/confirm.go
@@ -47,17 +47,18 @@ func AskStrict(s string, c string) bool {
 
 	for {
 		response, err := reader.ReadString('\n')
+		response = strings.TrimSuffix(response, "\n")
 		if err != nil {
 			log.Fatal(microerror.Mask(err))
 		}
 
 		switch strings.ToLower(strings.TrimSpace(response)) {
-		case c:
+		case strings.ToLower(c):
 			return true
 		case "n", "no":
 			return false
 		default:
-			fmt.Printf(color.YellowString("The input entered does not match."))
+			fmt.Printf(color.YellowString("The input entered does not match. "))
 			fmt.Printf(color.YellowString("Try again or abort by typing 'n' or 'no': "))
 		}
 	}

--- a/testutils/testutils.go
+++ b/testutils/testutils.go
@@ -112,14 +112,14 @@ contexts:
 // TempClusterCache creates a temporary config directory with
 // clustercache file containing the given cache content
 // The directory path is returned.
-func TempClusterCache(fs afero.Fs, cacheContent string) (string, error) {
+func TempClusterCache(fs afero.Fs, cacheYAML string) (string, error) {
 	dir := TempDir(fs)
 	config.ConfigDirPath = dir
 	config.FileSystem = fs
 	filePath := path.Join(config.ConfigDirPath, "clustercache")
 
-	if cacheContent != "" {
-		err := afero.WriteFile(fs, filePath, []byte(cacheContent), 0600)
+	if cacheYAML != "" {
+		err := afero.WriteFile(fs, filePath, []byte(cacheYAML), 0600)
 		if err != nil {
 			return "", err
 		}

--- a/testutils/testutils.go
+++ b/testutils/testutils.go
@@ -3,6 +3,7 @@ package testutils
 import (
 	"bytes"
 	"io"
+	"io/ioutil"
 	"os"
 	"path"
 
@@ -32,6 +33,21 @@ func CaptureOutput(f func()) (printed string) {
 	out := <-outC
 
 	return out
+}
+
+// CaptureOutputSync runs a function synchronously and captures returns STDOUT output as a string.
+func CaptureOutputSync(f func()) (printed string) {
+	orig := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	f()
+
+	w.Close()
+	out, _ := ioutil.ReadAll(r)
+	os.Stdout = orig
+
+	return string(out)
 }
 
 // TempDir creates a temporary directory for a temporary config file in tests.

--- a/testutils/testutils.go
+++ b/testutils/testutils.go
@@ -108,3 +108,22 @@ contexts:
 
 	return kubeConfigPath, nil
 }
+
+// TempClusterCache creates a temporary config directory with
+// clustercache file containing the given cache content
+// The directory path is returned.
+func TempClusterCache(fs afero.Fs, cacheContent string) (string, error) {
+	dir := TempDir(fs)
+	config.ConfigDirPath = dir
+	config.FileSystem = fs
+	filePath := path.Join(config.ConfigDirPath, "clustercache")
+
+	if cacheContent != "" {
+		err := afero.WriteFile(fs, filePath, []byte(cacheContent), 0600)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return dir, nil
+}

--- a/testutils/testutils.go
+++ b/testutils/testutils.go
@@ -116,7 +116,7 @@ func TempClusterCache(fs afero.Fs, cacheYAML string) (string, error) {
 	dir := TempDir(fs)
 	config.ConfigDirPath = dir
 	config.FileSystem = fs
-	filePath := path.Join(config.ConfigDirPath, "clustercache")
+	filePath := path.Join(config.ConfigDirPath, "clustercache.yaml")
 
 	if cacheYAML != "" {
 		err := afero.WriteFile(fs, filePath, []byte(cacheYAML), 0600)

--- a/testutils/testutils_test.go
+++ b/testutils/testutils_test.go
@@ -16,3 +16,15 @@ func TestCaptureOutput(t *testing.T) {
 		t.Errorf("Expected %q, got %q", input, output)
 	}
 }
+
+func TestCaptureOutputSync(t *testing.T) {
+	input := "This is the first line\n"
+	f := func() {
+		fmt.Printf(input)
+	}
+
+	output := CaptureOutputSync(f)
+	if output != input {
+		t.Errorf("Expected %q, got %q", input, output)
+	}
+}

--- a/util/cluster.go
+++ b/util/cluster.go
@@ -1,0 +1,95 @@
+package util
+
+import (
+	"fmt"
+
+	"github.com/fatih/color"
+	"github.com/giantswarm/columnize"
+	"github.com/giantswarm/gsclientgen/models"
+	"github.com/giantswarm/gsctl/client"
+	"github.com/giantswarm/gsctl/client/clienterror"
+	"github.com/giantswarm/gsctl/commands/errors"
+	"github.com/giantswarm/gsctl/confirm"
+	"github.com/giantswarm/microerror"
+)
+
+const listClustersActivityName = "list-clusters"
+
+func GetClusterID(clusterNameOrID string, clientWrapper *client.Wrapper) (string, error) {
+	auxParams := clientWrapper.DefaultAuxiliaryParams()
+	auxParams.ActivityName = listClustersActivityName
+
+	response, err := clientWrapper.GetClusters(auxParams)
+	if err != nil {
+		switch {
+		case clienterror.IsUnauthorizedError(err):
+			return "", microerror.Mask(errors.NotAuthorizedError)
+
+		case clienterror.IsAccessForbiddenError(err):
+			return "", microerror.Mask(errors.AccessForbiddenError)
+
+		default:
+			return "", microerror.Mask(err)
+		}
+	}
+
+	var clusterIDs []string
+	for _, cluster := range response.Payload {
+		if matchesValidation(clusterNameOrID, cluster) {
+			clusterIDs = append(clusterIDs, cluster.ID)
+		}
+	}
+
+	switch {
+	case clusterIDs == nil:
+		return "", microerror.Mask(errors.ClusterNotFoundError)
+
+	case len(clusterIDs) > 1:
+		confirmed, id := handleNameCollision(clusterNameOrID, response.Payload)
+		if !confirmed {
+			return "", nil
+		}
+
+		return id, nil
+
+	default:
+		return clusterIDs[0], nil
+	}
+}
+
+func matchesValidation(nameOrID string, cluster *models.V4ClusterListItem) bool {
+	return cluster.DeleteDate == nil && (cluster.ID == nameOrID || cluster.Name == nameOrID)
+}
+
+func handleNameCollision(nameOrID string, clusters []*models.V4ClusterListItem) (bool, string) {
+	var (
+		clusterIDs []string
+
+		table = []string{color.CyanString("ID | ORGANIZATION | NAME")}
+	)
+
+	for _, cluster := range clusters {
+		if matchesValidation(nameOrID, cluster) {
+			clusterIDs = append(clusterIDs, cluster.ID)
+			table = append(table, fmt.Sprintf("%5s | %5s | %5s\n", cluster.ID, cluster.Owner, cluster.Name))
+		}
+	}
+
+	// Print output
+	fmt.Println("Multiple clusters found")
+	fmt.Printf("\n")
+	fmt.Println(columnize.SimpleFormat(table))
+	fmt.Printf("\n")
+
+	confirmed, id := confirm.AskStrictOneOf(
+		fmt.Sprintf(
+			"Found more than one cluster called '%s', please type the ID of the cluster that you would like to delete",
+			nameOrID,
+		),
+		clusterIDs,
+	)
+	if !confirmed {
+		return false, ""
+	}
+	return true, id
+}

--- a/util/cluster.go
+++ b/util/cluster.go
@@ -3,6 +3,7 @@ package util
 import (
 	"fmt"
 	"path"
+	"sort"
 	"strings"
 
 	"github.com/fatih/color"
@@ -193,6 +194,8 @@ func removeDuplicates(c []string) []string {
 	for ID := range uniqueVals {
 		final = append(final, ID)
 	}
+
+	sort.Strings(final)
 
 	return final
 }

--- a/util/cluster.go
+++ b/util/cluster.go
@@ -75,11 +75,7 @@ func handleNameCollision(nameOrID string, clusters []*models.V4ClusterListItem) 
 		}
 	}
 
-	// Print output
-	fmt.Println("Multiple clusters found")
-	fmt.Printf("\n")
-	fmt.Println(columnize.SimpleFormat(table))
-	fmt.Printf("\n")
+	printNameCollisionTable(table)
 
 	confirmed, id := confirm.AskStrictOneOf(
 		fmt.Sprintf(
@@ -92,4 +88,12 @@ func handleNameCollision(nameOrID string, clusters []*models.V4ClusterListItem) 
 		return false, ""
 	}
 	return true, id
+}
+
+func printNameCollisionTable(table []string) {
+	// Print output
+	fmt.Println("Multiple clusters found")
+	fmt.Printf("\n")
+	fmt.Println(columnize.SimpleFormat(table))
+	fmt.Printf("\n")
 }

--- a/util/cluster.go
+++ b/util/cluster.go
@@ -116,6 +116,9 @@ func printNameCollisionTable(table []string) {
 	fmt.Printf("\n")
 }
 
+// CacheClusterIDs adds cluster IDs to a persistent cache,
+// which can be used for decreasing timeout in getting
+// cluster IDs, for commands that take both cluster names and IDs
 func CacheClusterIDs(c ...string) {
 	existingC := make(chan []string)
 	go func() {
@@ -142,13 +145,13 @@ func CacheClusterIDs(c ...string) {
 	_ = <-writeC
 }
 
+// IsInClusterCache checks if a cluster ID is present in the
+// persistent cluster cache
 func IsInClusterCache(ID string) bool {
 	existing, _ := readClusterCache()
 
 	for _, name := range existing {
 		if name == ID {
-			fmt.Printf("%s found in cache\n", ID)
-
 			return true
 		}
 	}

--- a/util/cluster_test.go
+++ b/util/cluster_test.go
@@ -1,0 +1,121 @@
+package util
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/giantswarm/gsctl/client"
+	"github.com/giantswarm/gsctl/commands/errors"
+	"github.com/giantswarm/gsctl/testutils"
+	"github.com/spf13/afero"
+)
+
+func TestGetClusterID(t *testing.T) {
+	var testCases = []struct {
+		clusterNameOrID string
+		expectedID      string
+		errorMatcher    func(error) bool
+		output          string
+	}{
+		{
+			clusterNameOrID: "My dearest production cluster",
+			expectedID:      "fow72",
+			errorMatcher:    nil,
+		}, {
+			clusterNameOrID: "2sg4i",
+			expectedID:      "2sg4i",
+			errorMatcher:    nil,
+		}, {
+			clusterNameOrID: "Some cluster that is not here",
+			expectedID:      "",
+			errorMatcher:    errors.IsClusterNotFoundError,
+		}, {
+			clusterNameOrID: "A deleted cluster",
+			expectedID:      "",
+			errorMatcher:    errors.IsClusterNotFoundError,
+		},
+	}
+
+	fs := afero.NewMemMapFs()
+	_, err := testutils.TempConfig(fs, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if r.Method == "GET" && r.URL.Path == "/v4/clusters/" {
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte(`[
+			{
+				"create_date": "2017-05-16T09:30:31.192170835Z",
+				"id": "fow72",
+				"name": "My dearest production cluster",
+				"owner": "acme",
+				"path": "/v4/clusters/fow72/"
+			},
+			{
+				"create_date": "2017-04-16T09:30:31.192170835Z",
+				"id": "2sg4i",
+				"name": "Abandoned cluster from the early days",
+				"owner": "some_org",
+				"path": "/v4/clusters/2sg4i/"
+			},
+			{
+				"create_date": "2017-10-06T02:24:55.192170835Z",
+				"id": "7ste0",
+				"name": "A fairly recent test cluster",
+				"owner": "acme",
+				"path": "/v4/clusters/7ste0/"
+			},
+			{
+				"create_date": "2017-10-20T07:24:55.192170835Z",
+				"id": "9as2a",
+				"name": "That brand new cluster",
+				"owner": "acme_dev",
+				"path": "/v4/clusters/9as2a/"
+			},{
+				"create_date": "2017-10-10T07:24:55.192170835Z",
+				"id": "d740d",
+				"name": "That brand new cluster",
+				"owner": "acme_prod",
+				"path": "/v4/clusters/d740d/"
+			},
+			{
+				"create_date": "2017-10-10T07:24:55.192170835Z",
+				"delete_date": "2019-10-10T07:24:55.192170835Z",
+				"id": "del01",
+				"name": "A deleted cluster",
+				"owner": "acme",
+				"path": "/v5/clusters/del01/"
+			}
+		]`))
+				} else {
+					t.Errorf("Case %d - Unsupported operation %s %s called in mock server", i, r.Method, r.URL.Path)
+				}
+			}))
+			defer mockServer.Close()
+
+			// client
+			clientWrapper, err := client.NewWithConfig(mockServer.URL, "test-token")
+			if err != nil {
+				t.Fatalf("Error in client creation: %s", err)
+			}
+
+			// output
+			id, err := GetClusterID(tc.clusterNameOrID, clientWrapper)
+
+			if id != tc.expectedID {
+				t.Errorf("Case %d - Result did not match ", i)
+			} else if err == nil && tc.errorMatcher != nil {
+				t.Errorf("Case %d - Expected an error but didn't get one. Should I be happy or not? ", i)
+			} else if tc.errorMatcher != nil && !tc.errorMatcher(err) {
+				t.Errorf("Case %d - Error did not match expected type. Got '%s'", i, err)
+			}
+		})
+	}
+}

--- a/util/cluster_test.go
+++ b/util/cluster_test.go
@@ -109,12 +109,17 @@ func TestGetClusterID(t *testing.T) {
 			// output
 			id, err := GetClusterID(tc.clusterNameOrID, clientWrapper)
 
-			if id != tc.expectedID {
+			switch {
+
+			case id != tc.expectedID:
 				t.Errorf("Case %d - Result did not match ", i)
-			} else if err == nil && tc.errorMatcher != nil {
+
+			case err == nil && tc.errorMatcher != nil:
 				t.Errorf("Case %d - Expected an error but didn't get one. Should I be happy or not? ", i)
-			} else if tc.errorMatcher != nil && !tc.errorMatcher(err) {
+
+			case tc.errorMatcher != nil && !tc.errorMatcher(err):
 				t.Errorf("Case %d - Error did not match expected type. Got '%s'", i, err)
+
 			}
 		})
 	}


### PR DESCRIPTION
Towards https://github.com/giantswarm/gsctl/issues/188

At the moment, this only provides support for the delete cluster command
- Renamed `ClusterIDMissing` errors to `ClusterNameOrIDMissing`
- Before executing the delete request, it gets all the clusters and checks to see if there is a cluster with the provided ID or name in there
- Changed error messages to also say cluster **name**, not just **ID**

When a cluster is deleted, the confirmation will state the name/ID provided by the user. So if the user provided an ID, the confirmation will show the ID; or a name, if he provided a name.

**Preview**
* Deleting a cluster with the name
![image](https://user-images.githubusercontent.com/13508038/75463528-3ea96500-5986-11ea-887d-0f61680ac7cd.png)

* Deleting a cluster with the ID
![image](https://user-images.githubusercontent.com/13508038/75463649-64366e80-5986-11ea-9d93-0cd760de736d.png)

* Trying to delete a cluster with an ID/name that doesn't exist
![image](https://user-images.githubusercontent.com/13508038/75463717-79130200-5986-11ea-80da-50bb508197cc.png)

* Trying to delete a cluster that has the same name as another existing one
![image](https://user-images.githubusercontent.com/13508038/75863904-80f8f900-5e01-11ea-8847-882972f5e2ba.png)

* Saving cluster IDs in the cache file (`~/.config/gsctl/clustercache.yaml`)
![image](https://user-images.githubusercontent.com/13508038/75777676-a977e900-5d56-11ea-93e5-c06918b86681.png)

As a side note, this only includes the `delete cluster` command, because I want to know that my implementation is right, before copying and pasting it to the other commands.
Also, I would like to do 1-2 commands per PR, to keep them small, so we could prevent any unwanted bugs.
