### PR TITLE
Confirm TTL duration (if too long) when creating keypairs/kubeconfigs

### DIFF
--- a/commands/create/keypair/command.go
+++ b/commands/create/keypair/command.go
@@ -40,7 +40,9 @@ var (
 
 const (
 	activityName = "add-keypair"
-	maxTTLHours  = 30 * 24 // 30 days
+
+	// Maximum TTL (in hours)
+	maxTTLHours = 30 * 24 // 30 days
 )
 
 // Arguments struct to pass to our business function and

--- a/commands/create/keypair/command.go
+++ b/commands/create/keypair/command.go
@@ -41,8 +41,8 @@ var (
 const (
 	activityName = "add-keypair"
 
-	// Maximum TTL (in hours)
-	maxTTLHours = 30 * 24 // 30 days
+	// Maximum safe TTL (in hours)
+	maxSafeTTLHours = 30 * 24 // 30 days
 )
 
 // Arguments struct to pass to our business function and
@@ -142,7 +142,7 @@ func printValidation(cmd *cobra.Command, cmdLineArgs []string) {
 		os.Exit(1)
 	}
 
-	if !arguments.force && arguments.ttlHours >= maxTTLHours {
+	if !arguments.force && arguments.ttlHours >= maxSafeTTLHours {
 		fmt.Println("The desired expiry date is pretty far away.")
 		fmt.Println("There is no way to revoke keypairs once they've been created.")
 		question := fmt.Sprintf("Are you sure you want to set the TTL to %s?", flags.TTL)

--- a/commands/create/keypair/command.go
+++ b/commands/create/keypair/command.go
@@ -143,7 +143,9 @@ func printValidation(cmd *cobra.Command, cmdLineArgs []string) {
 	}
 
 	if !arguments.force && arguments.ttlHours >= maxTTLHours {
-		question := fmt.Sprintf("The desired expiry date is pretty far away. Are you sure you want to set the TTL to %s?", flags.TTL)
+		fmt.Println("The desired expiry date is pretty far away.")
+		fmt.Println("There is no way to revoke keypairs once they've been created.")
+		question := fmt.Sprintf("Are you sure you want to set the TTL to %s?", flags.TTL)
 		confirmed := confirm.Ask(question)
 		if !confirmed {
 			os.Exit(0)

--- a/commands/create/keypair/command.go
+++ b/commands/create/keypair/command.go
@@ -111,7 +111,7 @@ func init() {
 	Command.Flags().StringVarP(&flags.Description, "description", "d", "", "Description for the key pair")
 	Command.Flags().StringVarP(&flags.CNPrefix, "cn-prefix", "", "", "The common name prefix for the issued certificates 'CN' field.")
 	Command.Flags().StringVarP(&flags.CertificateOrganizations, "certificate-organizations", "", "", "A comma separated list of organizations for the issued certificates 'O' fields.")
-	Command.Flags().StringVarP(&flags.TTL, "ttl", "", "30d", "Lifetime of the created key pair, e.g. 3h. Allowed units: h, d, w, m, y.")
+	Command.Flags().StringVarP(&flags.TTL, "ttl", "", "1d", "Lifetime of the created key pair, e.g. 3h. Allowed units: h, d, w, m, y.")
 
 	Command.MarkFlagRequired("cluster")
 }
@@ -126,7 +126,7 @@ func printValidation(cmd *cobra.Command, cmdLineArgs []string) {
 			fmt.Println("Please provide a number and a unit, e. g. '10h', '1d', '1w'.")
 		} else if errors.IsDurationExceededError(argsErr) {
 			fmt.Println(color.RedString("The expiration period passed with --ttl is too long."))
-			fmt.Println("The maximum possible value is the eqivalent of 292 years.")
+			fmt.Println("The maximum possible value is the equivalent of 292 years.")
 		} else {
 			fmt.Println(color.RedString(argsErr.Error()))
 		}

--- a/commands/create/keypair/command_test.go
+++ b/commands/create/keypair/command_test.go
@@ -54,6 +54,7 @@ func Test_CreateKeypair(t *testing.T) {
 		authToken:       "test-token",
 		clusterNameOrID: "test-cluster-id",
 		fileSystem:      fs,
+		force:           true,
 	}
 
 	err = verifyPreconditions(args)

--- a/commands/create/kubeconfig/command.go
+++ b/commands/create/kubeconfig/command.go
@@ -205,7 +205,9 @@ func createKubeconfigPreRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 	}
 
 	if !arguments.force && arguments.ttlHours >= maxTTLHours {
-		question := fmt.Sprintf("The desired expiry date is pretty far away. Are you sure you want to set the TTL to %s?", flags.TTL)
+		fmt.Println("The desired expiry date is pretty far away.")
+		fmt.Println("There is no way to revoke keypairs once they've been created.")
+		question := fmt.Sprintf("Are you sure you want to set the TTL to %s?", flags.TTL)
 		confirmed := confirm.Ask(question)
 		if !confirmed {
 			os.Exit(0)

--- a/commands/create/kubeconfig/command.go
+++ b/commands/create/kubeconfig/command.go
@@ -87,8 +87,8 @@ const (
 
 	urlDelimiter = "."
 
-	// Maximum TTL (in hours)
-	maxTTLHours = 30 * 24 // 30 days
+	// Maximum safe TTL (in hours)
+	maxSafeTTLHours = 30 * 24 // 30 days
 )
 
 // Arguments is an argument struct to pass to our business
@@ -204,7 +204,7 @@ func createKubeconfigPreRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
 		os.Exit(1)
 	}
 
-	if !arguments.force && arguments.ttlHours >= maxTTLHours {
+	if !arguments.force && arguments.ttlHours >= maxSafeTTLHours {
 		fmt.Println("The desired expiry date is pretty far away.")
 		fmt.Println("There is no way to revoke keypairs once they've been created.")
 		question := fmt.Sprintf("Are you sure you want to set the TTL to %s?", flags.TTL)

--- a/commands/create/kubeconfig/command.go
+++ b/commands/create/kubeconfig/command.go
@@ -178,7 +178,7 @@ func init() {
 	Command.Flags().StringVarP(&flags.CertificateOrganizations, "certificate-organizations", "", "", "A comma separated list of organizations for the issued certificates 'O' fields.")
 	Command.Flags().BoolVarP(&flags.Force, "force", "", false, "If set, --self-contained will overwrite existing files without interactive confirmation.")
 	Command.Flags().BoolVarP(&flags.TenantInternal, "tenant-internal", "", false, "If set, kubeconfig will be rendered with internal Kubernets API address.")
-	Command.Flags().StringVarP(&flags.TTL, "ttl", "", "30d", "Lifetime of the created key pair, e.g. 3h. Allowed units: h, d, w, m, y.")
+	Command.Flags().StringVarP(&flags.TTL, "ttl", "", "1d", "Lifetime of the created key pair, e.g. 3h. Allowed units: h, d, w, m, y.")
 
 	Command.MarkFlagRequired("cluster")
 }


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/4630

* Works for both `create keypair` and `create kubeconfig`
* Changed default TTL value from `30d` to `1d`
* Ask for confirmation if TTL >= 30d
* Use `--force` to bypass the TTL check

## Preview

**Validation**
![image](https://user-images.githubusercontent.com/13508038/79464534-7766d180-7ffa-11ea-9a65-2448ff89782d.png)

**Force mode**
![image](https://user-images.githubusercontent.com/13508038/79458972-e0e2e200-7ff2-11ea-8a88-85bba289955d.png)
