### PR TITLE
Organizations set credentials command always gives 401 error

### DIFF
--- a/commands/update/organization/setcredentials/command.go
+++ b/commands/update/organization/setcredentials/command.go
@@ -338,7 +338,7 @@ func setOrgCredentials(args Arguments) (*setOrgCredentialsResult, error) {
 		fmt.Println(color.WhiteString("Sending API request to set credentials"))
 	}
 
-	clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.authToken)
+	clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.userProvidedToken)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/commands/update/organization/setcredentials/command.go
+++ b/commands/update/organization/setcredentials/command.go
@@ -347,8 +347,6 @@ func setOrgCredentials(args Arguments) (*setOrgCredentialsResult, error) {
 	auxParams.ActivityName = activityName
 
 	response, err := clientWrapper.SetCredentials(args.organizationID, requestBody, auxParams)
-	fmt.Printf("response: %#v\n", response)
-	fmt.Printf("err: %#v\n", err)
 	if err != nil {
 		if clienterror.IsConflictError(err) {
 			return nil, microerror.Mask(errors.CredentialsAlreadySetError)


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/9254

`gsctl` gave this error while trying to to set credentials for an organization
```
response: (*organizations.AddCredentialsCreated)(nil)
err: &clienterror.APIError{HTTPStatusCode:401, OriginalError:(*organizations.AddCredentialsUnauthorized)(0xc0000d2238), ErrorMessage:"Unauthorized", ErrorDetails:"You do not have permission to set credentials for this organization.", URL:"", HTTPMethod:"", IsTimeout:false, IsTemporary:false}
Unauthorized
```

More info 
https://gigantic.slack.com/archives/CQ465CFG8/p1583243960011200

* Pass the right token to the client executing the 'set-credentials' request

![image](https://user-images.githubusercontent.com/13508038/75791159-72143700-5d6c-11ea-9c2d-7ab2bc6daf21.png)
