### PR TITLE
Replace go build version with 1.14.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PROJECT=gsctl
 ORGANISATION=giantswarm
 BIN=$(PROJECT)
-GOVERSION := 1.13.5
+GOVERSION := 1.14.0
 BUILDDATE := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 COMMITHASH := $(shell git rev-parse HEAD)
 VERSION := $(shell (test -f VERSION && cat VERSION) || echo "")


### PR DESCRIPTION
Forgot this in the go1.14 upgrade PR (https://github.com/giantswarm/gsctl/pull/539)