### PR TITLE
Deprecate 'gsctl version' command and use '--version' flag instead

### DIFF
--- a/commands/root.go
+++ b/commands/root.go
@@ -44,6 +44,7 @@ var RootCommand = &cobra.Command{
 	Use: config.ProgramName,
 	// this is inherited by all child commands
 	PersistentPreRunE: initConfig,
+	Run:               printResult,
 }
 
 func init() {
@@ -56,6 +57,7 @@ func init() {
 	RootCommand.PersistentFlags().StringVarP(&flags.Token, "auth-token", "", tokenFromEnv, "Authorization token to use")
 	RootCommand.PersistentFlags().StringVarP(&flags.ConfigDirPath, "config-dir", "", config.DefaultConfigDirPath, "Configuration directory path to use")
 	RootCommand.PersistentFlags().BoolVarP(&flags.Verbose, "verbose", "v", false, "Print more information")
+	RootCommand.Flags().Bool("version", false, version.Command.Short)
 
 	// add subcommands
 	RootCommand.AddCommand(CompletionCommand)
@@ -97,4 +99,14 @@ func initConfig(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+func printResult(cmd *cobra.Command, args []string) {
+	isVersion, _ := cmd.Flags().GetBool("version")
+	if isVersion {
+		version.Command.Run(version.Command, nil)
+		return
+	}
+
+	_ = cmd.Help()
 }

--- a/commands/version/command.go
+++ b/commands/version/command.go
@@ -30,8 +30,9 @@ const (
 var (
 	// Command is the "version" go command
 	Command = &cobra.Command{
-		Use:   "version",
-		Short: "Print version number",
+		Use:        "version",
+		Deprecated: "Please use 'gsctl --version' instead.",
+		Short:      "Print version number",
 		Long: `Prints the gsctl version number.
 
 When executed with the -v/--verbose flag, the build date is printed in addition.`,

--- a/commands/version/command.go
+++ b/commands/version/command.go
@@ -31,7 +31,7 @@ var (
 	// Command is the "version" go command
 	Command = &cobra.Command{
 		Use:        "version",
-		Deprecated: "Please use 'gsctl --version' instead.",
+		Deprecated: "please use 'gsctl --version' instead.",
 		Short:      "Print version number",
 		Long: `Prints the gsctl version number.
 


### PR DESCRIPTION
Fixes https://github.com/giantswarm/gsctl/issues/172

This PR deprecates `gsctl version` (it won't show up in the help command, and it will show a warning message if you use it). It will still work , until we're ready to remove it completely.

## Preview (with placeholder versions)

**`$ gsctl version`**

![image](https://user-images.githubusercontent.com/13508038/81851084-36120500-9559-11ea-8a91-91fe4dd65c65.png)

**`$ gsctl --version`**

![image](https://user-images.githubusercontent.com/13508038/81850744-b421dc00-9558-11ea-8d85-db3417307baa.png)

