### PR TITLE
Validate instance type before sending server request

### DIFF
--- a/commands/create/cluster/command.go
+++ b/commands/create/cluster/command.go
@@ -397,16 +397,24 @@ func addCluster(args Arguments) (*creationResult, error) {
 	auxParams := clientWrapper.DefaultAuxiliaryParams()
 	auxParams.ActivityName = createClusterActivityName
 
+	info, err := clientWrapper.GetInfo(auxParams)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
 	var instanceTypes []string
+	{
+		if info.Payload.General.Provider == "azure" {
+			instanceTypes = info.Payload.Workers.VMSize.Options
+		} else if info.Payload.General.Provider == "aws" {
+			instanceTypes = info.Payload.Workers.InstanceType.Options
+		}
+	}
+
 	// Ensure provider information is there.
 	if config.Config.Provider == "" {
 		if flags.Verbose {
 			fmt.Println(color.WhiteString("Fetching installation information"))
-		}
-
-		info, err := clientWrapper.GetInfo(auxParams)
-		if err != nil {
-			return nil, microerror.Mask(err)
 		}
 
 		if info.Payload.General.Provider == "azure" {

--- a/commands/create/cluster/command.go
+++ b/commands/create/cluster/command.go
@@ -245,6 +245,9 @@ func printResult(cmd *cobra.Command, positionalArgs []string) {
 			if arguments.InputYAMLFile != "" {
 				subtext = "Please specify an owner organization for the cluster in your definition file or set one via the --owner flag."
 			}
+		case errors.IsClusterInstanceTypeNotFoundError(err):
+			headline = "Instance type not found"
+			subtext = "Please specify a valid instance type. You can run 'gsctl info' to get a list of all available ones."
 		case errors.IsYAMLNotParseable(err):
 			headline = "Could not parse YAML"
 			if arguments.InputYAMLFile == standardInputSpecialPath {
@@ -394,6 +397,7 @@ func addCluster(args Arguments) (*creationResult, error) {
 	auxParams := clientWrapper.DefaultAuxiliaryParams()
 	auxParams.ActivityName = createClusterActivityName
 
+	var instanceTypes []string
 	// Ensure provider information is there.
 	if config.Config.Provider == "" {
 		if flags.Verbose {
@@ -403,6 +407,12 @@ func addCluster(args Arguments) (*creationResult, error) {
 		info, err := clientWrapper.GetInfo(auxParams)
 		if err != nil {
 			return nil, microerror.Mask(err)
+		}
+
+		if info.Payload.General.Provider == "azure" {
+			instanceTypes = info.Payload.Workers.VMSize.Options
+		} else if info.Payload.General.Provider == "aws" {
+			instanceTypes = info.Payload.Workers.InstanceType.Options
 		}
 
 		err = config.Config.SetProvider(info.Payload.General.Provider)
@@ -541,6 +551,15 @@ func addCluster(args Arguments) (*creationResult, error) {
 		}
 
 		updateDefinitionFromFlagsV4(result.DefinitionV4, args.ClusterName, args.ReleaseVersion, args.Owner)
+
+		// If instanceTypes is nil, it means that the provider is KVM,
+		// so we won't validate.
+		{
+			valid := validateInstanceTypes(result.DefinitionV4, instanceTypes, config.Config.Provider)
+			if !valid {
+				return nil, microerror.Mask(errors.ClusterInstanceTypeNotFoundError)
+			}
+		}
 
 		id, location, err := addClusterV4(result.DefinitionV4, args, clientWrapper, auxParams)
 		if err != nil {

--- a/commands/create/cluster/command_test.go
+++ b/commands/create/cluster/command_test.go
@@ -325,6 +325,12 @@ func Test_CreateClusterSuccessfully(t *testing.T) {
 					},
 					"features": {
 					  "nodepools": {"release_version_minimum": "9.0.0"}
+					},
+					"workers": {
+					  "instance_type": {
+					    "default": "standard",
+						"options": ["standard", "hiram", "hicpu"]
+					  }
 					}
 				  }`))
 			} else if r.Method == "GET" && r.URL.String() == "/v4/releases/" {
@@ -440,6 +446,12 @@ func Test_CreateClusterExecutionFailures(t *testing.T) {
 					},
 					"features": {
 					  "nodepools": {"release_version_minimum": "9.0.0"}
+					},
+					"workers": {
+					  "instance_type": {
+					    "default": "standard",
+						"options": ["standard", "hiram", "hicpu"]
+					  }
 					}
 				  }`))
 			} else {

--- a/commands/create/cluster/command_test.go
+++ b/commands/create/cluster/command_test.go
@@ -436,7 +436,7 @@ func Test_CreateClusterExecutionFailures(t *testing.T) {
 
 		// mock server
 		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			//t.Log("mockServer request: ", r.Method, r.URL)
+			// t.Log("mockServer request: ", r.Method, r.URL)
 			if r.Method == "GET" && r.URL.String() == "/v4/info/" {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
@@ -572,7 +572,7 @@ func Test_getLatestActiveReleaseVersion(t *testing.T) {
 
 		// mock server
 		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			//t.Log("mockServer request: ", r.Method, r.URL)
+			// t.Log("mockServer request: ", r.Method, r.URL)
 			if r.Method == "GET" && r.URL.String() == "/v4/releases/" {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
@@ -605,6 +605,85 @@ func Test_getLatestActiveReleaseVersion(t *testing.T) {
 
 		if latest != tc.latestRelease {
 			t.Errorf("Test case %d: Expected '%s' but got '%s'", i, tc.latestRelease, latest)
+		}
+	}
+}
+
+// Test_validateInstanceTypes checks that the instance type validation is working as expected.
+func Test_validateInstanceTypes(t *testing.T) {
+	var testCases = []struct {
+		clusterDefinition *types.ClusterDefinitionV4
+		instanceTypes     []string
+		provider          string
+		result            bool
+	}{
+		{
+			clusterDefinition: &types.ClusterDefinitionV4{
+				Name:           "UnitTestCluster",
+				Owner:          "acme",
+				ReleaseVersion: "0.3.0",
+			},
+			instanceTypes: []string{"small", "med", "large"},
+			provider:      "aws",
+			result:        true,
+		},
+		{
+			clusterDefinition: &types.ClusterDefinitionV4{
+				Name:           "UnitTestCluster",
+				Owner:          "acme",
+				ReleaseVersion: "0.3.0",
+				Workers: []types.NodeDefinition{
+					{
+						AWS: types.AWSSpecificDefinition{
+							InstanceType: "med",
+						},
+					},
+				},
+			},
+			instanceTypes: []string{"small", "med", "large"},
+			provider:      "aws",
+			result:        true,
+		},
+		{
+			clusterDefinition: &types.ClusterDefinitionV4{
+				Name:           "UnitTestCluster",
+				Owner:          "acme",
+				ReleaseVersion: "0.3.0",
+				Workers: []types.NodeDefinition{
+					{
+						AWS: types.AWSSpecificDefinition{
+							InstanceType: "someother",
+						},
+					},
+				},
+			},
+			instanceTypes: []string{"small", "med", "large"},
+			provider:      "aws",
+			result:        false,
+		},
+		{
+			clusterDefinition: &types.ClusterDefinitionV4{
+				Name:           "UnitTestCluster",
+				Owner:          "acme",
+				ReleaseVersion: "0.3.0",
+				Workers: []types.NodeDefinition{
+					{
+						Azure: types.AzureSpecificDefinition{
+							VMSize: "small",
+						},
+					},
+				},
+			},
+			instanceTypes: []string{"small", "med", "large"},
+			provider:      "azure",
+			result:        true,
+		},
+	}
+
+	for i, tc := range testCases {
+		result := validateInstanceTypes(tc.clusterDefinition, tc.instanceTypes, tc.provider)
+		if result != tc.result {
+			t.Errorf("Test case %d: Expected '%t', got '%t'", i, tc.result, result)
 		}
 	}
 }

--- a/commands/create/cluster/v4.go
+++ b/commands/create/cluster/v4.go
@@ -120,6 +120,10 @@ func addClusterV4(def *types.ClusterDefinitionV4, args Arguments, clientWrapper 
 }
 
 func validateInstanceTypes(def *types.ClusterDefinitionV4, instanceTypes []string, provider string) bool {
+	if len(def.Workers) == 0 {
+		return true
+	}
+
 	var chosenInstance string
 	{
 		if provider == "aws" {
@@ -129,7 +133,7 @@ func validateInstanceTypes(def *types.ClusterDefinitionV4, instanceTypes []strin
 		}
 
 		if chosenInstance == "" {
-			return false
+			return true
 		}
 	}
 

--- a/commands/create/cluster/v4.go
+++ b/commands/create/cluster/v4.go
@@ -118,3 +118,26 @@ func addClusterV4(def *types.ClusterDefinitionV4, args Arguments, clientWrapper 
 
 	return id, location, nil
 }
+
+func validateInstanceTypes(def *types.ClusterDefinitionV4, instanceTypes []string, provider string) bool {
+	var chosenInstance string
+	{
+		if provider == "aws" {
+			chosenInstance = def.Workers[0].AWS.InstanceType
+		} else if provider == "azure" {
+			chosenInstance = def.Workers[0].Azure.VMSize
+		}
+
+		if chosenInstance == "" {
+			return false
+		}
+	}
+
+	for _, instance := range instanceTypes {
+		if instance == chosenInstance {
+			return true
+		}
+	}
+
+	return false
+}

--- a/commands/errors/errors.go
+++ b/commands/errors/errors.go
@@ -3,8 +3,9 @@
 package errors
 
 import (
-	"github.com/giantswarm/gsctl/client/clienterror"
 	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/gsctl/client/clienterror"
 )
 
 // UnknownError should be thrown if we have no idea what went wrong.
@@ -229,6 +230,17 @@ var ClusterOwnerMissingError = &microerror.Error{
 // IsClusterOwnerMissingError asserts ClusterOwnerMissingError.
 func IsClusterOwnerMissingError(err error) bool {
 	return microerror.Cause(err) == ClusterOwnerMissingError
+}
+
+// ClusterInstanceTypeNotFoundError means that the user has specified
+// an instance type that was not found.
+var ClusterInstanceTypeNotFoundError = &microerror.Error{
+	Kind: "ClusterInstanceTypeNotFoundError",
+}
+
+// IsClusterInstanceTypeNotFoundError asserts ClusterInstanceTypeNotFoundError.
+func IsClusterInstanceTypeNotFoundError(err error) bool {
+	return microerror.Cause(err) == ClusterInstanceTypeNotFoundError
 }
 
 // OrganizationNotFoundError means that the specified organization could not be found


### PR DESCRIPTION
Fixes https://github.com/giantswarm/gsctl/issues/145

Even if the api provides an error if the instance type is not found, we can re-use the data we previously fetched on the client and quickly check if the instance type is available or not.

**Preview**

![image](https://user-images.githubusercontent.com/13508038/80738770-c726bc00-8b15-11ea-97b3-d2422dbe9745.png)
