### PR TITLE
Upgrade to Go 1.14.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.13.5
+      - image: circleci/golang:1.14.2
 
     # We use 'large' because with 'medium' an 'medium#' we saw tests fail due to memory problems and too many threads.
     resource_class: large

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PROJECT=gsctl
 ORGANISATION=giantswarm
 BIN=$(PROJECT)
-GOVERSION := 1.14.0
+GOVERSION := 1.14.2
 BUILDDATE := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 COMMITHASH := $(shell git rev-parse HEAD)
 VERSION := $(shell (test -f VERSION && cat VERSION) || echo "")


### PR DESCRIPTION
Recent upgrade to 1.14.0 https://github.com/giantswarm/gsctl/pull/540 broke building gsctl from source for me. I'm on Pop!_OS, Ubuntu based distro. Build would fail like this:

```
$ gsctl git:(master) make clean install
rm -rf bin-dist build go-build-cache release ./gsctl
mkdir -p /home/stevo/git/giantswarm/gsctl/go-build-cache
chown -R 1000:1000 /home/stevo/git/giantswarm/gsctl/go-build-cache
docker run --rm \
	-v /home/stevo/git/giantswarm/gsctl:/go/src/github.com/giantswarm/gsctl \
	-v /home/stevo/git/giantswarm/gsctl/go-build-cache:/.cache \
	-e GOPATH=/go -e GOOS=linux -e GOARCH=amd64 \
	-w /go/src/github.com/giantswarm/gsctl \
	--user 1000:1000 \
	golang:1.14.0-alpine /bin/sh -c "go install github.com/gobuffalo/packr/packr && packr"
runtime: mlock of signal stack failed: 12
runtime: increase the mlock limit (ulimit -l) or
runtime: update your kernel to 5.3.15+, 5.4.2+, or 5.5+
fatal error: mlock failed

runtime stack:
...
```

There's upstream issue https://github.com/golang/go/issues/37436

It's a long thread. Seems Go 1.14.0 is affected by some kernel bug, which is fixed in kernel versions 5.3.15+, 5.4.2+, or 5.5+, so they checked for kernel version and panic if kernel version is not satisfied; but it turns out kernel fix has been cherry-picked by different distros to older kernel versions too. Problem is Go has no easy way to verify if kernel fix is included in given version or not. At least one idea was https://github.com/golang/go/issues/37436#issuecomment-597360484
Seems it was implemented for future 1.15.0 but also cherry picked for 1.14.1
- cherry pick issue https://github.com/golang/go/issues/37807
- cherry pick commit https://github.com/golang/go/commit/c5125098b23067a274a49aaa0c39a12abcc45704
- wiki page https://github.com/golang/go/wiki/LinuxKernelSignalVectorBug

Since 1.14.2 is available already this PR upgrades to it.