### PR TITLE
Add support for using cluster name: 'create kubeconfig' command

### DIFF
--- a/commands/create/kubeconfig/command.go
+++ b/commands/create/kubeconfig/command.go
@@ -13,6 +13,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/giantswarm/gscliauth/config"
 	"github.com/giantswarm/gsclientgen/models"
+	"github.com/giantswarm/gsctl/clustercache"
 	"github.com/giantswarm/k8sclient/k8srestconfig"
 	"github.com/giantswarm/kubeconfig"
 	"github.com/giantswarm/microerror"
@@ -52,11 +53,11 @@ Examples:
 
   gsctl create kubeconfig -c my0c3
 
-  gsctl create kubeconfig -c my0c3 --self-contained ./kubeconfig.yaml
+  gsctl create kubeconfig -c "Production cluster" --self-contained ./kubeconfig.yaml
 
   gsctl create kubeconfig -c my0c3 --ttl 3h -d "Key pair living for only 3 hours"
 
-  gsctl create kubeconfig -c my0c3 --certificate-organizations system:masters
+  gsctl create kubeconfig -c "Development cluster" --certificate-organizations system:masters
 `,
 		PreRun: createKubeconfigPreRunOutput,
 		Run:    createKubeconfigRunOutput,
@@ -93,7 +94,7 @@ type Arguments struct {
 	apiEndpoint       string
 	authToken         string
 	certOrgs          string
-	clusterID         string
+	clusterNameOrID   string
 	cnPrefix          string
 	contextName       string
 	description       string
@@ -137,7 +138,7 @@ func collectArguments() (Arguments, error) {
 		apiEndpoint:       endpoint,
 		authToken:         token,
 		certOrgs:          flags.CertificateOrganizations,
-		clusterID:         flags.ClusterID,
+		clusterNameOrID:   flags.ClusterID,
 		cnPrefix:          flags.CNPrefix,
 		contextName:       contextName,
 		description:       description,
@@ -252,7 +253,7 @@ func verifyCreateKubeconfigPreconditions(args Arguments, cmdLineArgs []string) e
 	if config.Config.Token == "" && args.authToken == "" {
 		return microerror.Mask(errors.NotLoggedInError)
 	}
-	if args.clusterID == "" {
+	if args.clusterNameOrID == "" {
 		return microerror.Mask(errors.ClusterNameOrIDMissingError)
 	}
 
@@ -308,10 +309,10 @@ func createKubeconfigRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 			headline = "Error: " + err.Error()
 		case util.IsCouldNotUseKubectlContextError(err):
 			headline = "Error: " + err.Error()
-			subtext = "Context name to select is: giantswarm-" + arguments.clusterID
+			subtext = "Context name to select is: giantswarm-" + arguments.clusterNameOrID
 		case errors.IsClusterNotFoundError(err):
-			headline = fmt.Sprintf("Error: Cluster '%s' does not exist.", arguments.clusterID)
-			subtext = "Please check the ID spelling or list clusters using 'gsctl list clusters'."
+			headline = fmt.Sprintf("Error: Cluster '%s' does not exist.", arguments.clusterNameOrID)
+			subtext = "Please check the name/ID spelling or list clusters using 'gsctl list clusters'."
 		case errors.IsCouldNotWriteFileError(err):
 			headline = "Error: File could not be written"
 			subtext = fmt.Sprintf("Details: %s", err.Error())
@@ -402,13 +403,18 @@ func createKubeconfig(ctx context.Context, args Arguments) (createKubeconfigResu
 
 	clientWrapper, err := client.NewWithConfig(args.apiEndpoint, args.userProvidedToken)
 	if err != nil {
-		return createKubeconfigResult{}, microerror.Mask(err)
+		return result, microerror.Mask(err)
+	}
+
+	clusterID, err := clustercache.GetID(args.apiEndpoint, args.clusterNameOrID, clientWrapper)
+	if err != nil {
+		return result, microerror.Mask(err)
 	}
 
 	auxParams := clientWrapper.DefaultAuxiliaryParams()
 	auxParams.ActivityName = createKubeconfigActivityName
 
-	result.apiEndpoint, err = getClusterDetails(clientWrapper, args.clusterID, auxParams, args.verbose)
+	result.apiEndpoint, err = getClusterDetails(clientWrapper, clusterID, auxParams, args.verbose)
 	if err != nil {
 		return createKubeconfigResult{}, microerror.Mask(err)
 	}
@@ -426,7 +432,7 @@ func createKubeconfig(ctx context.Context, args Arguments) (createKubeconfigResu
 		CertificateOrganizations: args.certOrgs,
 	}
 
-	response, err := clientWrapper.CreateKeyPair(args.clusterID, addKeyPairBody, auxParams)
+	response, err := clientWrapper.CreateKeyPair(clusterID, addKeyPairBody, auxParams)
 	if err != nil {
 		// create specific error types for cases we care about
 		if clienterror.IsAccessForbiddenError(err) {
@@ -449,21 +455,21 @@ func createKubeconfig(ctx context.Context, args Arguments) (createKubeconfigResu
 	if args.selfContainedPath == "" {
 		// modify the given kubeconfig file
 		result.caCertPath = util.StoreCaCertificate(args.fileSystem, config.CertsDirPath,
-			args.clusterID, response.Payload.CertificateAuthorityData)
+			clusterID, response.Payload.CertificateAuthorityData)
 		result.clientCertPath = util.StoreClientCertificate(args.fileSystem, config.CertsDirPath,
-			args.clusterID, response.Payload.ID, response.Payload.ClientCertificateData)
+			clusterID, response.Payload.ID, response.Payload.ClientCertificateData)
 		result.clientKeyPath = util.StoreClientKey(args.fileSystem, config.CertsDirPath,
-			args.clusterID, response.Payload.ID, response.Payload.ClientKeyData)
+			clusterID, response.Payload.ID, response.Payload.ClientKeyData)
 		result.contextName = args.contextName
 
 		// edit kubectl config
-		if err := util.KubectlSetCluster(args.clusterID, result.apiEndpoint, result.caCertPath); err != nil {
+		if err := util.KubectlSetCluster(clusterID, result.apiEndpoint, result.caCertPath); err != nil {
 			return result, microerror.Mask(util.CouldNotSetKubectlClusterError)
 		}
-		if err := util.KubectlSetCredentials(args.clusterID, result.clientKeyPath, result.clientCertPath); err != nil {
+		if err := util.KubectlSetCredentials(clusterID, result.clientKeyPath, result.clientCertPath); err != nil {
 			return result, microerror.Mask(util.CouldNotSetKubectlCredentialsError)
 		}
-		if err := util.KubectlSetContext(args.contextName, args.clusterID); err != nil {
+		if err := util.KubectlSetContext(args.contextName, clusterID); err != nil {
 			return result, microerror.Mask(util.CouldNotSetKubectlContextError)
 		}
 		if err := util.KubectlUseContext(args.contextName); err != nil {
@@ -495,7 +501,7 @@ func createKubeconfig(ctx context.Context, args Arguments) (createKubeconfigResu
 				return result, microerror.Mask(err)
 			}
 
-			yamlBytes, err = kubeconfig.NewKubeConfigForRESTConfig(ctx, restConfig, fmt.Sprintf("giantswarm-%s", args.clusterID), "")
+			yamlBytes, err = kubeconfig.NewKubeConfigForRESTConfig(ctx, restConfig, fmt.Sprintf("giantswarm-%s", clusterID), "")
 			if err != nil {
 				return result, microerror.Mask(err)
 			}

--- a/commands/create/kubeconfig/command.go
+++ b/commands/create/kubeconfig/command.go
@@ -170,7 +170,7 @@ type createKubeconfigResult struct {
 }
 
 func init() {
-	Command.Flags().StringVarP(&flags.ClusterID, "cluster", "c", "", "ID of the cluster")
+	Command.Flags().StringVarP(&flags.ClusterID, "cluster", "c", "", "Name or ID of the cluster")
 	Command.Flags().StringVarP(&flags.Description, "description", "d", "", "Description for the key pair")
 	Command.Flags().StringVarP(&flags.CNPrefix, "cn-prefix", "", "", "The common name prefix for the issued certificates 'CN' field.")
 	Command.Flags().StringVarP(&cmdKubeconfigSelfContained, "self-contained", "", "", "Create a self-contained kubectl config with embedded credentials and write it to this path.")

--- a/commands/create/kubeconfig/command_test.go
+++ b/commands/create/kubeconfig/command_test.go
@@ -58,9 +58,9 @@ func makeMockServer() *httptest.Server {
 			{
 				"create_date": "2017-05-16T09:30:31.192170835Z",
 				"id": "test-cluster-id",
-				"name": "somecluster",
+				"name": "Name of the cluster",
 				"owner": "acme",
-				"path": "/v4/clusters/test-id/"
+				"path": "/v4/clusters/test-cluster-id/"
 			}
 		]`))
 		}
@@ -129,7 +129,7 @@ func Test_CreateKubeconfig(t *testing.T) {
 		t.Error(err)
 	}
 
-	if !strings.Contains(string(content), "current-context: giantswarm-"+args.clusterNameOrID) {
+	if !strings.Contains(string(content), "current-context: giantswarm-test-cluster-id") {
 		t.Error("Kubeconfig doesn't contain the expected current-context value")
 	}
 	if !strings.Contains(string(content), "client-certificate: "+configDir) {
@@ -201,7 +201,7 @@ func Test_CreateKubeconfigSelfContained(t *testing.T) {
 		t.Error(err)
 	}
 
-	if !strings.Contains(string(content), "current-context: giantswarm-"+args.clusterNameOrID) {
+	if !strings.Contains(string(content), "current-context: giantswarm-test-cluster-id") {
 		t.Error("Kubeconfig doesn't contain the expected current-context value")
 	}
 	if !strings.Contains(string(content), "client-certificate-data:") {

--- a/commands/create/kubeconfig/command_test.go
+++ b/commands/create/kubeconfig/command_test.go
@@ -94,7 +94,7 @@ func Test_CreateKubeconfig(t *testing.T) {
 	args := Arguments{
 		authToken:       "auth-token",
 		apiEndpoint:     mockServer.URL,
-		clusterNameOrID: "test-cluster-id",
+		clusterNameOrID: "Name of the cluster",
 		contextName:     "giantswarm-test-cluster-id",
 		fileSystem:      fs,
 	}
@@ -162,7 +162,7 @@ func Test_CreateKubeconfigSelfContained(t *testing.T) {
 	args := Arguments{
 		apiEndpoint:       mockServer.URL,
 		authToken:         "auth-token",
-		clusterNameOrID:   "test-cluster-id",
+		clusterNameOrID:   "Name of the cluster",
 		contextName:       "giantswarm-test-cluster-id",
 		fileSystem:        fs,
 		selfContainedPath: path.Join(tmpdir, "kubeconfig"),
@@ -243,7 +243,7 @@ func Test_CreateKubeconfigCustomContext(t *testing.T) {
 	args := Arguments{
 		apiEndpoint:     mockServer.URL,
 		authToken:       "auth-token",
-		clusterNameOrID: "test-cluster-id",
+		clusterNameOrID: "Name of the cluster",
 		contextName:     "test-context",
 		fileSystem:      fs,
 	}

--- a/commands/create/kubeconfig/command_test.go
+++ b/commands/create/kubeconfig/command_test.go
@@ -52,6 +52,17 @@ func makeMockServer() *httptest.Server {
 	        "id": "48:b9:01:ce:34:8f:b2:08:d3:4f:8c:bb:5e:2f:d7:b6:bc:ae:5c:98",
 	        "ttl_hours": 24
 	      }`))
+		} else if r.Method == "GET" && r.URL.String() == "/v4/clusters/" {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`[
+			{
+				"create_date": "2017-05-16T09:30:31.192170835Z",
+				"id": "test-cluster-id",
+				"name": "somecluster",
+				"owner": "acme",
+				"path": "/v4/clusters/test-id/"
+			}
+		]`))
 		}
 	}))
 }
@@ -81,11 +92,11 @@ func Test_CreateKubeconfig(t *testing.T) {
 	defer fs.RemoveAll(path.Dir(kubeConfigPath))
 
 	args := Arguments{
-		authToken:   "auth-token",
-		apiEndpoint: mockServer.URL,
-		clusterID:   "test-cluster-id",
-		contextName: "giantswarm-test-cluster-id",
-		fileSystem:  fs,
+		authToken:       "auth-token",
+		apiEndpoint:     mockServer.URL,
+		clusterNameOrID: "test-cluster-id",
+		contextName:     "giantswarm-test-cluster-id",
+		fileSystem:      fs,
 	}
 
 	err = verifyCreateKubeconfigPreconditions(args, []string{})
@@ -118,7 +129,7 @@ func Test_CreateKubeconfig(t *testing.T) {
 		t.Error(err)
 	}
 
-	if !strings.Contains(string(content), "current-context: giantswarm-"+args.clusterID) {
+	if !strings.Contains(string(content), "current-context: giantswarm-"+args.clusterNameOrID) {
 		t.Error("Kubeconfig doesn't contain the expected current-context value")
 	}
 	if !strings.Contains(string(content), "client-certificate: "+configDir) {
@@ -151,7 +162,7 @@ func Test_CreateKubeconfigSelfContained(t *testing.T) {
 	args := Arguments{
 		apiEndpoint:       mockServer.URL,
 		authToken:         "auth-token",
-		clusterID:         "test-cluster-id",
+		clusterNameOrID:   "test-cluster-id",
 		contextName:       "giantswarm-test-cluster-id",
 		fileSystem:        fs,
 		selfContainedPath: path.Join(tmpdir, "kubeconfig"),
@@ -190,7 +201,7 @@ func Test_CreateKubeconfigSelfContained(t *testing.T) {
 		t.Error(err)
 	}
 
-	if !strings.Contains(string(content), "current-context: giantswarm-"+args.clusterID) {
+	if !strings.Contains(string(content), "current-context: giantswarm-"+args.clusterNameOrID) {
 		t.Error("Kubeconfig doesn't contain the expected current-context value")
 	}
 	if !strings.Contains(string(content), "client-certificate-data:") {
@@ -230,11 +241,11 @@ func Test_CreateKubeconfigCustomContext(t *testing.T) {
 	defer fs.RemoveAll(path.Dir(kubeConfigPath))
 
 	args := Arguments{
-		apiEndpoint: mockServer.URL,
-		authToken:   "auth-token",
-		clusterID:   "test-cluster-id",
-		contextName: "test-context",
-		fileSystem:  fs,
+		apiEndpoint:     mockServer.URL,
+		authToken:       "auth-token",
+		clusterNameOrID: "test-cluster-id",
+		contextName:     "test-context",
+		fileSystem:      fs,
 	}
 
 	flags.APIEndpoint = mockServer.URL
@@ -284,11 +295,11 @@ func Test_CreateKubeconfigNoConnection(t *testing.T) {
 	}
 
 	args := Arguments{
-		authToken:   "auth-token",
-		apiEndpoint: "http://0.0.0.0:12345",
-		clusterID:   "test-cluster-id",
-		contextName: "giantswarm-test-cluster-id",
-		fileSystem:  fs,
+		authToken:       "auth-token",
+		apiEndpoint:     "http://0.0.0.0:12345",
+		clusterNameOrID: "test-cluster-id",
+		contextName:     "giantswarm-test-cluster-id",
+		fileSystem:      fs,
 	}
 
 	err = verifyCreateKubeconfigPreconditions(args, []string{})


### PR DESCRIPTION
Towards https://github.com/giantswarm/gsctl/issues/188

This adds support for using both cluster names and IDs with the `gsctl create kubeconfig` command.

All good 👍 Everything's working as expected