### PR TITLE
Update apps to use v4

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -728,9 +728,9 @@ func (w *Wrapper) GetClusterStatus(clusterID string, p *AuxiliaryParams) (*Clust
 }
 
 // CreateApp creates an App in a cluster.
-func (w *Wrapper) CreateApp(clusterID string, appName string, addAppRequest *models.V4CreateAppRequest, p *AuxiliaryParams) (*apps.CreateClusterAppOK, error) {
+func (w *Wrapper) CreateApp(clusterID string, appName string, addAppRequest *models.V4CreateAppRequest, p *AuxiliaryParams) (*apps.CreateClusterAppV4OK, error) {
 
-	params := apps.NewCreateClusterAppParams().WithClusterID(clusterID).WithAppName(appName).WithBody(addAppRequest)
+	params := apps.NewCreateClusterAppV4Params().WithClusterID(clusterID).WithAppName(appName).WithBody(addAppRequest)
 
 	setParams(p, w, params)
 
@@ -739,7 +739,7 @@ func (w *Wrapper) CreateApp(clusterID string, appName string, addAppRequest *mod
 		return nil, microerror.Mask(err)
 	}
 
-	response, err := w.gsclient.Apps.CreateClusterApp(params, authWriter)
+	response, err := w.gsclient.Apps.CreateClusterAppV4(params, authWriter)
 	if err != nil {
 		return nil, clienterror.New(err)
 	}
@@ -750,7 +750,7 @@ func (w *Wrapper) CreateApp(clusterID string, appName string, addAppRequest *mod
 //GetApp fetches details on a cluster using the gsclientgen client.
 func (w *Wrapper) GetApp(clusterID string, appName string, p *AuxiliaryParams) (*models.V4GetClusterAppsResponseItems, error) {
 
-	params := apps.NewGetClusterAppsParams().WithClusterID(clusterID)
+	params := apps.NewGetClusterAppsV4Params().WithClusterID(clusterID)
 
 	setParams(p, w, params)
 
@@ -759,7 +759,7 @@ func (w *Wrapper) GetApp(clusterID string, appName string, p *AuxiliaryParams) (
 		return nil, microerror.Mask(err)
 	}
 
-	response, err := w.gsclient.Apps.GetClusterApps(params, authWriter)
+	response, err := w.gsclient.Apps.GetClusterAppsV4(params, authWriter)
 	if err != nil {
 		return nil, clienterror.New(err)
 	}
@@ -778,7 +778,7 @@ func (w *Wrapper) GetApp(clusterID string, appName string, p *AuxiliaryParams) (
 // GetAppStatus fetches details on a cluster using the gsclientgen client.
 func (w *Wrapper) GetAppStatus(clusterID string, appName string, p *AuxiliaryParams) (string, error) {
 
-	params := apps.NewGetClusterAppsParams().WithClusterID(clusterID)
+	params := apps.NewGetClusterAppsV4Params().WithClusterID(clusterID)
 
 	setParams(p, w, params)
 
@@ -787,7 +787,7 @@ func (w *Wrapper) GetAppStatus(clusterID string, appName string, p *AuxiliaryPar
 		return "", microerror.Mask(err)
 	}
 
-	response, err := w.gsclient.Apps.GetClusterApps(params, authWriter)
+	response, err := w.gsclient.Apps.GetClusterAppsV4(params, authWriter)
 	if err != nil {
 		return "", clienterror.New(err)
 	}
@@ -805,8 +805,8 @@ func (w *Wrapper) GetAppStatus(clusterID string, appName string, p *AuxiliaryPar
 }
 
 // DeleteApp deletes an app using the gsclientgen client.
-func (w *Wrapper) DeleteApp(clusterID string, appName string, p *AuxiliaryParams) (*apps.DeleteClusterAppOK, error) {
-	params := apps.NewDeleteClusterAppParams().WithClusterID(clusterID).WithAppName(appName)
+func (w *Wrapper) DeleteApp(clusterID string, appName string, p *AuxiliaryParams) (*apps.DeleteClusterAppV4OK, error) {
+	params := apps.NewDeleteClusterAppV4Params().WithClusterID(clusterID).WithAppName(appName)
 	setParams(p, w, params)
 
 	authWriter, err := getAuthorization(w)
@@ -814,7 +814,7 @@ func (w *Wrapper) DeleteApp(clusterID string, appName string, p *AuxiliaryParams
 		return nil, microerror.Mask(err)
 	}
 
-	response, err := w.gsclient.Apps.DeleteClusterApp(params, authWriter)
+	response, err := w.gsclient.Apps.DeleteClusterAppV4(params, authWriter)
 	if err != nil {
 		return nil, clienterror.New(err)
 	}
@@ -823,9 +823,9 @@ func (w *Wrapper) DeleteApp(clusterID string, appName string, p *AuxiliaryParams
 }
 
 // ModifyApp modifies an app using the gsclientgen client.
-func (w *Wrapper) ModifyApp(clusterID string, appName string, body *models.V4ModifyAppRequest, p *AuxiliaryParams) (*apps.ModifyClusterAppOK, error) {
+func (w *Wrapper) ModifyApp(clusterID string, appName string, body *models.V4ModifyAppRequest, p *AuxiliaryParams) (*apps.ModifyClusterAppV4OK, error) {
 
-	params := apps.NewModifyClusterAppParams().WithClusterID(clusterID).WithAppName(appName).WithBody(body)
+	params := apps.NewModifyClusterAppV4Params().WithClusterID(clusterID).WithAppName(appName).WithBody(body)
 	setParams(p, w, params)
 
 	authWriter, err := getAuthorization(w)
@@ -833,7 +833,7 @@ func (w *Wrapper) ModifyApp(clusterID string, appName string, body *models.V4Mod
 		return nil, microerror.Mask(err)
 	}
 
-	response, err := w.gsclient.Apps.ModifyClusterApp(params, authWriter)
+	response, err := w.gsclient.Apps.ModifyClusterAppV4(params, authWriter)
 	if err != nil {
 		return nil, clienterror.New(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/giantswarm/apiextensions v0.0.0-20191213075442-71155aa0f5b7
 	github.com/giantswarm/columnize v2.0.3-0.20190718092621-cc99d98ffb29+incompatible
 	github.com/giantswarm/gscliauth v0.1.1-0.20200207091127-822ebfd95297
-	github.com/giantswarm/gsclientgen v2.0.3+incompatible
+	github.com/giantswarm/gsclientgen v2.0.4-0.20200325211540-6c98781fca72+incompatible
 	github.com/giantswarm/k8sclient v0.0.0-20191213144452-f75fead2ae06
 	github.com/giantswarm/kubeconfig v0.0.0-20191209121754-c5784ae65a49
 	github.com/giantswarm/microerror v0.0.0-20191011121515-e0ebc4ecf5a5

--- a/go.sum
+++ b/go.sum
@@ -101,6 +101,10 @@ github.com/giantswarm/gscliauth v0.1.1-0.20200207091127-822ebfd95297 h1:O0UN70TP
 github.com/giantswarm/gscliauth v0.1.1-0.20200207091127-822ebfd95297/go.mod h1:qYjj5CylbM318aJhK1qc912yMTp9fUk0na2IaIQU7xc=
 github.com/giantswarm/gsclientgen v2.0.3+incompatible h1:9s1LCJ1wHEqPkdeYxY3otmsXYIK0+OnL7AtQZxDMPA4=
 github.com/giantswarm/gsclientgen v2.0.3+incompatible/go.mod h1:w3fPQmyNcZPB0I/eULLADOfkk0VTSn8Pijvj7JacnNQ=
+github.com/giantswarm/gsclientgen v2.0.4-0.20200325154052-d6aaf1bed1d4+incompatible h1:ETpk/yV8f+L04gea1lSyjHVGT365d7ySaX29Qn6Rc2k=
+github.com/giantswarm/gsclientgen v2.0.4-0.20200325154052-d6aaf1bed1d4+incompatible/go.mod h1:w3fPQmyNcZPB0I/eULLADOfkk0VTSn8Pijvj7JacnNQ=
+github.com/giantswarm/gsclientgen v2.0.4-0.20200325211540-6c98781fca72+incompatible h1:9c+aaAKcAAPGCdZjaA7tKI5YYIzQFieKJz1SjeRo51w=
+github.com/giantswarm/gsclientgen v2.0.4-0.20200325211540-6c98781fca72+incompatible/go.mod h1:w3fPQmyNcZPB0I/eULLADOfkk0VTSn8Pijvj7JacnNQ=
 github.com/giantswarm/k8sclient v0.0.0-20191213144452-f75fead2ae06 h1:ARogDNpItRylPLIYWQqHLne7Cv1PnHahcGxx8/Zm+l4=
 github.com/giantswarm/k8sclient v0.0.0-20191213144452-f75fead2ae06/go.mod h1:XH0Ea+GvJOStcuamQyFSJXIQasGcPpHnWnHQVyG7AJc=
 github.com/giantswarm/kubeconfig v0.0.0-20191209121754-c5784ae65a49 h1:7A4URevsdTMdWlAnbYdryrfLdqBuHvyU2ans0oDEqck=


### PR DESCRIPTION
Following from https://github.com/giantswarm/gsclientgen/pull/54 and towards https://github.com/giantswarm/giantswarm/issues/8347

`gsctl` missed the versioned apps changes in https://github.com/giantswarm/api-spec/pull/192 so it needs to be updated with a newly generated `gsclientgen`.

As far as I can tell, these functions are here for https://github.com/giantswarm/giantswarm/issues/7033 but they're not really used yet so I think this change won't affect anything.