### PR TITLE
Tenant cluster labeling

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -24,7 +24,6 @@ import (
 	"github.com/giantswarm/gsclientgen/client/node_pools"
 	"github.com/giantswarm/gsclientgen/client/organizations"
 	"github.com/giantswarm/gsclientgen/client/releases"
-
 	"github.com/giantswarm/gsclientgen/models"
 	"github.com/giantswarm/microerror"
 	"github.com/go-openapi/runtime"
@@ -860,7 +859,6 @@ func (w *Wrapper) UpdateClusterLabels(clusterID string, body *models.V5SetCluste
 		return nil, microerror.Mask(err)
 	}
 
-	// response, err := w.gsclient.Apps.ModifyClusterAppV4(params, authWriter)
 	response, err := w.gsclient.ClusterLabels.SetClusterLabels(params, authWriter)
 	if err != nil {
 		return nil, clienterror.New(err)

--- a/client/client.go
+++ b/client/client.go
@@ -866,3 +866,26 @@ func (w *Wrapper) UpdateClusterLabels(clusterID string, body *models.V5SetCluste
 
 	return response, nil
 }
+
+// GetClustersByLabel fetches a list of clusters based on a label selector using the gsclientgen client.
+func (w *Wrapper) GetClustersByLabel(body *models.V5ListClustersByLabelRequest, p *AuxiliaryParams) (*clusters.GetClustersOK, error) {
+	params := clusters.NewGetV5ClustersByLabelParams().WithBody(body)
+	setParams(p, w, params)
+
+	authWriter, err := getAuthorization(w)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	response, err := w.gsclient.Clusters.GetV5ClustersByLabel(params, authWriter)
+	if err != nil {
+		return nil, clienterror.New(err)
+	}
+
+	// wrap this into a GetClustersOK to be compatible with GetClusters
+	wrappeddResponse := &clusters.GetClustersOK{
+		Payload: response.Payload,
+	}
+
+	return wrappeddResponse, nil
+}

--- a/client/client.go
+++ b/client/client.go
@@ -17,12 +17,14 @@ import (
 	gsclient "github.com/giantswarm/gsclientgen/client"
 	"github.com/giantswarm/gsclientgen/client/apps"
 	"github.com/giantswarm/gsclientgen/client/auth_tokens"
+	"github.com/giantswarm/gsclientgen/client/cluster_labels"
 	"github.com/giantswarm/gsclientgen/client/clusters"
 	"github.com/giantswarm/gsclientgen/client/info"
 	"github.com/giantswarm/gsclientgen/client/key_pairs"
 	"github.com/giantswarm/gsclientgen/client/node_pools"
 	"github.com/giantswarm/gsclientgen/client/organizations"
 	"github.com/giantswarm/gsclientgen/client/releases"
+
 	"github.com/giantswarm/gsclientgen/models"
 	"github.com/giantswarm/microerror"
 	"github.com/go-openapi/runtime"
@@ -841,6 +843,25 @@ func (w *Wrapper) ModifyApp(clusterID string, appName string, body *models.V4Mod
 	}
 
 	response, err := w.gsclient.Apps.ModifyClusterAppV4(params, authWriter)
+	if err != nil {
+		return nil, clienterror.New(err)
+	}
+
+	return response, nil
+}
+
+// UpdateClusterLabels updates labels of a cluster
+func (w *Wrapper) UpdateClusterLabels(clusterID string, body *models.V5SetClusterLabelsRequest, p *AuxiliaryParams) (*cluster_labels.SetClusterLabelsOK, error) {
+	params := cluster_labels.NewSetClusterLabelsParams().WithClusterID(clusterID).WithBody(body)
+	setParams(p, w, params)
+
+	authWriter, err := getAuthorization(w)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	// response, err := w.gsclient.Apps.ModifyClusterAppV4(params, authWriter)
+	response, err := w.gsclient.ClusterLabels.SetClusterLabels(params, authWriter)
 	if err != nil {
 		return nil, clienterror.New(err)
 	}

--- a/commands/create/cluster/command_test.go
+++ b/commands/create/cluster/command_test.go
@@ -119,6 +119,10 @@ func Test_verifyPreconditions(t *testing.T) {
 	}
 }
 
+func stringP(v string) *string {
+	return &v
+}
+
 // Test_CreateClusterSuccessfully tests cluster creations that should succeed.
 func Test_CreateClusterSuccessfully(t *testing.T) {
 	var testCases = []struct {
@@ -282,6 +286,27 @@ func Test_CreateClusterSuccessfully(t *testing.T) {
 				},
 			},
 		},
+		{
+			description: "Definition from v5 YAML file with labels",
+			inputArgs: &Arguments{
+				ClusterName:           "Cluster Name from Args with Labels",
+				CreateDefaultNodePool: false,
+				FileSystem:            afero.NewOsFs(), // needed for YAML file access
+				InputYAMLFile:         "testdata/v5_with_labels.yaml",
+				Owner:                 "acme",
+				AuthToken:             "fake token",
+				Verbose:               true,
+			},
+			expectedResult: &creationResult{
+				ID: "f6e8r",
+				DefinitionV5: &types.ClusterDefinitionV5{
+					APIVersion: "v5",
+					Name:       "Cluster Name from Args with Labels",
+					Owner:      "acme",
+					Labels:     map[string]*string{"key": stringP("value"), "labelkey": stringP("labelvalue")},
+				},
+			},
+		},
 	}
 
 	for i, tc := range testCases {
@@ -315,7 +340,11 @@ func Test_CreateClusterSuccessfully(t *testing.T) {
 					"master": {
 						"availability_zone": "eu-central-1c"
 					},
-					"nodepools": []
+					"nodepools": [],
+					"labels": {
+						"key": "value",
+						"labelkey": "labelvalue"
+					}
 				}`))
 			} else if r.Method == "GET" && r.URL.String() == "/v4/info/" {
 				w.WriteHeader(http.StatusOK)

--- a/commands/create/cluster/testdata/v5_with_labels.yaml
+++ b/commands/create/cluster/testdata/v5_with_labels.yaml
@@ -1,0 +1,5 @@
+api_version: v5
+owner: acme
+labels:
+  key: value
+  labelkey: labelvalue

--- a/commands/create/cluster/v5.go
+++ b/commands/create/cluster/v5.go
@@ -127,6 +127,18 @@ func addClusterV5(def *types.ClusterDefinitionV5, args Arguments, clientWrapper 
 		}
 	}
 
+	// Create labels
+	if def.Labels != nil && len(def.Labels) > 0 {
+		labelsRequest := models.V5SetClusterLabelsRequest{Labels: def.Labels}
+		_, err := clientWrapper.UpdateClusterLabels(response.Payload.ID, &labelsRequest, auxParams)
+		if err != nil {
+			fmt.Println(color.RedString("Error attaching labels %s", err.Error()))
+			hasErrors = true
+		} else if args.Verbose {
+			fmt.Println(color.WhiteString("Attached labels to cluster with ID %s named '%s'", response.Payload.ID, response.Payload.Name))
+		}
+	}
+
 	return response.Payload.ID, hasErrors, nil
 
 }

--- a/commands/show/cluster/command.go
+++ b/commands/show/cluster/command.go
@@ -25,8 +25,6 @@ import (
 	"github.com/giantswarm/gsctl/webui"
 )
 
-const labelFilterKeySubstring = "giantswarm.io"
-
 var (
 
 	// ShowClusterCommand performs the "show cluster" function
@@ -618,7 +616,7 @@ func formatClusterLabels(labels map[string]string) []string {
 	isFirstLine := true
 
 	for key, value := range labels {
-		if strings.Contains(key, labelFilterKeySubstring) == false {
+		if strings.Contains(key, util.LabelFilterKeySubstring) == false {
 			if isFirstLine {
 				isFirstLine = false
 				formattedClusterLabels = []string{fmt.Sprintf("%s|%s=%s", color.YellowString("Labels:"), key, value)}

--- a/commands/show/cluster/command.go
+++ b/commands/show/cluster/command.go
@@ -25,6 +25,8 @@ import (
 	"github.com/giantswarm/gsctl/webui"
 )
 
+const labelFilterKeySubstring = "giantswarm.io"
+
 var (
 
 	// ShowClusterCommand performs the "show cluster" function
@@ -616,7 +618,7 @@ func formatClusterLabels(labels map[string]string) []string {
 	isFirstLine := true
 
 	for key, value := range labels {
-		if strings.Contains(key, "giantswarm.io") == false {
+		if strings.Contains(key, labelFilterKeySubstring) == false {
 			if isFirstLine {
 				isFirstLine = false
 				formattedClusterLabels = []string{fmt.Sprintf("%s|%s=%s", color.YellowString("Labels:"), key, value)}

--- a/commands/show/cluster/command.go
+++ b/commands/show/cluster/command.go
@@ -492,6 +492,7 @@ func printV5Result(args Arguments, details *models.V5ClusterDetailsResponse,
 	clusterTable = append(clusterTable, color.YellowString("Kubernetes API endpoint:")+"|"+details.APIEndpoint)
 	clusterTable = append(clusterTable, color.YellowString("Master availability zone:")+"|"+details.Master.AvailabilityZone)
 	clusterTable = append(clusterTable, color.YellowString("Release version:")+"|"+details.ReleaseVersion)
+	clusterTable = append(clusterTable, formatClusterLabels(details.Labels)...)
 
 	// BYOC credentials.
 	if credentialDetails != nil && credentialDetails.ID != "" {
@@ -607,4 +608,23 @@ func formatNodePoolDetails(nodePools *models.V5GetNodePoolsResponse) []string {
 	rows = append(rows, color.YellowString("RAM in nodes (GB):")+fmt.Sprintf("|%d", ramGB))
 
 	return rows
+}
+
+func formatClusterLabels(labels map[string]string) []string {
+	formattedClusterLabels := []string{color.YellowString("Labels:|") + "-"}
+
+	isFirstLine := true
+
+	for key, value := range labels {
+		if strings.Contains(key, "giantswarm.io") == false {
+			if isFirstLine {
+				isFirstLine = false
+				formattedClusterLabels = []string{fmt.Sprintf("%s|%s=%s", color.YellowString("Labels:"), key, value)}
+			} else {
+				formattedClusterLabels = append(formattedClusterLabels, fmt.Sprintf("|%s=%s", key, value))
+			}
+		}
+	}
+
+	return formattedClusterLabels
 }

--- a/commands/show/cluster/command_test.go
+++ b/commands/show/cluster/command_test.go
@@ -505,3 +505,37 @@ func TestShowAWSBYOCClusterV4(t *testing.T) {
 	}
 
 }
+
+func TestFormatClusterLabels(t *testing.T) {
+	mockLabels := map[string]string{
+		"shouldbeignored.giantswarm.io": "imhidden",
+		"release.giantswarm.io":         "0.0.0",
+	}
+
+	result := formatClusterLabels(mockLabels)
+
+	if len(result) != 1 {
+		t.Errorf("formatted cluster labels result has invalid length. Expected %d got %d", 1, len(result))
+	}
+
+	if result[0] != "Labels:|-" {
+		t.Errorf("formatted cluster labels result expected '%s' got '%s'", "Labels:|-", result[0])
+	}
+
+	mockLabels["testkey"] = "testvalue"
+	mockLabels["veryvalidkey"] = "veryvalidvalue"
+
+	result = formatClusterLabels(mockLabels)
+
+	if len(result) != 2 {
+		t.Errorf("formatted cluster labels result has invalid length. Expected %d got %d", 2, len(result))
+	}
+
+	if result[0] != "Labels:|testkey=testvalue" {
+		t.Errorf("formatted cluster labels result expected '%s' got '%s'", "Labels:|testkey=testvalue", result[0])
+	}
+
+	if result[1] != "|veryvalidkey=veryvalidvalue" {
+		t.Errorf("formatted cluster labels result expected '%s' got '%s'", "|veryvalidkey=veryvalidvalue", result[1])
+	}
+}

--- a/commands/show/cluster/command_test.go
+++ b/commands/show/cluster/command_test.go
@@ -531,11 +531,11 @@ func TestFormatClusterLabels(t *testing.T) {
 		t.Errorf("formatted cluster labels result has invalid length. Expected %d got %d", 2, len(result))
 	}
 
-	if result[0] != "Labels:|testkey=testvalue" {
-		t.Errorf("formatted cluster labels result expected '%s' got '%s'", "Labels:|testkey=testvalue", result[0])
+	if !strings.HasPrefix(result[0], "Labels:|") {
+		t.Errorf("formatted cluster labels result expected '%s' to start with '%s'", result[0], "Labels:|")
 	}
 
-	if result[1] != "|veryvalidkey=veryvalidvalue" {
-		t.Errorf("formatted cluster labels result expected '%s' got '%s'", "|veryvalidkey=veryvalidvalue", result[1])
+	if !strings.HasPrefix(result[1], "|") {
+		t.Errorf("formatted cluster labels result expected '%s' to start with '%s'", result[1], "|")
 	}
 }

--- a/commands/types/types.go
+++ b/commands/types/types.go
@@ -54,6 +54,7 @@ type ClusterDefinitionV5 struct {
 	ReleaseVersion string                `yaml:"release_version,omitempty"`
 	Master         *MasterDefinition     `yaml:"master,omitempty"`
 	NodePools      []*NodePoolDefinition `yaml:"nodepools,omitempty"`
+	Labels         map[string]*string    `yaml:"labels,omitempty"`
 }
 
 // ScalingDefinition defines how a tenant cluster can scale.

--- a/commands/update/cluster/command.go
+++ b/commands/update/cluster/command.go
@@ -57,7 +57,7 @@ func init() {
 func initFlags() {
 	Command.ResetFlags()
 	Command.Flags().StringVarP(&flags.Name, "name", "n", "", "new cluster name")
-	Command.Flags().StringSliceVar(&flags.Label, "label", nil, "label")
+	Command.Flags().StringSliceVar(&flags.Label, "label", nil, "modification of a label in form of key=value. Can be specified multiple times. To delete a label set to key=")
 }
 
 // Arguments represents all the ways the user can influence the command.

--- a/commands/update/cluster/command.go
+++ b/commands/update/cluster/command.go
@@ -59,7 +59,7 @@ func init() {
 func initFlags() {
 	Command.ResetFlags()
 	Command.Flags().StringVarP(&flags.Name, "name", "n", "", "new cluster name")
-	Command.Flags().StringSliceVar(&flags.Label, "label", nil, "modification of a label in form of key=value. Can be specified multiple times. To delete a label set to key=")
+	Command.Flags().StringSliceVar(&flags.Label, "label", nil, "modification of a label in form of 'key=value'. Can be specified multiple times. To delete a label set to 'key='")
 }
 
 // Arguments represents all the ways the user can influence the command.

--- a/commands/update/cluster/command.go
+++ b/commands/update/cluster/command.go
@@ -10,6 +10,7 @@ import (
 	"github.com/giantswarm/gscliauth/config"
 	"github.com/giantswarm/gsclientgen/models"
 	"github.com/giantswarm/gsctl/clustercache"
+	"github.com/giantswarm/gsctl/util"
 	"github.com/giantswarm/microerror"
 	"github.com/spf13/cobra"
 
@@ -17,8 +18,6 @@ import (
 	"github.com/giantswarm/gsctl/commands/errors"
 	"github.com/giantswarm/gsctl/flags"
 )
-
-const labelFilterKeySubstring = "giantswarm.io"
 
 var (
 	// Command is the cobra command for 'gsctl update cluster'
@@ -292,7 +291,7 @@ func printResult(cmd *cobra.Command, positionalArgs []string) {
 	if len(result.Labels) > 0 {
 		fmt.Println("New cluster labels:")
 		for key, label := range result.Labels {
-			if strings.Contains(key, labelFilterKeySubstring) == false {
+			if strings.Contains(key, util.LabelFilterKeySubstring) == false {
 				fmt.Printf("%s=%s\n", key, label)
 			}
 		}

--- a/commands/update/cluster/command.go
+++ b/commands/update/cluster/command.go
@@ -18,6 +18,8 @@ import (
 	"github.com/giantswarm/gsctl/flags"
 )
 
+const labelFilterKeySubstring = "giantswarm.io"
+
 var (
 	// Command is the cobra command for 'gsctl update cluster'
 	Command = &cobra.Command{
@@ -290,7 +292,7 @@ func printResult(cmd *cobra.Command, positionalArgs []string) {
 	if len(result.Labels) > 0 {
 		fmt.Println("New cluster labels:")
 		for key, label := range result.Labels {
-			if strings.Contains(key, "giantswarm.io") == false {
+			if strings.Contains(key, labelFilterKeySubstring) == false {
 				fmt.Printf("%s=%s\n", key, label)
 			}
 		}

--- a/commands/update/cluster/command.go
+++ b/commands/update/cluster/command.go
@@ -227,6 +227,7 @@ func updateName(args Arguments) (*result, error) {
 	return nil, microerror.Mask(errV4)
 }
 
+// updateLabels applies label changes to v5 clusters. v5 only!
 func updateLabels(args Arguments) (*result, error) {
 	clientWrapper, err := client.NewWithConfig(args.APIEndpoint, args.UserProvidedToken)
 	if err != nil {
@@ -240,6 +241,12 @@ func updateLabels(args Arguments) (*result, error) {
 
 	auxParams := clientWrapper.DefaultAuxiliaryParams()
 	auxParams.ActivityName = activityName
+
+	// verify this cluster exists and is a v5 cluster
+	_, err = clientWrapper.GetClusterV5(clusterID, auxParams)
+	if err != nil {
+		return nil, microerror.Maskf(errors.ClusterNotFoundError, "cluster with id '%s' not found or not a v5 cluster", clusterID)
+	}
 
 	requestBody, err := modifyClusterLabelsRequestFromArguments(args.Labels)
 	if err != nil {

--- a/commands/update/cluster/command_test.go
+++ b/commands/update/cluster/command_test.go
@@ -108,6 +108,17 @@ func Test_verifyPreconditions(t *testing.T) {
 			},
 			errors.IsNoOpError,
 		},
+		// name and label arguments given at same time
+		{
+			Arguments{
+				AuthToken:       "token",
+				APIEndpoint:     "https://mock-url",
+				ClusterNameOrID: "cluster-id",
+				Name:            "newname",
+				Labels:          []string{"labelchange=one", "labelchange=two"},
+			},
+			errors.IsConflictingFlagsError,
+		},
 	}
 
 	fs := afero.NewMemMapFs()

--- a/commands/update/cluster/command_test.go
+++ b/commands/update/cluster/command_test.go
@@ -150,6 +150,26 @@ func TestSuccess(t *testing.T) {
 				ClusterName: "New name",
 			},
 		},
+		// Label change
+		{
+			args: Arguments{
+				ClusterNameOrID: "clusterid",
+				AuthToken:       "token",
+				Labels: []string{
+					"newlabelkey=newlabelvalue",
+				},
+			},
+			responseBody: `{
+				"labels": {
+					"newlabelkey": "newlabelvalue"
+				}
+			}`,
+			expectedResult: &result{
+				Labels: map[string]string{
+					"newlabelkey": "newlabelvalue",
+				},
+			},
+		},
 	}
 
 	fs := afero.NewMemMapFs()
@@ -179,6 +199,9 @@ func TestSuccess(t *testing.T) {
 							"owner": "acme"
 						}
 					]`))
+				} else if r.Method == "PUT" && r.URL.Path == "/v5/clusters/clusterid/labels/" {
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte(tc.responseBody))
 				} else {
 					t.Errorf("Case %d - Unsupported operation %s %s called in mock server", i, r.Method, r.URL.Path)
 				}

--- a/commands/update/cluster/command_test.go
+++ b/commands/update/cluster/command_test.go
@@ -302,3 +302,43 @@ func TestExecuteWithError(t *testing.T) {
 		})
 	}
 }
+
+func Test_modifyClusterLabelsRequestFromArguments(t *testing.T) {
+	mockLabels := []string{"this=works", "workstoo="}
+
+	request, err := modifyClusterLabelsRequestFromArguments(mockLabels)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(request.Labels) != 2 {
+		t.Errorf("Invalid labels map length. Expected %d, got %d", 2, len(request.Labels))
+	}
+
+	mockLabels = []string{"missingequalsign", "perfectly=valid"}
+
+	request, err = modifyClusterLabelsRequestFromArguments(mockLabels)
+	if err == nil {
+		t.Errorf("Expected error")
+	}
+
+	expectedErrorStr := "no op error: malformed label change 'missingequalsign' (single = required)"
+
+	if err.Error() != expectedErrorStr {
+		t.Errorf("Expected error to be '%s' got '%s'", expectedErrorStr, err.Error())
+	}
+
+	mockLabels = []string{"=invalid"}
+
+	request, err = modifyClusterLabelsRequestFromArguments(mockLabels)
+	if err == nil {
+		t.Errorf("Expected error")
+	}
+
+	expectedErrorStr = "no op error: malformed label change '=invalid' (empty key)"
+
+	if err.Error() != expectedErrorStr {
+		t.Errorf("Expected error to be '%s' got '%s'", expectedErrorStr, err.Error())
+	}
+
+}

--- a/commands/update/cluster/labels.go
+++ b/commands/update/cluster/labels.go
@@ -13,9 +13,12 @@ func modifyClusterLabelsRequestFromArguments(labels []string) (*models.V5SetClus
 	request := &models.V5SetClusterLabelsRequest{Labels: map[string]*string{}}
 
 	for _, label := range labels {
-		labelParts := strings.Split(label, "=")
+		labelParts := strings.Split(strings.TrimSpace(label), "=")
 		if len(labelParts) != 2 {
-			return request, microerror.Mask(errors.NoOpError)
+			return request, microerror.Maskf(errors.NoOpError, "malformed label change '%s' (single = required)", label)
+		}
+		if labelParts[0] == "" {
+			return request, microerror.Maskf(errors.NoOpError, "malformed label change '%s' (empty key)", label)
 		}
 		if labelParts[1] == "" {
 			request.Labels[labelParts[0]] = nil

--- a/commands/update/cluster/labels.go
+++ b/commands/update/cluster/labels.go
@@ -1,0 +1,28 @@
+package cluster
+
+import (
+	"strings"
+
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/gsclientgen/models"
+	"github.com/giantswarm/gsctl/commands/errors"
+)
+
+func modifyClusterLabelsRequestFromArguments(labels []string) (*models.V5SetClusterLabelsRequest, error) {
+	request := &models.V5SetClusterLabelsRequest{Labels: map[string]*string{}}
+
+	for _, label := range labels {
+		labelParts := strings.Split(label, "=")
+		if len(labelParts) != 2 {
+			return request, microerror.Mask(errors.NoOpError)
+		}
+		if labelParts[1] == "" {
+			request.Labels[labelParts[0]] = nil
+		} else {
+			request.Labels[labelParts[0]] = &labelParts[1]
+		}
+	}
+
+	return request, nil
+}

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -56,6 +56,9 @@ var (
 	// InputYAMLFile is the path to the input file used optionally as cluster definition
 	InputYAMLFile string
 
+	// Label contains label changes passed as multiple flags.
+	Label []string
+
 	// Name is the name of a cluster or node pool.
 	Name string
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/giantswarm/apiextensions v0.0.0-20191213075442-71155aa0f5b7
 	github.com/giantswarm/columnize v2.0.3-0.20190718092621-cc99d98ffb29+incompatible
 	github.com/giantswarm/gscliauth v0.2.1
-	github.com/giantswarm/gsclientgen v0.0.0-20200423130825-3202ff18d14f
+	github.com/giantswarm/gsclientgen v1.0.2-0.20200507100632-8ff496037482
 	github.com/giantswarm/k8sclient v0.0.0-20191213144452-f75fead2ae06
 	github.com/giantswarm/kubeconfig v0.0.0-20191209121754-c5784ae65a49
 	github.com/giantswarm/microerror v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -79,8 +79,6 @@ github.com/giantswarm/columnize v2.0.3-0.20190718092621-cc99d98ffb29+incompatibl
 github.com/giantswarm/columnize v2.0.3-0.20190718092621-cc99d98ffb29+incompatible/go.mod h1:V/9Aa/R3o321yAbarEACmGhTg0SiPge6nFDtIH7CTvE=
 github.com/giantswarm/gscliauth v0.2.1 h1:DPO3dido3306/mgPs9DMz5V6IP3rXNc/s5mVh7YZ5yw=
 github.com/giantswarm/gscliauth v0.2.1/go.mod h1:Ys1puKDjd31rt6VDUwbJg8G3RkoLNLwisOwHxTjyKIc=
-github.com/giantswarm/gsclientgen v0.0.0-20200423130825-3202ff18d14f h1:1boujA6r6THrCRSRtlQm2zS3LkmhuV8qtyfzp70yfqs=
-github.com/giantswarm/gsclientgen v0.0.0-20200423130825-3202ff18d14f/go.mod h1:6/9SZF0LQbz3eY0h2Gh1zBZkXtky8OfYVbhDQXj33S4=
 github.com/giantswarm/gsclientgen v1.0.2-0.20200507100632-8ff496037482 h1:SXOCs0gqjqHZV2ugPzVV0PE5WgpAXN/sLGQI55ElKiA=
 github.com/giantswarm/gsclientgen v1.0.2-0.20200507100632-8ff496037482/go.mod h1:6/9SZF0LQbz3eY0h2Gh1zBZkXtky8OfYVbhDQXj33S4=
 github.com/giantswarm/k8sclient v0.0.0-20191213144452-f75fead2ae06 h1:ARogDNpItRylPLIYWQqHLne7Cv1PnHahcGxx8/Zm+l4=

--- a/go.sum
+++ b/go.sum
@@ -81,6 +81,8 @@ github.com/giantswarm/gscliauth v0.2.1 h1:DPO3dido3306/mgPs9DMz5V6IP3rXNc/s5mVh7
 github.com/giantswarm/gscliauth v0.2.1/go.mod h1:Ys1puKDjd31rt6VDUwbJg8G3RkoLNLwisOwHxTjyKIc=
 github.com/giantswarm/gsclientgen v0.0.0-20200423130825-3202ff18d14f h1:1boujA6r6THrCRSRtlQm2zS3LkmhuV8qtyfzp70yfqs=
 github.com/giantswarm/gsclientgen v0.0.0-20200423130825-3202ff18d14f/go.mod h1:6/9SZF0LQbz3eY0h2Gh1zBZkXtky8OfYVbhDQXj33S4=
+github.com/giantswarm/gsclientgen v1.0.2-0.20200507100632-8ff496037482 h1:SXOCs0gqjqHZV2ugPzVV0PE5WgpAXN/sLGQI55ElKiA=
+github.com/giantswarm/gsclientgen v1.0.2-0.20200507100632-8ff496037482/go.mod h1:6/9SZF0LQbz3eY0h2Gh1zBZkXtky8OfYVbhDQXj33S4=
 github.com/giantswarm/k8sclient v0.0.0-20191213144452-f75fead2ae06 h1:ARogDNpItRylPLIYWQqHLne7Cv1PnHahcGxx8/Zm+l4=
 github.com/giantswarm/k8sclient v0.0.0-20191213144452-f75fead2ae06/go.mod h1:XH0Ea+GvJOStcuamQyFSJXIQasGcPpHnWnHQVyG7AJc=
 github.com/giantswarm/kubeconfig v0.0.0-20191209121754-c5784ae65a49 h1:7A4URevsdTMdWlAnbYdryrfLdqBuHvyU2ans0oDEqck=

--- a/util/constants.go
+++ b/util/constants.go
@@ -1,0 +1,4 @@
+package util
+
+// LabelFilterKeySubstring is the substring used to hide giantswarm labels
+const LabelFilterKeySubstring = "giantswarm.io"


### PR DESCRIPTION
Towards giantswarm/giantswarm#1693, Related to giantswarm/giantswarm#10575

This PR adds support of cluster labels described in giantswarm/docs#481 to gsctl

Changes: (Copied from giantswarm/docs#481)

- `gsctl list cluster`
  - `-o json` additionally includes user defined cluster labels
  - `--selector` or `-l` can be used to filter the list of returned clusters
- `gsctl show cluster` returns user defined cluster labels for node pool clusters on AWS ([Example](https://github.com/giantswarm/docs/pull/481/commits/d801b975b5952f437b42bb640c81d1952b12d93a#diff-5eede8a45557a2cf5bd14b48d3fdc857R42-R43))
- `gsctl create cluster`
  - cluster labels can be specified through a `labels` object in the v5 yaml cluster definition
- **new**: `gsctl update cluster`
  - `--label` allows to specify a label change in form of `key=value`. Can be specified multiple times. Set to `key=` to delete a label
