### PR TITLE
Display 400 errors properly

### DIFF
--- a/client/error.go
+++ b/client/error.go
@@ -101,6 +101,9 @@ func HandleErrors(err error) {
 	} else if httpStatusCode == http.StatusServiceUnavailable {
 		headline = message
 		subtext = details
+	} else if httpStatusCode == http.StatusBadRequest {
+		headline = message
+		subtext = details
 	} else if message != "" {
 		headline = message
 	}


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/8317

Before this, 400 errors were displayed like this:

![image](https://user-images.githubusercontent.com/13508038/81398400-70c70800-9129-11ea-8304-a4b8baa9c424.png)

Now, we display the actual error that the API returned:

![image](https://user-images.githubusercontent.com/13508038/81398461-85a39b80-9129-11ea-8bb6-45b760c77bda.png)
