### PR TITLE
Add support for using cluster name: 'create keypair' command

### DIFF
--- a/clustercache/clustercache.go
+++ b/clustercache/clustercache.go
@@ -202,7 +202,7 @@ func handleNameCollision(nameOrID string, clusters []*models.V4ClusterListItem) 
 	printNameCollisionTable(nameOrID, table)
 
 	confirmed, id := confirm.AskStrictOneOf(
-		"Please type the ID of the cluster that you would like to delete",
+		"Please type the ID of the cluster that you want to use",
 		clusterIDs,
 	)
 	if !confirmed {

--- a/commands/create/keypair/command.go
+++ b/commands/create/keypair/command.go
@@ -248,9 +248,6 @@ func createKeypair(args Arguments) (createKeypairResult, error) {
 	if err != nil {
 		return result, microerror.Mask(err)
 	}
-	if clusterID == "" {
-		return result, microerror.Mask(errors.ClusterNotFoundError)
-	}
 
 	auxParams := clientWrapper.DefaultAuxiliaryParams()
 	auxParams.ActivityName = activityName

--- a/commands/create/keypair/command_test.go
+++ b/commands/create/keypair/command_test.go
@@ -26,7 +26,20 @@ func Test_CreateKeypair(t *testing.T) {
 		fmt.Printf("mockServer request: %s %s\n", r.Method, r.URL)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(keypairResponse))
+
+		if r.Method == "GET" && r.URL.String() == "/v4/clusters/" {
+			w.Write([]byte(`[
+			{
+				"create_date": "2017-05-16T09:30:31.192170835Z",
+				"id": "test-cluster-id",
+				"name": "somecluster",
+				"owner": "acme",
+				"path": "/v4/clusters/test-id/"
+			}
+		]`))
+		} else {
+			w.Write([]byte(keypairResponse))
+		}
 	}))
 	defer mockServer.Close()
 
@@ -37,10 +50,10 @@ func Test_CreateKeypair(t *testing.T) {
 	}
 
 	args := Arguments{
-		apiEndpoint: mockServer.URL,
-		authToken:   "test-token",
-		clusterID:   "test-cluster-id",
-		fileSystem:  fs,
+		apiEndpoint:     mockServer.URL,
+		authToken:       "test-token",
+		clusterNameOrID: "test-cluster-id",
+		fileSystem:      fs,
 	}
 
 	err = verifyPreconditions(args)
@@ -74,7 +87,20 @@ func TestCommandExecution(t *testing.T) {
 		fmt.Printf("mockServer request: %s %s\n", r.Method, r.URL)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(keypairResponse))
+
+		if r.Method == "GET" && r.URL.String() == "/v4/clusters/" {
+			w.Write([]byte(`[
+			{
+				"create_date": "2017-05-16T09:30:31.192170835Z",
+				"id": "test-id",
+				"name": "somecluster",
+				"owner": "acme",
+				"path": "/v4/clusters/test-id/"
+			}
+		]`))
+		} else {
+			w.Write([]byte(keypairResponse))
+		}
 	}))
 	defer mockServer.Close()
 

--- a/commands/delete/cluster/command.go
+++ b/commands/delete/cluster/command.go
@@ -203,9 +203,6 @@ func deleteCluster(args Arguments) (bool, error) {
 		if err != nil {
 			return false, microerror.Mask(err)
 		}
-		if clusterID == "" {
-			return false, microerror.Mask(errors.ClusterNotFoundError)
-		}
 	}
 
 	// confirmation

--- a/commands/delete/cluster/command.go
+++ b/commands/delete/cluster/command.go
@@ -204,7 +204,7 @@ func deleteCluster(args Arguments) (bool, error) {
 			return false, microerror.Mask(err)
 		}
 		if clusterID == "" {
-			return false, nil
+			return false, microerror.Mask(errors.ClusterNotFoundError)
 		}
 	}
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/gsctl/issues/188

This adds support for using both cluster names and IDs with the `gsctl create keypair` command.

Additional things:
* The collision confirm message has been changed to a more generic one (it was a hardcoded message regarding cluster deletion)
* Removed redudant clusterID check from the `delete cluster` command

Tested manually and is working as expected