### PR TITLE
Make the scale cluster command support atomic parameters

### DIFF
--- a/commands/scale/cluster/command.go
+++ b/commands/scale/cluster/command.go
@@ -356,7 +356,7 @@ func scaleCluster(args Arguments) (*Result, error) {
 	// Preparing API call.
 	var reqBody *models.V4ModifyClusterRequest
 	{
-		minWorkers := int64(scalingResult.ScalingMaxBefore)
+		minWorkers := int64(scalingResult.ScalingMinBefore)
 		if args.WorkersMinSet {
 			minWorkers = args.WorkersMin
 		}

--- a/commands/scale/cluster/command_test.go
+++ b/commands/scale/cluster/command_test.go
@@ -292,20 +292,26 @@ func TestScaleCluster(t *testing.T) {
 		initialMinScaling int
 		desiredMinScaling int
 		workersMinSet     bool
+		resultWorkersMin  int
+
 		initialMaxScaling int
 		desiredMaxScaling int
 		workersMaxSet     bool
 		numWorkersAfter   int
+		resultWorkersMax  int
 	}{
 		{
 			numWorkersBefore:  3,
 			initialMinScaling: 3,
 			desiredMinScaling: 5,
 			workersMinSet:     true,
+			resultWorkersMin:  5,
+
 			initialMaxScaling: 3,
 			desiredMaxScaling: 5,
 			workersMaxSet:     true,
 			numWorkersAfter:   5,
+			resultWorkersMax:  5,
 		},
 	}
 
@@ -419,9 +425,9 @@ selected_endpoint: ` + mockServer.URL
 			expectedResult := Result{
 				NumWorkersBefore: tc.numWorkersBefore,
 				ScalingMinBefore: tc.initialMinScaling,
-				ScalingMinAfter:  tc.desiredMinScaling,
+				ScalingMinAfter:  tc.resultWorkersMin,
 				ScalingMaxBefore: tc.initialMaxScaling,
-				ScalingMaxAfter:  tc.desiredMaxScaling,
+				ScalingMaxAfter:  tc.resultWorkersMax,
 			}
 			if diff := cmp.Diff(expectedResult, *result); diff != "" {
 				t.Errorf("Case %d: Scaling result unequal. (-expected +got):\n%s", i, diff)

--- a/commands/scale/cluster/command_test.go
+++ b/commands/scale/cluster/command_test.go
@@ -288,7 +288,8 @@ func TestScaleClusterNotLoggedIn(t *testing.T) {
 // user logged in.
 func TestScaleCluster(t *testing.T) {
 	testCases := []struct {
-		numWorkersBefore  int
+		numWorkersBefore int
+
 		initialMinScaling int
 		desiredMinScaling int
 		workersMinSet     bool
@@ -297,11 +298,13 @@ func TestScaleCluster(t *testing.T) {
 		initialMaxScaling int
 		desiredMaxScaling int
 		workersMaxSet     bool
-		numWorkersAfter   int
 		resultWorkersMax  int
+
+		numWorkersAfter int
 	}{
 		{
-			numWorkersBefore:  3,
+			numWorkersBefore: 3,
+
 			initialMinScaling: 3,
 			desiredMinScaling: 5,
 			workersMinSet:     true,
@@ -310,8 +313,54 @@ func TestScaleCluster(t *testing.T) {
 			initialMaxScaling: 3,
 			desiredMaxScaling: 5,
 			workersMaxSet:     true,
-			numWorkersAfter:   5,
 			resultWorkersMax:  5,
+
+			numWorkersAfter: 5,
+		},
+		{
+			numWorkersBefore: 4,
+
+			initialMinScaling: 3,
+			desiredMinScaling: 5,
+			workersMinSet:     true,
+			resultWorkersMin:  5,
+
+			initialMaxScaling: 6,
+			desiredMaxScaling: 10,
+			workersMaxSet:     true,
+			resultWorkersMax:  10,
+
+			numWorkersAfter: 4,
+		},
+		{
+			numWorkersBefore: 4,
+
+			initialMinScaling: 3,
+			desiredMinScaling: 5,
+			workersMinSet:     true,
+			resultWorkersMin:  5,
+
+			initialMaxScaling: 6,
+			desiredMaxScaling: 10,
+			workersMaxSet:     false,
+			resultWorkersMax:  6,
+
+			numWorkersAfter: 4,
+		},
+		{
+			numWorkersBefore: 10,
+
+			initialMinScaling: 8,
+			desiredMinScaling: 10,
+			workersMinSet:     false,
+			resultWorkersMin:  8,
+
+			initialMaxScaling: 8,
+			desiredMaxScaling: 10,
+			workersMaxSet:     true,
+			resultWorkersMax:  10,
+
+			numWorkersAfter: 8,
 		},
 	}
 

--- a/commands/scale/cluster/command_test.go
+++ b/commands/scale/cluster/command_test.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"encoding/json"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -11,10 +12,12 @@ import (
 
 	"github.com/Jeffail/gabs"
 	"github.com/giantswarm/gscliauth/config"
-	"github.com/giantswarm/gsctl/client"
+	"github.com/giantswarm/gsclientgen/models"
 	"github.com/giantswarm/microerror"
 	"github.com/google/go-cmp/cmp"
 	"github.com/spf13/afero"
+
+	"github.com/giantswarm/gsctl/client"
 
 	"github.com/giantswarm/gsctl/commands/errors"
 	"github.com/giantswarm/gsctl/testutils"
@@ -284,60 +287,57 @@ func TestScaleClusterNotLoggedIn(t *testing.T) {
 // TestScaleCluster tests scaling a cluster under normal conditions:
 // user logged in.
 func TestScaleCluster(t *testing.T) {
-	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Logf("mockServer: %s %s", r.Method, r.URL.String())
-		w.Header().Set("Content-Type", "application/json")
-		if r.Method == "GET" && r.URL.String() == "/v4/clusters/cluster-id/" {
-			// cluster details before the patch
-			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{
-				"id": "cluster-id",
-				"name": "",
-				"api_endpoint": "",
-				"create_date": "2017-05-16T09:30:31.192170835Z",
-				"owner": "acmeorg",
-				"scaling": {
-					"max":3,
-					"min":3
-				},
-				"workers": [
-					{"memory": {"size_gb": 5}, "storage": {"size_gb": 50}, "cpu": {"cores": 2}, "labels": {"foo": "bar"}},
-					{"memory": {"size_gb": 5}, "storage": {"size_gb": 50}, "cpu": {"cores": 2}, "labels": {"foo": "bar"}},
-					{"memory": {"size_gb": 5}, "storage": {"size_gb": 50}, "cpu": {"cores": 2}, "labels": {"foo": "bar"}}
-				]
-			}`))
-		} else if r.Method == "PATCH" && r.URL.String() == "/v4/clusters/cluster-id/" {
-			// inspect PATCH request body
-			w.WriteHeader(http.StatusOK)
-			patchBytes, readErr := ioutil.ReadAll(r.Body)
-			if readErr != nil {
-				t.Error(readErr)
-			}
-			patch, parseErr := gabs.ParseJSON(patchBytes)
-			if parseErr != nil {
-				t.Error(parseErr)
-			}
-			if !patch.Exists("workers") {
-				t.Error("Patch request body does not contain 'workers' key.")
-			}
+	testCases := []struct {
+		numWorkersBefore  int
+		initialMinScaling int
+		desiredMinScaling int
+		workersMinSet     bool
+		initialMaxScaling int
+		desiredMaxScaling int
+		workersMaxSet     bool
+		numWorkersAfter   int
+	}{
+		{
+			numWorkersBefore:  3,
+			initialMinScaling: 3,
+			desiredMinScaling: 5,
+			workersMinSet:     true,
+			initialMaxScaling: 3,
+			desiredMaxScaling: 5,
+			workersMaxSet:     true,
+			numWorkersAfter:   5,
+		},
+	}
 
-			w.Write([]byte(`{
-				"id": "cluster-id",
-				"name": "",
-				"api_endpoint": "",
-				"create_date": "2017-05-16T09:30:31.192170835Z",
-				"owner": "acmeorg",
-				"workers": [
-					{"memory": {"size_gb": 5}, "storage": {"size_gb": 50}, "cpu": {"cores": 2}, "labels": {"foo": "bar"}},
-					{"memory": {"size_gb": 5}, "storage": {"size_gb": 50}, "cpu": {"cores": 2}, "labels": {"foo": "bar"}},
-					{"memory": {"size_gb": 5}, "storage": {"size_gb": 50}, "cpu": {"cores": 2}, "labels": {"foo": "bar"}},
-					{"memory": {"size_gb": 5}, "storage": {"size_gb": 50}, "cpu": {"cores": 2}, "labels": {"foo": "bar"}},
-					{"memory": {"size_gb": 5}, "storage": {"size_gb": 50}, "cpu": {"cores": 2}, "labels": {"foo": "bar"}}
-				]
-			}`))
-		} else if r.Method == "GET" && r.URL.String() == "/v4/clusters/cluster-id/status/" {
-			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				t.Logf("mockServer: %s %s", r.Method, r.URL.String())
+				w.Header().Set("Content-Type", "application/json")
+				if r.Method == "GET" && r.URL.String() == "/v4/clusters/cluster-id/" {
+					// cluster details before the patch
+					w.WriteHeader(http.StatusOK)
+					w.Write(generateClusterResponse(tc.numWorkersBefore, tc.initialMinScaling, tc.initialMaxScaling))
+				} else if r.Method == "PATCH" && r.URL.String() == "/v4/clusters/cluster-id/" {
+					// inspect PATCH request body
+					w.WriteHeader(http.StatusOK)
+					patchBytes, readErr := ioutil.ReadAll(r.Body)
+					if readErr != nil {
+						t.Error(readErr)
+					}
+					patch, parseErr := gabs.ParseJSON(patchBytes)
+					if parseErr != nil {
+						t.Error(parseErr)
+					}
+					if !patch.Exists("workers") {
+						t.Error("Patch request body does not contain 'workers' key.")
+					}
+
+					w.Write(generateClusterResponse(tc.numWorkersAfter, 0, 0))
+				} else if r.Method == "GET" && r.URL.String() == "/v4/clusters/cluster-id/status/" {
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte(`{
 				"cluster": {
 					"conditions": [
 						{
@@ -370,60 +370,97 @@ func TestScaleCluster(t *testing.T) {
 					]
 				}
 			}`))
-		} else {
-			w.WriteHeader(http.StatusNotFound)
-			w.Write([]byte(`{"code": "RESOURCE_NOT_FOUND", "message": "Could not find this."}`))
-		}
-	}))
-	defer mockServer.Close()
+				} else {
+					w.WriteHeader(http.StatusNotFound)
+					w.Write([]byte(`{"code": "RESOURCE_NOT_FOUND", "message": "Could not find this."}`))
+				}
+			}))
+			defer mockServer.Close()
 
-	// config
-	yamlText := `
+			// config
+			yamlText := `
 endpoints:
   ` + mockServer.URL + `:
     email: email@example.com
     token: some-token
     provider: aws
 selected_endpoint: ` + mockServer.URL
-	fs := afero.NewMemMapFs()
-	_, err := testutils.TempConfig(fs, yamlText)
-	if err != nil {
-		t.Error(err)
+			fs := afero.NewMemMapFs()
+			_, err := testutils.TempConfig(fs, yamlText)
+			if err != nil {
+				t.Error(err)
+			}
+
+			testArgs := Arguments{
+				APIEndpoint:       mockServer.URL,
+				ClusterNameOrID:   "cluster-id",
+				WorkersMax:        int64(tc.desiredMaxScaling),
+				WorkersMin:        int64(tc.desiredMinScaling),
+				UserProvidedToken: "my-token",
+				WorkersMinSet:     tc.workersMinSet,
+				WorkersMaxSet:     tc.workersMaxSet,
+			}
+
+			clientWrapper, err := client.NewWithConfig(testArgs.APIEndpoint, testArgs.UserProvidedToken)
+			if err != nil {
+				t.Errorf("Unexpected error '%s'", err)
+			}
+
+			err = verifyPreconditions(testArgs, clientWrapper)
+			if err != nil {
+				t.Error(err)
+			}
+
+			result, scaleErr := scaleCluster(testArgs)
+			if scaleErr != nil {
+				t.Error(scaleErr)
+			}
+
+			expectedResult := Result{
+				NumWorkersBefore: tc.numWorkersBefore,
+				ScalingMinBefore: tc.initialMinScaling,
+				ScalingMinAfter:  tc.desiredMinScaling,
+				ScalingMaxBefore: tc.initialMaxScaling,
+				ScalingMaxAfter:  tc.desiredMaxScaling,
+			}
+			if diff := cmp.Diff(expectedResult, *result); diff != "" {
+				t.Errorf("Case %d: Scaling result unequal. (-expected +got):\n%s", i, diff)
+			}
+		})
+	}
+}
+
+func generateClusterResponse(workerCount int, workersMin int, workersMax int) []byte {
+	c := models.V4ClusterDetailsResponse{
+		ID:          "cluster-id",
+		Name:        "",
+		APIEndpoint: "",
+		CreateDate:  "2017-05-16T09:30:31.192170835Z",
+		Owner:       "acmeorg",
+		Scaling: &models.V4ClusterDetailsResponseScaling{
+			Min: int64(workersMin),
+			Max: int64(workersMax),
+		},
 	}
 
-	testArgs := Arguments{
-		APIEndpoint:       mockServer.URL,
-		ClusterNameOrID:   "cluster-id",
-		WorkersMax:        int64(5),
-		WorkersMin:        int64(5),
-		UserProvidedToken: "my-token",
-		WorkersMinSet:     true,
-		WorkersMaxSet:     true,
+	for i := 0; i < workerCount; i++ {
+		c.Workers = append(c.Workers, &models.V4ClusterDetailsResponseWorkersItems{
+			Memory: &models.V4ClusterDetailsResponseWorkersItemsMemory{
+				SizeGb: 5,
+			},
+			Storage: &models.V4ClusterDetailsResponseWorkersItemsStorage{
+				SizeGb: 5,
+			},
+			CPU: &models.V4ClusterDetailsResponseWorkersItemsCPU{
+				Cores: 2,
+			},
+			Labels: map[string]string{
+				"foo": "bar",
+			},
+		})
 	}
 
-	clientWrapper, err := client.NewWithConfig(testArgs.APIEndpoint, testArgs.UserProvidedToken)
-	if err != nil {
-		t.Errorf("Unexpected error '%s'", err)
-	}
+	bytes, _ := json.Marshal(c)
 
-	err = verifyPreconditions(testArgs, clientWrapper)
-	if err != nil {
-		t.Error(err)
-	}
-
-	result, scaleErr := scaleCluster(testArgs)
-	if scaleErr != nil {
-		t.Error(scaleErr)
-	}
-
-	expectedResult := Result{
-		NumWorkersBefore: 3,
-		ScalingMinBefore: 3,
-		ScalingMinAfter:  5,
-		ScalingMaxBefore: 3,
-		ScalingMaxAfter:  5,
-	}
-	if diff := cmp.Diff(expectedResult, *result); diff != "" {
-		t.Errorf("Scaling result unequal. (-expected +got):\n%s", diff)
-	}
+	return bytes
 }

--- a/commands/scale/cluster/command_test.go
+++ b/commands/scale/cluster/command_test.go
@@ -411,11 +411,19 @@ selected_endpoint: ` + mockServer.URL
 		t.Error(err)
 	}
 
-	_, scaleErr := scaleCluster(testArgs)
-
+	result, scaleErr := scaleCluster(testArgs)
 	if scaleErr != nil {
 		t.Error(scaleErr)
 	}
 
-	// TODO: check result
+	expectedResult := Result{
+		NumWorkersBefore: 3,
+		ScalingMinBefore: 3,
+		ScalingMinAfter:  5,
+		ScalingMaxBefore: 3,
+		ScalingMaxAfter:  5,
+	}
+	if diff := cmp.Diff(expectedResult, *result); diff != "" {
+		t.Errorf("Scaling result unequal. (-expected +got):\n%s", diff)
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/5578

This enables atomic modification of worker counts.

Example:
If the cluster had initially:
```
* min workers: 3
* max workers: 5
```
by only providing the `--workers-min 4` argument, only the min workers count will be changed, the max workers count will be left untouched, so the result will be:
```diff
-- * min workers: 3
++ * min workers: 4
* max workers: 5
```