### PR TITLE
Add json output to the 'list nodepools' command

### DIFF
--- a/commands/list/nodepools/command.go
+++ b/commands/list/nodepools/command.go
@@ -127,18 +127,10 @@ func verifyPreconditions(args Arguments, positionalArgs []string) error {
 func printValidation(cmd *cobra.Command, positionalArgs []string) {
 	arguments = collectArguments(positionalArgs)
 	err := verifyPreconditions(arguments, positionalArgs)
-
-	if err == nil {
-		return
+	if err != nil {
+		handleError(err)
+		os.Exit(1)
 	}
-
-	client.HandleErrors(err)
-	errors.HandleCommonErrors(err)
-
-	// Display error
-	fmt.Println(color.RedString(err.Error()))
-
-	os.Exit(1)
 }
 
 // fetchNodePools collects all information we would want to display

--- a/commands/list/nodepools/command.go
+++ b/commands/list/nodepools/command.go
@@ -214,8 +214,6 @@ func getOutput(nps []*models.V5GetNodePoolsResponseItems) (string, error) {
 		return "", microerror.Mask(err)
 	}
 
-	table := make([]string, 0, len(nps)+1)
-
 	headers := []string{
 		color.CyanString("ID"),
 		color.CyanString("NAME"),
@@ -231,6 +229,8 @@ func getOutput(nps []*models.V5GetNodePoolsResponseItems) (string, error) {
 		color.CyanString("CPUS"),
 		color.CyanString("RAM (GB)"),
 	}
+
+	table := make([]string, 0, len(nps)+1)
 	table = append(table, strings.Join(headers, "|"))
 
 	for _, np := range nps {
@@ -243,10 +243,12 @@ func getOutput(nps []*models.V5GetNodePoolsResponseItems) (string, error) {
 		sumMemory := float64(np.Status.NodesReady) * float64(it.MemorySizeGB)
 
 		var instanceTypes string
-		if len(np.Status.InstanceTypes) > 0 {
-			instanceTypes = strings.Join(np.Status.InstanceTypes, ",")
-		} else {
-			instanceTypes = np.NodeSpec.Aws.InstanceType
+		{
+			if len(np.Status.InstanceTypes) > 0 {
+				instanceTypes = strings.Join(np.Status.InstanceTypes, ",")
+			} else {
+				instanceTypes = np.NodeSpec.Aws.InstanceType
+			}
 		}
 
 		table = append(table, strings.Join([]string{

--- a/commands/list/nodepools/command.go
+++ b/commands/list/nodepools/command.go
@@ -213,7 +213,7 @@ func getOutput(nps []*models.V5GetNodePoolsResponseItems, outputFormat string) (
 		return "", microerror.Mask(err)
 	}
 
-	if outputFormat == "json" {
+	if outputFormat == outputFormatJSON {
 		outputBytes, err := json.MarshalIndent(nps, outputJSONPrefix, outputJSONIndent)
 		if err != nil {
 			return "", microerror.Mask(err)

--- a/commands/list/nodepools/command.go
+++ b/commands/list/nodepools/command.go
@@ -127,12 +127,18 @@ func verifyPreconditions(args Arguments, positionalArgs []string) error {
 func printValidation(cmd *cobra.Command, positionalArgs []string) {
 	arguments = collectArguments(positionalArgs)
 	err := verifyPreconditions(arguments, positionalArgs)
+
 	if err == nil {
 		return
 	}
 
 	client.HandleErrors(err)
 	errors.HandleCommonErrors(err)
+
+	// Display error
+	fmt.Println(color.RedString(err.Error()))
+
+	os.Exit(1)
 }
 
 // fetchNodePools collects all information we would want to display

--- a/commands/list/nodepools/command.go
+++ b/commands/list/nodepools/command.go
@@ -221,7 +221,7 @@ func getOutput(nps []*models.V5GetNodePoolsResponseItems) (string, error) {
 	}
 
 	// create combined output data structure.
-	rows := []*resultRow{}
+	rows := make([]*resultRow, 0, len(nps))
 
 	for _, np := range nps {
 		it, err := awsInfo.GetInstanceTypeDetails(np.NodeSpec.Aws.InstanceType)
@@ -235,7 +235,7 @@ func getOutput(nps []*models.V5GetNodePoolsResponseItems) (string, error) {
 		rows = append(rows, &resultRow{np, it, sumCPUs, sumMemory})
 	}
 
-	table := []string{}
+	table := make([]string, 0, len(rows)+1)
 
 	headers := []string{
 		color.CyanString("ID"),

--- a/commands/list/nodepools/command.go
+++ b/commands/list/nodepools/command.go
@@ -142,6 +142,11 @@ func printValidation(cmd *cobra.Command, positionalArgs []string) {
 
 	client.HandleErrors(err)
 	errors.HandleCommonErrors(err)
+
+	// Display error
+	fmt.Println(color.RedString(err.Error()))
+
+	os.Exit(1)
 }
 
 // fetchNodePools collects all information we would want to display

--- a/commands/list/nodepools/command.go
+++ b/commands/list/nodepools/command.go
@@ -142,11 +142,6 @@ func printValidation(cmd *cobra.Command, positionalArgs []string) {
 
 	client.HandleErrors(err)
 	errors.HandleCommonErrors(err)
-
-	// Display error
-	fmt.Println(color.RedString(err.Error()))
-
-	os.Exit(1)
 }
 
 // fetchNodePools collects all information we would want to display

--- a/commands/list/nodepools/command.go
+++ b/commands/list/nodepools/command.go
@@ -2,6 +2,7 @@
 package nodepools
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"sort"
@@ -187,7 +188,7 @@ func printResult(cmd *cobra.Command, positionalArgs []string) {
 		return
 	}
 
-	output, err := getOutput(nodePools)
+	output, err := getOutput(nodePools, arguments.outputFormat)
 	if err != nil {
 		handleError(err)
 		os.Exit(1)
@@ -204,7 +205,7 @@ func formatNodesReady(nodes, nodesReady int64) string {
 	return color.YellowString(strconv.FormatInt(nodesReady, 10))
 }
 
-func getOutput(nps []*models.V5GetNodePoolsResponseItems) (string, error) {
+func getOutput(nps []*models.V5GetNodePoolsResponseItems, outputFormat string) (string, error) {
 	if len(nps) < 0 {
 		return "", nil
 	}
@@ -212,6 +213,15 @@ func getOutput(nps []*models.V5GetNodePoolsResponseItems) (string, error) {
 	awsInfo, err := nodespec.NewAWS()
 	if err != nil {
 		return "", microerror.Mask(err)
+	}
+
+	if outputFormat == "json" {
+		outputBytes, err := json.MarshalIndent(nps, outputJSONPrefix, outputJSONIndent)
+		if err != nil {
+			return "", microerror.Mask(err)
+		}
+
+		return string(outputBytes), nil
 	}
 
 	headers := []string{

--- a/commands/list/nodepools/command_test.go
+++ b/commands/list/nodepools/command_test.go
@@ -3,30 +3,89 @@ package nodepools
 import (
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	"github.com/giantswarm/gscliauth/config"
+	"github.com/google/go-cmp/cmp"
 	"github.com/spf13/afero"
 
 	"github.com/giantswarm/gsctl/testutils"
 )
 
 func Test_ListNodePools(t *testing.T) {
-	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		if r.Method == "GET" {
-			switch uri := r.URL.Path; uri {
-			case "/v5/clusters/cluster-id/nodepools/":
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`[
-					{"id": "a7rc4", "name": "Batch number crunching", "availability_zones": ["eu-west-1d"], "scaling": {"min": 2, "max": 5}, "node_spec": {"aws": {"instance_type": "p3.8xlarge"}, "volume_sizes_gb": {"docker": 100, "kubelet": 100}}, "status": {"nodes": 4, "nodes_ready": 4}},
-					{"id": "6feel", "name": "Application servers", "availability_zones": ["eu-west-1a", "eu-west-1b", "eu-west-1c"], "scaling": {"min": 3, "max": 15}, "node_spec": {"aws": {"instance_type": "p3.2xlarge"}, "volume_sizes_gb": {"docker": 100, "kubelet": 100}}, "status": {"nodes": 10, "nodes_ready": 9}},
-					{"id": "a6bf4", "name": "New node pool", "availability_zones": ["eu-west-1c"], "scaling": {"min": 3, "max": 3}, "node_spec": {"aws": {"instance_type": "m5.2xlarge"}, "volume_sizes_gb": {"docker": 100, "kubelet": 100}}, "status": {"nodes": 0, "nodes_ready": 0}}
-				]`))
+	testCases := []struct {
+		npResponse   string
+		outputFormat string
+		output       string
+	}{
+		{
+			npResponse: `[
+                {"id": "a7rc4", "name": "Batch number crunching", "availability_zones": ["eu-west-1d"], "scaling": {"min": 2, "max": 5}, "node_spec": {"aws": {"instance_type": "p3.8xlarge", "instance_distribution": {"on_demand_base_capacity": 0, "on_demand_percentage_above_base_capacity": 0}}, "volume_sizes_gb": {"docker": 100, "kubelet": 100}}, "status": {"nodes": 4, "nodes_ready": 4}},
+                {"id": "6feel", "name": "Application servers", "availability_zones": ["eu-west-1a", "eu-west-1b", "eu-west-1c"], "scaling": {"min": 3, "max": 15}, "node_spec": {"aws": {"instance_type": "p3.2xlarge", "instance_distribution": {"on_demand_base_capacity": 0, "on_demand_percentage_above_base_capacity": 0}}, "volume_sizes_gb": {"docker": 100, "kubelet": 100}}, "status": {"nodes": 10, "nodes_ready": 9}},
+                {"id": "a6bf4", "name": "New node pool", "availability_zones": ["eu-west-1c"], "scaling": {"min": 3, "max": 3}, "node_spec": {"aws": {"instance_type": "m5.2xlarge", "instance_distribution": {"on_demand_base_capacity": 0, "on_demand_percentage_above_base_capacity": 0}}, "volume_sizes_gb": {"docker": 100, "kubelet": 100}}, "status": {"nodes": 0, "nodes_ready": 0}}
+            ]`,
+			outputFormat: "table",
+			output: `ID     NAME                    AZ     INSTANCE TYPE  ALIKE  ON-DEMAND BASE  SPOT PERCENTAGE  NODES MIN/MAX  NODES DESIRED  NODES READY  SPOT INSTANCES  CPUS  RAM (GB)
+6feel  Application servers     A,B,C  p3.2xlarge     false               0              100           3/15             10            9               0    72     549.0
+a6bf4  New node pool           C      m5.2xlarge     false               0              100            3/3              0            0               0     0       0.0
+a7rc4  Batch number crunching  D      p3.8xlarge     false               0              100            2/5              4            4               0   128     976.0`,
+		},
+		{
+			npResponse: `[
+                {"id": "a6bf4", "name": "New node pool", "availability_zones": ["eu-west-1c"], "scaling": {"min": 3, "max": 3}, "node_spec": {"aws": {"instance_type": "m5.2xlarge", "instance_distribution": {"on_demand_base_capacity": 0, "on_demand_percentage_above_base_capacity": 0}}, "volume_sizes_gb": {"docker": 100, "kubelet": 100}}, "status": {"nodes": 0, "nodes_ready": 0}}
+            ]`,
+			outputFormat: "table",
+			output: `ID     NAME           AZ  INSTANCE TYPE  ALIKE  ON-DEMAND BASE  SPOT PERCENTAGE  NODES MIN/MAX  NODES DESIRED  NODES READY  SPOT INSTANCES  CPUS  RAM (GB)
+a6bf4  New node pool  C   m5.2xlarge     false               0              100            3/3              0            0               0     0       0.0`,
+		},
+		{
+			npResponse: `[
+                {"id": "a6bf4", "name": "New node pool", "availability_zones": ["eu-west-1c"], "scaling": {"min": 3, "max": 3}, "node_spec": {"aws": {"instance_type": "m5.2xlarge", "instance_distribution": {"on_demand_base_capacity": 0, "on_demand_percentage_above_base_capacity": 0}}, "volume_sizes_gb": {"docker": 100, "kubelet": 100}}, "status": {"nodes": 0, "nodes_ready": 0}}
+            ]`,
+			outputFormat: "json",
+			output: `[
+  {
+    "availability_zones": [
+      "eu-west-1c"
+    ],
+    "id": "a6bf4",
+    "name": "New node pool",
+    "node_spec": {
+      "aws": {
+        "instance_distribution": {},
+        "instance_type": "m5.2xlarge"
+      },
+      "volume_sizes_gb": {
+        "docker": 100,
+        "kubelet": 100
+      }
+    },
+    "scaling": {
+      "max": 3,
+      "min": 3
+    },
+    "status": {
+      "instance_types": null
+    }
+  }
+]`,
+		},
+	}
 
-			case "/v4/clusters/":
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`[
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if r.Method == "GET" {
+					switch uri := r.URL.Path; uri {
+					case "/v5/clusters/cluster-id/nodepools/":
+						w.WriteHeader(http.StatusOK)
+						w.Write([]byte(tc.npResponse))
+
+					case "/v4/clusters/":
+						w.WriteHeader(http.StatusOK)
+						w.Write([]byte(`[
 					{
 						"id": "cluster-id",
 						"name": "Name of the cluster",
@@ -34,45 +93,45 @@ func Test_ListNodePools(t *testing.T) {
 					}
 				]`))
 
-			default:
-				t.Errorf("Unsupported route %s called in mock server", r.URL.Path)
-				w.WriteHeader(http.StatusNotFound)
-				w.Write([]byte(`{"code": "RESOURCE_NOT_FOUND", "message": "Status for this cluster is not yet available."}`))
+					default:
+						t.Errorf("Case %d: Unsupported route %s called in mock server", i, r.URL.Path)
+						w.WriteHeader(http.StatusNotFound)
+						w.Write([]byte(`{"code": "RESOURCE_NOT_FOUND", "message": "Status for this cluster is not yet available."}`))
+					}
+				}
+			}))
+			defer mockServer.Close()
+
+			// temp config
+			fs := afero.NewMemMapFs()
+			configDir := testutils.TempDir(fs)
+			config.Initialize(fs, configDir)
+
+			args := Arguments{
+				clusterNameOrID: "cluster-id",
+				apiEndpoint:     mockServer.URL,
+				authToken:       "my-token",
+				outputFormat:    tc.outputFormat,
 			}
-		}
-	}))
-	defer mockServer.Close()
 
-	// temp config
-	fs := afero.NewMemMapFs()
-	configDir := testutils.TempDir(fs)
-	config.Initialize(fs, configDir)
+			err := verifyPreconditions(args, []string{args.clusterNameOrID})
+			if err != nil {
+				t.Errorf("Case %d: %s", i, err)
+			}
 
-	args := Arguments{
-		clusterNameOrID: "cluster-id",
-		apiEndpoint:     mockServer.URL,
-		authToken:       "my-token",
-	}
+			results, err := fetchNodePools(args)
+			if err != nil {
+				t.Errorf("Case %d: %s", i, err)
+			}
 
-	err := verifyPreconditions(args, []string{args.clusterNameOrID})
-	if err != nil {
-		t.Error(err)
-	}
+			output, err := getOutput(results, args.outputFormat)
+			if err != nil {
+				t.Errorf("Case %d: %s", i, err)
+			}
 
-	results, err := fetchNodePools(args)
-	if err != nil {
-		t.Error(err)
-	}
-
-	if len(results) != 3 {
-		t.Errorf("Expected length 3, got %d", len(results))
-	}
-
-	if results[0].nodePool.ID != "6feel" {
-		t.Errorf("Expected NP ID 6feel in the front, got %s", results[0].nodePool.ID)
-	}
-
-	if results[2].sumCPUs != 128 {
-		t.Errorf("Expected 128 CPUs in the third row, got %d", results[2].sumCPUs)
+			if diff := cmp.Diff(tc.output, output); diff != "" {
+				t.Errorf("Case %d - Command output is incorrect. (-expected +got):\n%s", i, diff)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/10437

## Preview

**Table output** (no output flag, or output set to `table`)

![image](https://user-images.githubusercontent.com/13508038/81301280-21290380-9079-11ea-917e-bc7bbc1ce625.png)


**JSON output** (output flag set to `json`)
```json
[
  {
    "availability_zones": [
      "eu-west-1a",
      "eu-west-1c"
    ],
    "id": "f2qef",
    "name": "Some node pool",
    "node_spec": {
      "aws": {
        "instance_distribution": {
          "on_demand_base_capacity": 6
        },
        "instance_type": "c5.xlarge"
      },
      "volume_sizes_gb": {
        "docker": 100,
        "kubelet": 100
      }
    },
    "scaling": {
      "max": 10,
      "min": 3
    },
    "status": {
      "instance_types": null
    },
    "subnet": "172.19.65.0/24"
  },
  {
    "availability_zones": [
      "eu-west-1a"
    ],
    "id": "tj5fg",
    "name": "Some othe rnode pool",
    "node_spec": {
      "aws": {
        "instance_distribution": {
          "on_demand_percentage_above_base_capacity": 100
        },
        "instance_type": "m4.xlarge",
        "use_alike_instance_types": true
      },
      "volume_sizes_gb": {
        "docker": 100,
        "kubelet": 100
      }
    },
    "scaling": {
      "max": 10,
      "min": 3
    },
    "status": {
      "instance_types": null
    },
    "subnet": "172.19.70.0/24"
  }
]
```