### PR TITLE
Use a token defined as an environmental variable, if it exists

### DIFF
--- a/commands/info/command.go
+++ b/commands/info/command.go
@@ -264,6 +264,7 @@ func getEnvironmentVariables() map[string]string {
 		"GSCTL_DISABLE_CMDLINE_TRACKING",
 		"GSCTL_DISABLE_COLORS",
 		"GSCTL_ENDPOINT",
+		"GSCTL_AUTH_TOKEN",
 		"HTTP_PROXY",
 		"KUBECONFIG",
 	}

--- a/commands/root.go
+++ b/commands/root.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/giantswarm/gscliauth/config"
 	"github.com/giantswarm/microerror"
@@ -51,6 +52,13 @@ func init() {
 	RootCommand.PersistentFlags().StringVarP(&flags.Token, "auth-token", "", "", "Authorization token to use")
 	RootCommand.PersistentFlags().StringVarP(&flags.ConfigDirPath, "config-dir", "", config.DefaultConfigDirPath, "Configuration directory path to use")
 	RootCommand.PersistentFlags().BoolVarP(&flags.Verbose, "verbose", "v", false, "Print more information")
+
+	// Use the auth token defined as an environmental variable,
+	// if it exists.
+	tokenFromEnv := os.Getenv("GSCTL_AUTH_TOKEN")
+	if tokenFromEnv != "" && flags.Token == "" {
+		flags.Token = tokenFromEnv
+	}
 
 	// add subcommands
 	RootCommand.AddCommand(CompletionCommand)

--- a/commands/root.go
+++ b/commands/root.go
@@ -49,16 +49,13 @@ var RootCommand = &cobra.Command{
 func init() {
 	RootCommand.PersistentFlags().StringVarP(&flags.APIEndpoint, "endpoint", "e", "", "The API endpoint to use")
 
-	RootCommand.PersistentFlags().StringVarP(&flags.Token, "auth-token", "", "", "Authorization token to use")
-	RootCommand.PersistentFlags().StringVarP(&flags.ConfigDirPath, "config-dir", "", config.DefaultConfigDirPath, "Configuration directory path to use")
-	RootCommand.PersistentFlags().BoolVarP(&flags.Verbose, "verbose", "v", false, "Print more information")
-
 	// Use the auth token defined as an environmental variable,
 	// if it exists.
 	tokenFromEnv := os.Getenv("GSCTL_AUTH_TOKEN")
-	if tokenFromEnv != "" && flags.Token == "" {
-		flags.Token = tokenFromEnv
-	}
+
+	RootCommand.PersistentFlags().StringVarP(&flags.Token, "auth-token", "", tokenFromEnv, "Authorization token to use")
+	RootCommand.PersistentFlags().StringVarP(&flags.ConfigDirPath, "config-dir", "", config.DefaultConfigDirPath, "Configuration directory path to use")
+	RootCommand.PersistentFlags().BoolVarP(&flags.Verbose, "verbose", "v", false, "Print more information")
 
 	// add subcommands
 	RootCommand.AddCommand(CompletionCommand)


### PR DESCRIPTION
Closes https://github.com/giantswarm/gsctl/issues/121

This gives the user the power to use an auth token set as an environmental variable.

This makes the environmental variable token behave like the token was provided as a flag. The reason for doing this in the root command, and not in the `gscliauth` config token selector, is because there is already some logic for overriding the token and using the one provided as a flag (such as defaulting the auth scheme to our GS API one).

Also, the auth token defined as an env variable has less priority than the one provided as a flag.

### Preview

![image](https://user-images.githubusercontent.com/13508038/79364149-3367c400-7f49-11ea-8981-a950e78cdfcb.png)

