### PR TITLE
Custom sort parameters for the 'list clusters' command

### DIFF
--- a/commands/list/clusters/command.go
+++ b/commands/list/clusters/command.go
@@ -316,35 +316,35 @@ func createTable(args Arguments) *table.Table {
 			Name:        tableColID,
 			DisplayName: "ID",
 			Sortable: sortable.Sortable{
-				SortType: sortable.Types.String,
+				SortType: sortable.String,
 			},
 		},
 		{
 			Name:        tableColOrg,
 			DisplayName: "ORGANIZATION",
 			Sortable: sortable.Sortable{
-				SortType: sortable.Types.String,
+				SortType: sortable.String,
 			},
 		},
 		{
 			Name:        tableColName,
 			DisplayName: "NAME",
 			Sortable: sortable.Sortable{
-				SortType: sortable.Types.String,
+				SortType: sortable.String,
 			},
 		},
 		{
 			Name:        tableColRelease,
 			DisplayName: "RELEASE",
 			Sortable: sortable.Sortable{
-				SortType: sortable.Types.Semver,
+				SortType: sortable.Semver,
 			},
 		},
 		{
 			Name:        tableColCreateDate,
 			DisplayName: "CREATED",
 			Sortable: sortable.Sortable{
-				SortType: sortable.Types.Date,
+				SortType: sortable.Date,
 			},
 		},
 	}
@@ -355,7 +355,7 @@ func createTable(args Arguments) *table.Table {
 			Name:        tableColDeletingSince,
 			DisplayName: "DELETING SINCE",
 			Sortable: sortable.Sortable{
-				SortType: sortable.Types.Date,
+				SortType: sortable.Date,
 			},
 		})
 	}
@@ -376,7 +376,7 @@ func sortTable(cTable *table.Table, args Arguments) error {
 		}
 	}
 
-	err = cTable.SortByColumnName(sortByColName, sortable.Directions.ASC)
+	err = cTable.SortByColumnName(sortByColName, sortable.ASC)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/commands/list/clusters/command.go
+++ b/commands/list/clusters/command.go
@@ -222,14 +222,14 @@ func getClustersOutput(args Arguments) (string, error) {
 			Name:        "release",
 			DisplayName: "RELEASE",
 			Sortable: sortable.Sortable{
-				SortType: sortable.SortableTypes.Semver,
+				SortType: sortable.Types.Semver,
 			},
 		},
 		table.Column{
 			Name:        "created",
 			DisplayName: "CREATED",
 			Sortable: sortable.Sortable{
-				SortType: sortable.SortableTypes.Date,
+				SortType: sortable.Types.Date,
 			},
 		},
 	}
@@ -297,7 +297,7 @@ func getClustersOutput(args Arguments) (string, error) {
 		rows = append(rows, fields)
 	}
 	cTable.SetRows(rows)
-	err = cTable.SortByColumnName("id", sortable.SortableDirections.ASC)
+	err = cTable.SortByColumnName("id", sortable.Directions.ASC)
 	if err != nil {
 		return "", microerror.Mask(err)
 	}

--- a/commands/list/clusters/command.go
+++ b/commands/list/clusters/command.go
@@ -32,9 +32,22 @@ var (
 		Use:     "clusters",
 		Aliases: []string{"cluster"},
 		Short:   "List clusters",
-		Long:    `Prints a list of all clusters you have access to.`,
-		PreRun:  printValidation,
-		Run:     printResult,
+		Long: `Prints a list of all clusters you have access to.
+
+Examples:
+
+  gsctl list clusters
+
+  gsctl list clusters --output json
+
+  gsctl list clusters --show-deleting
+
+  gsctl list clusters --selector environment=testing
+
+  gsctl list clusters --sort organization
+`,
+		PreRun: printValidation,
+		Run:    printResult,
 	}
 
 	cmdOutput string
@@ -83,7 +96,7 @@ func initFlags() {
 	Command.Flags().StringVarP(&cmdOutput, "output", "o", "table", "Use 'json' for JSON output. Defaults to human-friendly table output.")
 	Command.Flags().BoolVarP(&cmdShowDeleted, "show-deleting", "", false, "Show clusters which are currently being deleted (only with cluster release > 10.0.0).")
 	Command.Flags().StringVarP(&cmdSelector, "selector", "l", "", "Label selector query to filter clusters on.")
-	Command.Flags().StringVarP(&cmdSort, "sort", "s", "", fmt.Sprintf("Sort by one of the fields %s", getFormattedFilterFields(tableCols[:])))
+	Command.Flags().StringVarP(&cmdSort, "sort", "s", "id", fmt.Sprintf("Sort by one of the fields %s", getFormattedFilterFields(tableCols[:])))
 }
 
 type Arguments struct {

--- a/commands/list/clusters/command.go
+++ b/commands/list/clusters/command.go
@@ -43,6 +43,8 @@ var (
 
 	cmdSelector string
 
+	cmdSort string
+
 	arguments Arguments
 )
 
@@ -65,6 +67,7 @@ func initFlags() {
 	Command.Flags().StringVarP(&cmdOutput, "output", "o", "table", "Use 'json' for JSON output. Defaults to human-friendly table output.")
 	Command.Flags().BoolVarP(&cmdShowDeleted, "show-deleting", "", false, "Show clusters which are currently being deleted (only with cluster release > 10.0.0).")
 	Command.Flags().StringVarP(&cmdSelector, "selector", "l", "", "Label selector query to filter clusters on.")
+	Command.Flags().StringVarP(&cmdSort, "sort", "s", "", "Sort by the given field.")
 }
 
 type Arguments struct {
@@ -297,10 +300,7 @@ func getClustersOutput(args Arguments) (string, error) {
 		rows = append(rows, fields)
 	}
 	cTable.SetRows(rows)
-	err = cTable.SortByColumnName("id", sortable.Directions.ASC)
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
+	err = sortTable(&cTable, args)
 
 	clustercache.CacheIDs(args.apiEndpoint, clusterIDs)
 
@@ -324,4 +324,13 @@ func getClustersOutput(args Arguments) (string, error) {
 	}
 
 	return output, nil
+}
+
+func sortTable(cTable *table.Table, args Arguments) error {
+	err := cTable.SortByColumnName("id", sortable.Directions.ASC)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
 }

--- a/commands/list/clusters/command.go
+++ b/commands/list/clusters/command.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/giantswarm/gsctl/clustercache"
+	"github.com/giantswarm/gsctl/pkg/sortable"
 	"github.com/giantswarm/gsctl/pkg/table"
 
 	"github.com/giantswarm/gsctl/client"
@@ -220,15 +221,15 @@ func getClustersOutput(args Arguments) (string, error) {
 		table.Column{
 			Name:        "release",
 			DisplayName: "RELEASE",
-			Sortable: table.Sortable{
-				SortType: table.SortableTypes.Semver,
+			Sortable: sortable.Sortable{
+				SortType: sortable.SortableTypes.Semver,
 			},
 		},
 		table.Column{
 			Name:        "created",
 			DisplayName: "CREATED",
-			Sortable: table.Sortable{
-				SortType: table.SortableTypes.Date,
+			Sortable: sortable.Sortable{
+				SortType: sortable.SortableTypes.Date,
 			},
 		},
 	}
@@ -296,7 +297,7 @@ func getClustersOutput(args Arguments) (string, error) {
 		rows = append(rows, fields)
 	}
 	cTable.SetRows(rows)
-	err = cTable.SortByColumnName("id", table.SortableDirections.ASC)
+	err = cTable.SortByColumnName("id", sortable.SortableDirections.ASC)
 	if err != nil {
 		return "", microerror.Mask(err)
 	}

--- a/commands/list/clusters/command.go
+++ b/commands/list/clusters/command.go
@@ -186,11 +186,6 @@ func getClustersOutput(args Arguments) (string, error) {
 	}
 
 	if args.outputFormat == "json" {
-		// sort clusters by ID
-		sort.Slice(response.Payload[:], func(i, j int) bool {
-			return response.Payload[i].ID < response.Payload[j].ID
-		})
-
 		var clusters []*models.V4ClusterListItem
 		{
 			for _, cluster := range response.Payload {
@@ -202,12 +197,13 @@ func getClustersOutput(args Arguments) (string, error) {
 			}
 		}
 
-		outputBytes, err := json.MarshalIndent(clusters, outputJSONPrefix, outputJSONIndent)
+		var output string
+		output, err = getJSONOutput(clusters, arguments)
 		if err != nil {
 			return "", microerror.Mask(err)
 		}
 
-		return string(outputBytes), nil
+		return output, nil
 	}
 
 	headers := []table.Column{
@@ -302,6 +298,7 @@ func getClustersOutput(args Arguments) (string, error) {
 		rows = append(rows, fields)
 	}
 	cTable.SetRows(rows)
+
 	err = sortTable(&cTable, args)
 	if err != nil {
 		return "", microerror.Mask(err)
@@ -348,4 +345,18 @@ func sortTable(cTable *table.Table, args Arguments) error {
 	}
 
 	return nil
+}
+
+func getJSONOutput(clusterList []*models.V4ClusterListItem, args Arguments) (string, error) {
+	// sort clusters by ID
+	sort.Slice(clusterList[:], func(i, j int) bool {
+		return clusterList[i].ID < clusterList[j].ID
+	})
+
+	outputBytes, err := json.MarshalIndent(clusterList, outputJSONPrefix, outputJSONIndent)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return string(outputBytes), nil
 }

--- a/commands/list/clusters/command.go
+++ b/commands/list/clusters/command.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"sort"
 	"time"
 
 	"github.com/fatih/color"
@@ -405,26 +404,7 @@ func getJSONOutput(clusterList []*models.V4ClusterListItem, cTable *table.Table,
 		}
 	}
 
-	compareFunc := sortable.GetCompareFunc(sortByColumn.SortType)
-	sort.Slice(clustersAsMapList, func(i, j int) bool {
-		iField := "n/a"
-		{
-			iValue, ok := clustersAsMapList[i][fieldMapping[sortByColumn.Name]]
-			if ok {
-				iField = iValue.(string)
-			}
-		}
-
-		jField := "n/a"
-		{
-			jValue, ok := clustersAsMapList[j][fieldMapping[sortByColumn.Name]]
-			if ok {
-				jField = jValue.(string)
-			}
-		}
-
-		return compareFunc(iField, jField, sortable.Directions.ASC)
-	})
+	table.SortMapSliceUsingColumnData(clustersAsMapList, sortByColumn, fieldMapping)
 
 	output, err = json.MarshalIndent(clustersAsMapList, outputJSONPrefix, outputJSONIndent)
 	if err != nil {

--- a/commands/list/clusters/command.go
+++ b/commands/list/clusters/command.go
@@ -179,12 +179,12 @@ func getClustersOutput(args Arguments) (string, error) {
 		return "", microerror.Mask(err)
 	}
 
-	// sort clusters by ID
-	sort.Slice(response.Payload[:], func(i, j int) bool {
-		return response.Payload[i].ID < response.Payload[j].ID
-	})
-
 	if args.outputFormat == "json" {
+		// sort clusters by ID
+		sort.Slice(response.Payload[:], func(i, j int) bool {
+			return response.Payload[i].ID < response.Payload[j].ID
+		})
+
 		var clusters []*models.V4ClusterListItem
 		{
 			for _, cluster := range response.Payload {
@@ -290,6 +290,10 @@ func getClustersOutput(args Arguments) (string, error) {
 		rows = append(rows, fields)
 	}
 	cTable.SetRows(rows)
+	err = cTable.SortByColumnName("id", table.SortableDirections.ASC)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
 
 	clustercache.CacheIDs(args.apiEndpoint, clusterIDs)
 

--- a/commands/list/clusters/command.go
+++ b/commands/list/clusters/command.go
@@ -308,7 +308,7 @@ func getClustersOutput(args Arguments) (string, error) {
 	output := ""
 
 	// Only show table when there is content.
-	if len(rows) > 1 {
+	if len(rows) > 0 {
 		output += cTable.String()
 	} else {
 		output += color.YellowString("No clusters")

--- a/commands/list/clusters/command.go
+++ b/commands/list/clusters/command.go
@@ -64,6 +64,15 @@ const (
 	tableColDeletingSince = "deleting-since"
 )
 
+var tableCols = [...]string{
+	tableColID,
+	tableColCreateDate,
+	tableColName,
+	tableColOrg,
+	tableColRelease,
+	tableColDeletingSince,
+}
+
 func init() {
 	initFlags()
 }

--- a/commands/list/clusters/command.go
+++ b/commands/list/clusters/command.go
@@ -378,17 +378,15 @@ func createTable(args Arguments) *table.Table {
 				SortType: sortable.Date,
 			},
 		},
-	}
-
-	// Add the 'Deleting since' column if seeing deleted clusters is desired.
-	if args.showDeleting {
-		headers = append(headers, table.Column{
+		{
 			Name:        tableColDeletingSince,
 			DisplayName: "DELETING SINCE",
 			Sortable: sortable.Sortable{
 				SortType: sortable.Date,
 			},
-		})
+			// Only display the 'Deleting since' column if seeing deleted clusters is desired.
+			Hidden: !args.showDeleting,
+		},
 	}
 	t.SetColumns(headers)
 

--- a/commands/list/clusters/command.go
+++ b/commands/list/clusters/command.go
@@ -83,7 +83,7 @@ func initFlags() {
 	Command.Flags().StringVarP(&cmdOutput, "output", "o", "table", "Use 'json' for JSON output. Defaults to human-friendly table output.")
 	Command.Flags().BoolVarP(&cmdShowDeleted, "show-deleting", "", false, "Show clusters which are currently being deleted (only with cluster release > 10.0.0).")
 	Command.Flags().StringVarP(&cmdSelector, "selector", "l", "", "Label selector query to filter clusters on.")
-	Command.Flags().StringVarP(&cmdSort, "sort", "s", "", "Sort by the given field.")
+	Command.Flags().StringVarP(&cmdSort, "sort", "s", "", fmt.Sprintf("Sort by one of the fields %s", getFormattedFilterFields(tableCols[:])))
 }
 
 type Arguments struct {
@@ -196,6 +196,20 @@ func printResult(cmd *cobra.Command, cmdLineArgs []string) {
 	if output != "" {
 		fmt.Println(output)
 	}
+}
+
+func getFormattedFilterFields(colNames []string) string {
+	var result string
+	for _, col := range colNames {
+		if result != "" {
+			result += ", "
+		}
+
+		nameAsRuneSlice := []rune(col)
+		result += fmt.Sprintf("%v(%v)", string(nameAsRuneSlice[:1]), string(nameAsRuneSlice[1:]))
+	}
+
+	return result
 }
 
 // getClustersOutput returns a table of clusters the user has access to

--- a/commands/list/clusters/command.go
+++ b/commands/list/clusters/command.go
@@ -306,14 +306,23 @@ func createTable(args Arguments) *table.Table {
 		{
 			Name:        tableColID,
 			DisplayName: "ID",
+			Sortable: sortable.Sortable{
+				SortType: sortable.Types.String,
+			},
 		},
 		{
 			Name:        tableColOrg,
 			DisplayName: "ORGANIZATION",
+			Sortable: sortable.Sortable{
+				SortType: sortable.Types.String,
+			},
 		},
 		{
 			Name:        tableColName,
 			DisplayName: "NAME",
+			Sortable: sortable.Sortable{
+				SortType: sortable.Types.String,
+			},
 		},
 		{
 			Name:        tableColRelease,
@@ -336,6 +345,9 @@ func createTable(args Arguments) *table.Table {
 		headers = append(headers, table.Column{
 			Name:        tableColDeletingSince,
 			DisplayName: "DELETING SINCE",
+			Sortable: sortable.Sortable{
+				SortType: sortable.Types.Date,
+			},
 		})
 	}
 	t.SetColumns(headers)

--- a/commands/list/clusters/command.go
+++ b/commands/list/clusters/command.go
@@ -44,7 +44,7 @@ Examples:
 
   gsctl list clusters --selector environment=testing
 
-  gsctl list clusters --sort organization
+  gsctl list clusters --sort org
 `,
 		PreRun: printValidation,
 		Run:    printResult,

--- a/commands/list/clusters/command.go
+++ b/commands/list/clusters/command.go
@@ -303,6 +303,9 @@ func getClustersOutput(args Arguments) (string, error) {
 	}
 	cTable.SetRows(rows)
 	err = sortTable(&cTable, args)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
 
 	clustercache.CacheIDs(args.apiEndpoint, clusterIDs)
 

--- a/commands/list/clusters/command.go
+++ b/commands/list/clusters/command.go
@@ -351,13 +351,19 @@ func getJSONOutput(clusterList []*models.V4ClusterListItem, cTable *table.Table,
 	var (
 		err    error
 		output []byte
+
+		sortByColumnName = "id"
+		sortByColumn     table.Column
 	)
 
-	var sortByColumn table.Column
 	if args.sortBy != "" {
+		sortByColumnName = args.sortBy
+	}
+
+	if sortByColumnName != "" {
 		var colName string
 
-		colName, err = cTable.GetColumnNameFromInitials(args.sortBy)
+		colName, err = cTable.GetColumnNameFromInitials(sortByColumnName)
 		if err != nil {
 			return "", microerror.Mask(err)
 		}
@@ -368,7 +374,7 @@ func getJSONOutput(clusterList []*models.V4ClusterListItem, cTable *table.Table,
 		}
 	}
 
-	if args.sortBy == "" || len(clusterList) < 2 {
+	if len(clusterList) < 2 {
 		output, err = json.MarshalIndent(clusterList, outputJSONPrefix, outputJSONIndent)
 		if err != nil {
 			return "", microerror.Mask(err)

--- a/commands/list/clusters/command.go
+++ b/commands/list/clusters/command.go
@@ -220,10 +220,16 @@ func getClustersOutput(args Arguments) (string, error) {
 		table.Column{
 			Name:        "release",
 			DisplayName: "RELEASE",
+			Sortable: table.Sortable{
+				SortType: table.SortableTypes.Semver,
+			},
 		},
 		table.Column{
 			Name:        "created",
 			DisplayName: "CREATED",
+			Sortable: table.Sortable{
+				SortType: table.SortableTypes.Date,
+			},
 		},
 	}
 

--- a/commands/list/clusters/command.go
+++ b/commands/list/clusters/command.go
@@ -77,6 +77,7 @@ type Arguments struct {
 	scheme            string
 	selector          string
 	showDeleting      bool
+	sortBy            string
 	userProvidedToken string
 }
 
@@ -92,6 +93,7 @@ func collectArguments() Arguments {
 		scheme:            scheme,
 		selector:          cmdSelector,
 		showDeleting:      cmdShowDeleted,
+		sortBy:            cmdSort,
 		userProvidedToken: flags.Token,
 	}
 }
@@ -327,7 +329,17 @@ func getClustersOutput(args Arguments) (string, error) {
 }
 
 func sortTable(cTable *table.Table, args Arguments) error {
-	err := cTable.SortByColumnName("id", sortable.Directions.ASC)
+	var err error
+
+	sortByColName := "id"
+	if args.sortBy != "" {
+		sortByColName, err = cTable.GetColumnNameFromInitials(args.sortBy)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	err = cTable.SortByColumnName(sortByColName, sortable.Directions.ASC)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/evanphx/json-patch v4.5.0+incompatible // indirect
+	github.com/facette/natsort v0.0.0-20181210072756-2cd4dd1e2dcb
 	github.com/fatih/color v1.9.0
 	github.com/giantswarm/apiextensions v0.0.0-20191213075442-71155aa0f5b7
 	github.com/giantswarm/columnize v2.0.3-0.20190718092621-cc99d98ffb29+incompatible

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/Jeffail/gabs v1.4.0
 	github.com/Masterminds/semver v1.5.0
+	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/evanphx/json-patch v4.5.0+incompatible // indirect
 	github.com/fatih/color v1.9.0
 	github.com/giantswarm/apiextensions v0.0.0-20191213075442-71155aa0f5b7

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,8 @@ github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.5.0+incompatible h1:ouOWdg56aJriqS0huScTkVXPC5IcNrDCXZ6OoTAWu7M=
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/facette/natsort v0.0.0-20181210072756-2cd4dd1e2dcb h1:IT4JYU7k4ikYg1SCxNI1/Tieq/NFvh6dzLdgi7eu0tM=
+github.com/facette/natsort v0.0.0-20181210072756-2cd4dd1e2dcb/go.mod h1:bH6Xx7IW64qjjJq8M2u4dxNaBiDfKK+z/3eGDpXEQhc=
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
+github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a h1:idn718Q4B6AGu/h5Sxe66HYVdqdGu2l9Iebqhi/AEoA=

--- a/pkg/sortable/sort.go
+++ b/pkg/sortable/sort.go
@@ -6,6 +6,7 @@ import (
 	"github.com/giantswarm/gsctl/util"
 )
 
+// Types represent the kinds of data that can be in a string field.
 var Types = struct {
 	String string
 	Semver string
@@ -16,6 +17,7 @@ var Types = struct {
 	Date:   "date",
 }
 
+// Directions represent the sorting direction possibilities.
 var Directions = struct {
 	ASC  string
 	DESC string
@@ -24,10 +26,12 @@ var Directions = struct {
 	DESC: "desc",
 }
 
+// Sortable makes the data type that embeds it, sortable.
 type Sortable struct {
 	SortType string
 }
 
+// CompareStrings represents the comparison algorithm for regular strings.
 func CompareStrings(a string, b string, direction string) bool {
 	if direction == Directions.DESC {
 		return a > b
@@ -36,6 +40,7 @@ func CompareStrings(a string, b string, direction string) bool {
 	return a < b
 }
 
+// CompareSemvers represents the comparison algorithm for string-encoded versions, in semver format.
 func CompareSemvers(a string, b string, direction string) bool {
 	verA, err := semver.NewVersion(a)
 	if err != nil {
@@ -55,6 +60,7 @@ func CompareSemvers(a string, b string, direction string) bool {
 	return cmp <= 0
 }
 
+// CompareDates represents the comparison algorithm for string-encoded dates.
 func CompareDates(a string, b string, direction string) bool {
 	dateA := util.ParseDate(a)
 	dateB := util.ParseDate(b)
@@ -67,6 +73,7 @@ func CompareDates(a string, b string, direction string) bool {
 	return cmp == false
 }
 
+// GetCompareFunc gets the right comparison algorithm for the provided type.
 func GetCompareFunc(t string) func(string, string, string) bool {
 	switch t {
 	case Types.String:
@@ -82,5 +89,3 @@ func GetCompareFunc(t string) func(string, string, string) bool {
 		return CompareStrings
 	}
 }
-
-type CompareFunc func(int, int) bool

--- a/pkg/sortable/sort.go
+++ b/pkg/sortable/sort.go
@@ -6,25 +6,18 @@ import (
 	"github.com/giantswarm/gsctl/util"
 )
 
-// Types represent the kinds of data that can be in a string field.
-var Types = struct {
-	String string
-	Semver string
-	Date   string
-}{
-	String: "string",
-	Semver: "semver",
-	Date:   "date",
-}
+// The kinds of data that can be in a string field.
+const (
+	String = "string"
+	Semver = "semver"
+	Date   = "date"
+)
 
-// Directions represent the sorting direction possibilities.
-var Directions = struct {
-	ASC  string
-	DESC string
-}{
-	ASC:  "asc",
-	DESC: "desc",
-}
+// The sorting direction possibilities.
+const (
+	ASC  = "asc"
+	DESC = "desc"
+)
 
 // Sortable makes the data type that embeds it, sortable.
 type Sortable struct {
@@ -33,7 +26,7 @@ type Sortable struct {
 
 // CompareStrings represents the comparison algorithm for regular strings.
 func CompareStrings(a string, b string, direction string) bool {
-	if direction == Directions.DESC {
+	if direction == DESC {
 		return a > b
 	}
 
@@ -53,7 +46,7 @@ func CompareSemvers(a string, b string, direction string) bool {
 	}
 
 	cmp := verA.Compare(verB)
-	if direction == Directions.DESC {
+	if direction == DESC {
 		return cmp > 0
 	}
 
@@ -66,7 +59,7 @@ func CompareDates(a string, b string, direction string) bool {
 	dateB := util.ParseDate(b)
 
 	cmp := dateA.After(dateB)
-	if direction == Directions.DESC {
+	if direction == DESC {
 		return cmp
 	}
 
@@ -76,13 +69,13 @@ func CompareDates(a string, b string, direction string) bool {
 // GetCompareFunc gets the right comparison algorithm for the provided type.
 func GetCompareFunc(t string) func(string, string, string) bool {
 	switch t {
-	case Types.String:
+	case String:
 		return CompareStrings
 
-	case Types.Date:
+	case Date:
 		return CompareDates
 
-	case Types.Semver:
+	case Semver:
 		return CompareSemvers
 
 	default:

--- a/pkg/sortable/sort.go
+++ b/pkg/sortable/sort.go
@@ -62,8 +62,8 @@ func CompareSemvers(a string, b string, direction string) bool {
 
 // CompareDates represents the comparison algorithm for string-encoded dates.
 func CompareDates(a string, b string, direction string) bool {
-	dateA := util.ParseDate(a)
-	dateB := util.ParseDate(b)
+	dateA := util.ParseShortDate(a)
+	dateB := util.ParseShortDate(b)
 
 	cmp := dateA.After(dateB)
 	if direction == Directions.DESC {

--- a/pkg/sortable/sort.go
+++ b/pkg/sortable/sort.go
@@ -6,7 +6,7 @@ import (
 	"github.com/giantswarm/gsctl/util"
 )
 
-var SortableTypes = struct {
+var Types = struct {
 	String string
 	Semver string
 	Date   string
@@ -16,7 +16,7 @@ var SortableTypes = struct {
 	Date:   "date",
 }
 
-var SortableDirections = struct {
+var Directions = struct {
 	ASC  string
 	DESC string
 }{
@@ -29,7 +29,7 @@ type Sortable struct {
 }
 
 func CompareStrings(a string, b string, direction string) bool {
-	if direction == SortableDirections.DESC {
+	if direction == Directions.DESC {
 		return a > b
 	}
 
@@ -48,7 +48,7 @@ func CompareSemvers(a string, b string, direction string) bool {
 	}
 
 	cmp := verA.Compare(verB)
-	if direction == SortableDirections.DESC {
+	if direction == Directions.DESC {
 		return cmp > 0
 	}
 
@@ -60,7 +60,7 @@ func CompareDates(a string, b string, direction string) bool {
 	dateB := util.ParseDate(b)
 
 	cmp := dateA.After(dateB)
-	if direction == SortableDirections.DESC {
+	if direction == Directions.DESC {
 		return cmp
 	}
 
@@ -69,13 +69,13 @@ func CompareDates(a string, b string, direction string) bool {
 
 func GetCompareFunc(t string) func(string, string, string) bool {
 	switch t {
-	case SortableTypes.String:
+	case Types.String:
 		return CompareStrings
 
-	case SortableTypes.Date:
+	case Types.Date:
 		return CompareDates
 
-	case SortableTypes.Semver:
+	case Types.Semver:
 		return CompareSemvers
 
 	default:

--- a/pkg/sortable/sort.go
+++ b/pkg/sortable/sort.go
@@ -1,4 +1,4 @@
-package table
+package sortable
 
 import (
 	"github.com/Masterminds/semver"

--- a/pkg/sortable/sort.go
+++ b/pkg/sortable/sort.go
@@ -3,6 +3,8 @@ package sortable
 import (
 	"github.com/Masterminds/semver"
 
+	stringsort "github.com/facette/natsort"
+
 	"github.com/giantswarm/gsctl/util"
 )
 
@@ -26,11 +28,13 @@ type Sortable struct {
 
 // CompareStrings represents the comparison algorithm for regular strings.
 func CompareStrings(a string, b string, direction string) bool {
+	result := stringsort.Compare(a, b)
+
 	if direction == DESC {
-		return a > b
+		return !result
 	}
 
-	return a < b
+	return result
 }
 
 // CompareSemvers represents the comparison algorithm for string-encoded versions, in semver format.

--- a/pkg/sortable/sort.go
+++ b/pkg/sortable/sort.go
@@ -62,8 +62,8 @@ func CompareSemvers(a string, b string, direction string) bool {
 
 // CompareDates represents the comparison algorithm for string-encoded dates.
 func CompareDates(a string, b string, direction string) bool {
-	dateA := util.ParseShortDate(a)
-	dateB := util.ParseShortDate(b)
+	dateA := util.ParseDate(a)
+	dateB := util.ParseDate(b)
 
 	cmp := dateA.After(dateB)
 	if direction == Directions.DESC {

--- a/pkg/sortable/sort.go
+++ b/pkg/sortable/sort.go
@@ -1,6 +1,8 @@
 package sortable
 
 import (
+	"strings"
+
 	"github.com/Masterminds/semver"
 
 	stringsort "github.com/facette/natsort"
@@ -28,7 +30,7 @@ type Sortable struct {
 
 // CompareStrings represents the comparison algorithm for regular strings.
 func CompareStrings(a string, b string, direction string) bool {
-	result := stringsort.Compare(a, b)
+	result := stringsort.Compare(strings.ToLower(a), strings.ToLower(b))
 
 	if direction == DESC {
 		return !result

--- a/pkg/sortable/sort_test.go
+++ b/pkg/sortable/sort_test.go
@@ -127,6 +127,18 @@ func Test_CompareSemvers(t *testing.T) {
 			direction:      Directions.DESC,
 			expectedResult: false,
 		},
+		{
+			a:              "clearly-not-semver",
+			b:              "1.0.1",
+			direction:      Directions.ASC,
+			expectedResult: false,
+		},
+		{
+			a:              "1.0.1",
+			b:              "clearly-not-semver",
+			direction:      Directions.ASC,
+			expectedResult: false,
+		},
 	}
 
 	for i, tc := range testCases {

--- a/pkg/sortable/sort_test.go
+++ b/pkg/sortable/sort_test.go
@@ -12,14 +12,14 @@ func Test_GetCompareFunc(t *testing.T) {
 		fn           func(string, string, string) bool
 	}{
 		{
-			sortableType: Types.String,
+			sortableType: String,
 			fn:           CompareStrings,
 		}, {
-			sortableType: Types.Date,
+			sortableType: Date,
 			fn:           CompareDates,
 		},
 		{
-			sortableType: Types.Semver,
+			sortableType: Semver,
 			fn:           CompareSemvers,
 		},
 		{
@@ -50,37 +50,37 @@ func Test_CompareStrings(t *testing.T) {
 		{
 			a:              "some-string",
 			b:              "some-other-string",
-			direction:      Directions.ASC,
+			direction:      ASC,
 			expectedResult: false,
 		},
 		{
 			a:              "some-string",
 			b:              "some-other-string",
-			direction:      Directions.DESC,
+			direction:      DESC,
 			expectedResult: true,
 		},
 		{
 			a:              "12312assdaads",
 			b:              "some-string",
-			direction:      Directions.ASC,
+			direction:      ASC,
 			expectedResult: true,
 		},
 		{
 			a:              "12312assdaads",
 			b:              "some-string",
-			direction:      Directions.DESC,
+			direction:      DESC,
 			expectedResult: false,
 		},
 		{
 			a:              "_!ldsanl",
 			b:              "some-string",
-			direction:      Directions.ASC,
+			direction:      ASC,
 			expectedResult: true,
 		},
 		{
 			a:              "_!ldsanl",
 			b:              "some-string",
-			direction:      Directions.DESC,
+			direction:      DESC,
 			expectedResult: false,
 		},
 	}
@@ -106,37 +106,37 @@ func Test_CompareSemvers(t *testing.T) {
 		{
 			a:              "1.0.0",
 			b:              "1.0.1",
-			direction:      Directions.ASC,
+			direction:      ASC,
 			expectedResult: true,
 		},
 		{
 			a:              "1.0.0",
 			b:              "1.0.1",
-			direction:      Directions.DESC,
+			direction:      DESC,
 			expectedResult: false,
 		},
 		{
 			a:              "0.0.9",
 			b:              "1.0.1",
-			direction:      Directions.ASC,
+			direction:      ASC,
 			expectedResult: true,
 		},
 		{
 			a:              "0.0.9",
 			b:              "1.0.1",
-			direction:      Directions.DESC,
+			direction:      DESC,
 			expectedResult: false,
 		},
 		{
 			a:              "clearly-not-semver",
 			b:              "1.0.1",
-			direction:      Directions.ASC,
+			direction:      ASC,
 			expectedResult: false,
 		},
 		{
 			a:              "1.0.1",
 			b:              "clearly-not-semver",
-			direction:      Directions.ASC,
+			direction:      ASC,
 			expectedResult: false,
 		},
 	}
@@ -162,25 +162,25 @@ func Test_CompareDates(t *testing.T) {
 		{
 			a:              "1999 Nov 24, 00:57 UTC",
 			b:              "2016 Dec 05, 14:41 UTC",
-			direction:      Directions.ASC,
+			direction:      ASC,
 			expectedResult: true,
 		},
 		{
 			a:              "1999 Nov 24, 00:57 UTC",
 			b:              "2016 Dec 05, 14:41 UTC",
-			direction:      Directions.DESC,
+			direction:      DESC,
 			expectedResult: false,
 		},
 		{
 			a:              "1999-11-24T00:57:28.999999Z",
 			b:              "2006-01-02T15:04:05.000Z",
-			direction:      Directions.ASC,
+			direction:      ASC,
 			expectedResult: true,
 		},
 		{
 			a:              "1999-11-24T00:57:28.999999Z",
 			b:              "2006-01-02T15:04:05.000Z",
-			direction:      Directions.DESC,
+			direction:      DESC,
 			expectedResult: false,
 		},
 	}

--- a/pkg/sortable/sort_test.go
+++ b/pkg/sortable/sort_test.go
@@ -1,0 +1,185 @@
+package sortable
+
+import (
+	"reflect"
+	"strconv"
+	"testing"
+)
+
+func Test_GetCompareFunc(t *testing.T) {
+	testCases := []struct {
+		sortableType string
+		fn           func(string, string, string) bool
+	}{
+		{
+			sortableType: Types.String,
+			fn:           CompareStrings,
+		}, {
+			sortableType: Types.Date,
+			fn:           CompareDates,
+		},
+		{
+			sortableType: Types.Semver,
+			fn:           CompareSemvers,
+		},
+		{
+			sortableType: "random",
+			fn:           CompareStrings,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			result := reflect.ValueOf(GetCompareFunc(tc.sortableType))
+			expectedFn := reflect.ValueOf(tc.fn)
+
+			if result.Pointer() != expectedFn.Pointer() {
+				t.Errorf("Case %d - Result did not match", i)
+			}
+		})
+	}
+}
+
+func Test_CompareStrings(t *testing.T) {
+	testCases := []struct {
+		a              string
+		b              string
+		direction      string
+		expectedResult bool
+	}{
+		{
+			a:              "some-string",
+			b:              "some-other-string",
+			direction:      Directions.ASC,
+			expectedResult: false,
+		},
+		{
+			a:              "some-string",
+			b:              "some-other-string",
+			direction:      Directions.DESC,
+			expectedResult: true,
+		},
+		{
+			a:              "12312assdaads",
+			b:              "some-string",
+			direction:      Directions.ASC,
+			expectedResult: true,
+		},
+		{
+			a:              "12312assdaads",
+			b:              "some-string",
+			direction:      Directions.DESC,
+			expectedResult: false,
+		},
+		{
+			a:              "_!ldsanl",
+			b:              "some-string",
+			direction:      Directions.ASC,
+			expectedResult: true,
+		},
+		{
+			a:              "_!ldsanl",
+			b:              "some-string",
+			direction:      Directions.DESC,
+			expectedResult: false,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			result := CompareStrings(tc.a, tc.b, tc.direction)
+
+			if result != tc.expectedResult {
+				t.Errorf("Case %d - Expected %t, got %t", i, tc.expectedResult, result)
+			}
+		})
+	}
+}
+
+func Test_CompareSemvers(t *testing.T) {
+	testCases := []struct {
+		a              string
+		b              string
+		direction      string
+		expectedResult bool
+	}{
+		{
+			a:              "1.0.0",
+			b:              "1.0.1",
+			direction:      Directions.ASC,
+			expectedResult: true,
+		},
+		{
+			a:              "1.0.0",
+			b:              "1.0.1",
+			direction:      Directions.DESC,
+			expectedResult: false,
+		},
+		{
+			a:              "0.0.9",
+			b:              "1.0.1",
+			direction:      Directions.ASC,
+			expectedResult: true,
+		},
+		{
+			a:              "0.0.9",
+			b:              "1.0.1",
+			direction:      Directions.DESC,
+			expectedResult: false,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			result := CompareSemvers(tc.a, tc.b, tc.direction)
+
+			if result != tc.expectedResult {
+				t.Errorf("Case %d - Expected %t, got %t", i, tc.expectedResult, result)
+			}
+		})
+	}
+}
+
+func Test_CompareDates(t *testing.T) {
+	testCases := []struct {
+		a              string
+		b              string
+		direction      string
+		expectedResult bool
+	}{
+		{
+			a:              "1999 Nov 24, 00:57 UTC",
+			b:              "2016 Dec 05, 14:41 UTC",
+			direction:      Directions.ASC,
+			expectedResult: true,
+		},
+		{
+			a:              "1999 Nov 24, 00:57 UTC",
+			b:              "2016 Dec 05, 14:41 UTC",
+			direction:      Directions.DESC,
+			expectedResult: false,
+		},
+		{
+			a:              "1999-11-24T00:57:28.999999Z",
+			b:              "2006-01-02T15:04:05.000Z",
+			direction:      Directions.ASC,
+			expectedResult: true,
+		},
+		{
+			a:              "1999-11-24T00:57:28.999999Z",
+			b:              "2006-01-02T15:04:05.000Z",
+			direction:      Directions.DESC,
+			expectedResult: false,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			result := CompareDates(tc.a, tc.b, tc.direction)
+
+			if result != tc.expectedResult {
+				t.Errorf("Case %d - Expected %t, got %t", i, tc.expectedResult, result)
+			}
+		})
+	}
+}

--- a/pkg/sortable/sort_test.go
+++ b/pkg/sortable/sort_test.go
@@ -55,7 +55,7 @@ func Test_CompareStrings(t *testing.T) {
 		},
 		{
 			a:              "some-string",
-			b:              "some-other-string",
+			b:              "Some-other-string",
 			direction:      DESC,
 			expectedResult: true,
 		},

--- a/pkg/table/column.go
+++ b/pkg/table/column.go
@@ -1,0 +1,22 @@
+package table
+
+import (
+	"github.com/fatih/color"
+)
+
+type Column struct {
+	Name        string
+	DisplayName string
+}
+
+func (c *Column) GetHeader() string {
+	header := c.Name
+
+	if c.DisplayName != "" {
+		header = c.DisplayName
+	}
+
+	header = color.CyanString(header)
+
+	return header
+}

--- a/pkg/table/column.go
+++ b/pkg/table/column.go
@@ -14,6 +14,7 @@ type Column struct {
 	Name string
 	// DisplayName represents the table header visible in the printed table.
 	DisplayName string
+	Hidden      bool
 }
 
 // GetHeader gets the table header for the current column.

--- a/pkg/table/column.go
+++ b/pkg/table/column.go
@@ -2,10 +2,12 @@ package table
 
 import (
 	"github.com/fatih/color"
+
+	"github.com/giantswarm/gsctl/pkg/sortable"
 )
 
 type Column struct {
-	Sortable
+	sortable.Sortable
 	Name        string
 	DisplayName string
 }

--- a/pkg/table/column.go
+++ b/pkg/table/column.go
@@ -6,12 +6,17 @@ import (
 	"github.com/giantswarm/gsctl/pkg/sortable"
 )
 
+// Column represents the data structure of a table column.
 type Column struct {
 	sortable.Sortable
-	Name        string
+	// Name represents the column name that will be used for sorting,
+	// and as a default table header.
+	Name string
+	// DisplayName represents the table header visible in the printed table.
 	DisplayName string
 }
 
+// GetHeader gets the table header for the current column.
 func (c *Column) GetHeader() string {
 	header := c.Name
 

--- a/pkg/table/column.go
+++ b/pkg/table/column.go
@@ -5,6 +5,7 @@ import (
 )
 
 type Column struct {
+	Sortable
 	Name        string
 	DisplayName string
 }

--- a/pkg/table/column_test.go
+++ b/pkg/table/column_test.go
@@ -1,0 +1,37 @@
+package table
+
+import (
+	"strconv"
+	"testing"
+)
+
+func Test_GetHeader(t *testing.T) {
+	testCases := []struct {
+		column         Column
+		expectedResult string
+	}{
+		{
+			column: Column{
+				Name: "some-name",
+			},
+			expectedResult: "some-name",
+		},
+		{
+			column: Column{
+				Name:        "some-name",
+				DisplayName: "Cool Display Name",
+			},
+			expectedResult: "Cool Display Name",
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			result := tc.column.GetHeader()
+
+			if result != tc.expectedResult {
+				t.Errorf("Case %d - Expected %s, got %s", i, tc.expectedResult, result)
+			}
+		})
+	}
+}

--- a/pkg/table/error.go
+++ b/pkg/table/error.go
@@ -1,0 +1,23 @@
+package table
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var objectNotSliceError = &microerror.Error{
+	Kind: "objectNotSliceError",
+}
+
+// IsObjectNotSliceError asserts objectNotSliceError.
+func IsObjectNotSliceError(err error) bool {
+	return microerror.Cause(err) == objectNotSliceError
+}
+
+var columnNotFoundError = &microerror.Error{
+	Kind: "columnNotFoundError",
+}
+
+// IsColumnNotFoundError asserts columnNotFoundError.
+func IsColumnNotFoundError(err error) bool {
+	return microerror.Cause(err) == columnNotFoundError
+}

--- a/pkg/table/error.go
+++ b/pkg/table/error.go
@@ -13,11 +13,20 @@ func IsObjectNotSliceError(err error) bool {
 	return microerror.Cause(err) == objectNotSliceError
 }
 
-var columnNotFoundError = &microerror.Error{
-	Kind: "columnNotFoundError",
+var fieldNotFoundError = &microerror.Error{
+	Kind: "fieldNotFoundError",
 }
 
-// IsColumnNotFoundError asserts columnNotFoundError.
-func IsColumnNotFoundError(err error) bool {
-	return microerror.Cause(err) == columnNotFoundError
+// IsFieldNotFoundError asserts fieldNotFoundError.
+func IsFieldNotFoundError(err error) bool {
+	return microerror.Cause(err) == fieldNotFoundError
+}
+
+var multipleFieldsMatchingError = &microerror.Error{
+	Kind: "multipleFieldsMatchingError",
+}
+
+// IsMultipleFieldsMatchingError asserts multipleFieldsMatchingError.
+func IsMultipleFieldsMatchingError(err error) bool {
+	return microerror.Cause(err) == multipleFieldsMatchingError
 }

--- a/pkg/table/error.go
+++ b/pkg/table/error.go
@@ -4,15 +4,6 @@ import (
 	"github.com/giantswarm/microerror"
 )
 
-var objectNotSliceError = &microerror.Error{
-	Kind: "objectNotSliceError",
-}
-
-// IsObjectNotSliceError asserts objectNotSliceError.
-func IsObjectNotSliceError(err error) bool {
-	return microerror.Cause(err) == objectNotSliceError
-}
-
 var fieldNotFoundError = &microerror.Error{
 	Kind: "fieldNotFoundError",
 }

--- a/pkg/table/sort.go
+++ b/pkg/table/sort.go
@@ -29,7 +29,7 @@ func SortMapSliceUsingColumnData(mapSlice []map[string]interface{}, byCol Column
 			}
 		}
 
-		return compareFunc(iField, jField, sortable.Directions.ASC)
+		return compareFunc(iField, jField, sortable.ASC)
 	})
 }
 

--- a/pkg/table/sort.go
+++ b/pkg/table/sort.go
@@ -1,0 +1,86 @@
+package table
+
+import (
+	"github.com/Masterminds/semver"
+
+	"github.com/giantswarm/gsctl/util"
+)
+
+var SortableTypes = struct {
+	String string
+	Semver string
+	Date   string
+}{
+	String: "string",
+	Semver: "semver",
+	Date:   "date",
+}
+
+var SortableDirections = struct {
+	ASC  string
+	DESC string
+}{
+	ASC:  "asc",
+	DESC: "desc",
+}
+
+type Sortable struct {
+	SortType string
+}
+
+func CompareStrings(a string, b string, direction string) bool {
+	if direction == SortableDirections.DESC {
+		return a > b
+	}
+
+	return a < b
+}
+
+func CompareSemvers(a string, b string, direction string) bool {
+	verA, err := semver.NewVersion(a)
+	if err != nil {
+		return false
+	}
+
+	verB, err := semver.NewVersion(b)
+	if err != nil {
+		return false
+	}
+
+	cmp := verA.Compare(verB)
+	if direction == SortableDirections.DESC {
+		return cmp > 0
+	}
+
+	return cmp <= 0
+}
+
+func CompareDates(a string, b string, direction string) bool {
+	dateA := util.ParseDate(a)
+	dateB := util.ParseDate(b)
+
+	cmp := dateA.After(dateB)
+	if direction == SortableDirections.DESC {
+		return cmp == false
+	}
+
+	return cmp
+}
+
+func GetCompareFunc(t string) func(string, string, string) bool {
+	switch t {
+	case SortableTypes.String:
+		return CompareStrings
+
+	case SortableTypes.Date:
+		return CompareDates
+
+	case SortableTypes.Semver:
+		return CompareSemvers
+
+	default:
+		return CompareStrings
+	}
+}
+
+type CompareFunc func(int, int) bool

--- a/pkg/table/sort.go
+++ b/pkg/table/sort.go
@@ -33,7 +33,7 @@ func SortMapSliceUsingColumnData(mapSlice []map[string]interface{}, byCol Column
 	})
 }
 
-func RemoveColor(s string) string {
+func RemoveColors(s string) string {
 	t := stripansi.Strip(s)
 
 	return t

--- a/pkg/table/sort.go
+++ b/pkg/table/sort.go
@@ -6,6 +6,8 @@ import (
 	"github.com/giantswarm/gsctl/pkg/sortable"
 )
 
+// SortMapSliceUsingColumnData manages table-like sorting on non-table data types.
+// This is especially useful if you want to encode in JSON the data in a table
 func SortMapSliceUsingColumnData(mapSlice []map[string]interface{}, byCol Column, fieldMapping map[string]string) {
 	compareFunc := sortable.GetCompareFunc(byCol.SortType)
 	sort.Slice(mapSlice, func(i, j int) bool {

--- a/pkg/table/sort.go
+++ b/pkg/table/sort.go
@@ -61,10 +61,10 @@ func CompareDates(a string, b string, direction string) bool {
 
 	cmp := dateA.After(dateB)
 	if direction == SortableDirections.DESC {
-		return cmp == false
+		return cmp
 	}
 
-	return cmp
+	return cmp == false
 }
 
 func GetCompareFunc(t string) func(string, string, string) bool {

--- a/pkg/table/sort.go
+++ b/pkg/table/sort.go
@@ -3,6 +3,8 @@ package table
 import (
 	"sort"
 
+	"github.com/acarl005/stripansi"
+
 	"github.com/giantswarm/gsctl/pkg/sortable"
 )
 
@@ -29,4 +31,10 @@ func SortMapSliceUsingColumnData(mapSlice []map[string]interface{}, byCol Column
 
 		return compareFunc(iField, jField, sortable.Directions.ASC)
 	})
+}
+
+func RemoveColor(s string) string {
+	t := stripansi.Strip(s)
+
+	return t
 }

--- a/pkg/table/sort.go
+++ b/pkg/table/sort.go
@@ -1,0 +1,30 @@
+package table
+
+import (
+	"sort"
+
+	"github.com/giantswarm/gsctl/pkg/sortable"
+)
+
+func SortMapSliceUsingColumnData(mapSlice []map[string]interface{}, byCol Column, fieldMapping map[string]string) {
+	compareFunc := sortable.GetCompareFunc(byCol.SortType)
+	sort.Slice(mapSlice, func(i, j int) bool {
+		iField := "n/a"
+		{
+			iValue, ok := mapSlice[i][fieldMapping[byCol.Name]]
+			if ok {
+				iField = iValue.(string)
+			}
+		}
+
+		jField := "n/a"
+		{
+			jValue, ok := mapSlice[j][fieldMapping[byCol.Name]]
+			if ok {
+				jField = jValue.(string)
+			}
+		}
+
+		return compareFunc(iField, jField, sortable.Directions.ASC)
+	})
+}

--- a/pkg/table/sort_test.go
+++ b/pkg/table/sort_test.go
@@ -41,7 +41,7 @@ func Test_SortMapSliceUsingColumnData(t *testing.T) {
 			column: Column{
 				Name: "name",
 				Sortable: sortable.Sortable{
-					SortType: sortable.Types.String,
+					SortType: sortable.String,
 				},
 			},
 			fieldMapping: map[string]string{
@@ -95,7 +95,7 @@ func Test_SortMapSliceUsingColumnData(t *testing.T) {
 			column: Column{
 				Name: "created",
 				Sortable: sortable.Sortable{
-					SortType: sortable.Types.Date,
+					SortType: sortable.Date,
 				},
 			},
 			fieldMapping: map[string]string{
@@ -149,7 +149,7 @@ func Test_SortMapSliceUsingColumnData(t *testing.T) {
 			column: Column{
 				Name: "release",
 				Sortable: sortable.Sortable{
-					SortType: sortable.Types.Date,
+					SortType: sortable.Date,
 				},
 			},
 			fieldMapping: map[string]string{

--- a/pkg/table/sort_test.go
+++ b/pkg/table/sort_test.go
@@ -1,0 +1,215 @@
+package table
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/fatih/color"
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/giantswarm/gsctl/pkg/sortable"
+)
+
+func Test_SortMapSliceUsingColumnData(t *testing.T) {
+	testCases := []struct {
+		mapSlice       []map[string]interface{}
+		column         Column
+		fieldMapping   map[string]string
+		expectedResult []map[string]interface{}
+	}{
+		{
+			mapSlice: []map[string]interface{}{
+				{
+					"id":              "as712",
+					"name":            "Some name",
+					"creation_date":   "2020-01-02T15:04:05.000Z",
+					"release_version": "12.0.1",
+				},
+				{
+					"id":              "saf91",
+					"name":            "Some very different name",
+					"creation_date":   "2020-01-03T15:21:05.000Z",
+					"release_version": "9.0.1",
+				},
+				{
+					"id":              "d91ns",
+					"name":            "Some other name",
+					"creation_date":   "2020-01-03T15:04:05.000Z",
+					"release_version": "12.0.1",
+				},
+			},
+			column: Column{
+				Name: "name",
+				Sortable: sortable.Sortable{
+					SortType: sortable.Types.String,
+				},
+			},
+			fieldMapping: map[string]string{
+				"id":      "id",
+				"name":    "name",
+				"created": "creation_date",
+				"release": "release_version",
+			},
+			expectedResult: []map[string]interface{}{
+				{
+					"id":              "as712",
+					"name":            "Some name",
+					"creation_date":   "2020-01-02T15:04:05.000Z",
+					"release_version": "12.0.1",
+				},
+				{
+					"id":              "d91ns",
+					"name":            "Some other name",
+					"creation_date":   "2020-01-03T15:04:05.000Z",
+					"release_version": "12.0.1",
+				},
+				{
+					"id":              "saf91",
+					"name":            "Some very different name",
+					"creation_date":   "2020-01-03T15:21:05.000Z",
+					"release_version": "9.0.1",
+				},
+			},
+		},
+		{
+			mapSlice: []map[string]interface{}{
+				{
+					"id":              "d91ns",
+					"name":            "Some other name",
+					"creation_date":   "2020-01-03T15:04:05.000Z",
+					"release_version": "12.0.1",
+				},
+				{
+					"id":              "as712",
+					"name":            "Some name",
+					"creation_date":   "2020-01-02T15:04:05.000Z",
+					"release_version": "12.0.1",
+				},
+				{
+					"id":              "saf91",
+					"name":            "Some very different name",
+					"creation_date":   "2020-01-03T15:21:05.000Z",
+					"release_version": "9.0.1",
+				},
+			},
+			column: Column{
+				Name: "created",
+				Sortable: sortable.Sortable{
+					SortType: sortable.Types.Date,
+				},
+			},
+			fieldMapping: map[string]string{
+				"id":      "id",
+				"name":    "name",
+				"created": "creation_date",
+				"release": "release_version",
+			},
+			expectedResult: []map[string]interface{}{
+				{
+					"id":              "as712",
+					"name":            "Some name",
+					"creation_date":   "2020-01-02T15:04:05.000Z",
+					"release_version": "12.0.1",
+				},
+				{
+					"id":              "d91ns",
+					"name":            "Some other name",
+					"creation_date":   "2020-01-03T15:04:05.000Z",
+					"release_version": "12.0.1",
+				},
+				{
+					"id":              "saf91",
+					"name":            "Some very different name",
+					"creation_date":   "2020-01-03T15:21:05.000Z",
+					"release_version": "9.0.1",
+				},
+			},
+		},
+		{
+			mapSlice: []map[string]interface{}{
+				{
+					"id":              "d91ns",
+					"name":            "Some other name",
+					"creation_date":   "2020-01-03T15:04:05.000Z",
+					"release_version": "12.0.1",
+				},
+				{
+					"id":              "as712",
+					"name":            "Some name",
+					"creation_date":   "2020-01-02T15:04:05.000Z",
+					"release_version": "12.0.1",
+				},
+				{
+					"id":              "saf91",
+					"name":            "Some very different name",
+					"creation_date":   "2020-01-03T15:21:05.000Z",
+					"release_version": "9.0.1",
+				},
+			},
+			column: Column{
+				Name: "release",
+				Sortable: sortable.Sortable{
+					SortType: sortable.Types.Date,
+				},
+			},
+			fieldMapping: map[string]string{
+				"id":      "id",
+				"name":    "name",
+				"created": "creation_date",
+				"release": "release_version",
+			},
+			expectedResult: []map[string]interface{}{
+				{
+					"id":              "saf91",
+					"name":            "Some very different name",
+					"creation_date":   "2020-01-03T15:21:05.000Z",
+					"release_version": "9.0.1",
+				},
+				{
+					"id":              "as712",
+					"name":            "Some name",
+					"creation_date":   "2020-01-02T15:04:05.000Z",
+					"release_version": "12.0.1",
+				},
+				{
+					"id":              "d91ns",
+					"name":            "Some other name",
+					"creation_date":   "2020-01-03T15:04:05.000Z",
+					"release_version": "12.0.1",
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			SortMapSliceUsingColumnData(tc.mapSlice, tc.column, tc.fieldMapping)
+
+			if diff := cmp.Diff(tc.expectedResult, tc.mapSlice); diff != "" {
+				t.Errorf("Case %d - Result did not match.\nOutput: %s", i, diff)
+			}
+		})
+	}
+}
+
+func Test_RemoveColors(t *testing.T) {
+	testCases := []struct {
+		input          string
+		expectedResult string
+	}{
+		{
+			input:          color.CyanString("some-string"),
+			expectedResult: "some-string",
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			result := RemoveColors(tc.input)
+
+			if result != tc.expectedResult {
+				t.Errorf("Case %d - Expected %s, got %s", i, tc.expectedResult, result)
+			}
+		})
+	}
+}

--- a/pkg/table/table.go
+++ b/pkg/table/table.go
@@ -60,8 +60,8 @@ func (t *Table) SortByColumnName(n string, direction string) error {
 	// Get the comparison algorithm for the current sorting type.
 	compareFunc := sortable.GetCompareFunc(column.SortType)
 	sort.Slice(t.rows, func(i, j int) bool {
-		iVal := RemoveColor(t.rows[i][colIndex])
-		jVal := RemoveColor(t.rows[j][colIndex])
+		iVal := RemoveColors(t.rows[i][colIndex])
+		jVal := RemoveColors(t.rows[j][colIndex])
 
 		return compareFunc(iVal, jVal, direction)
 	})

--- a/pkg/table/table.go
+++ b/pkg/table/table.go
@@ -76,8 +76,8 @@ func (t *Table) SortByColumnName(n string, direction string) error {
 	}
 
 	sortDir := direction
-	if sortDir != sortable.SortableDirections.ASC && sortDir != sortable.SortableDirections.DESC {
-		sortDir = sortable.SortableDirections.ASC
+	if sortDir != sortable.Directions.ASC && sortDir != sortable.Directions.DESC {
+		sortDir = sortable.Directions.ASC
 	}
 
 	compareFunc := sortable.GetCompareFunc(column.SortType)

--- a/pkg/table/table.go
+++ b/pkg/table/table.go
@@ -49,7 +49,7 @@ func (t *Table) SortByColumnName(n string, direction string) error {
 			}
 		}
 		if column.Name == "" {
-			return microerror.Mask(columnNotFoundError)
+			return microerror.Mask(fieldNotFoundError)
 		}
 	}
 
@@ -64,6 +64,34 @@ func (t *Table) SortByColumnName(n string, direction string) error {
 	})
 
 	return nil
+}
+
+func (t *Table) GetColumnNameFromInitials(i string) (string, error) {
+	i = strings.ToLower(i)
+
+	var (
+		columnNames   = make([]string, 0, len(t.columns))
+		matchingNames []string
+	)
+	{
+		for _, col := range t.columns {
+			if col.Name != "" {
+				columnNames = append(columnNames, col.Name)
+
+				if strings.HasPrefix(strings.ToLower(col.Name), i) {
+					matchingNames = append(matchingNames, col.Name)
+				}
+			}
+		}
+	}
+
+	if len(matchingNames) == 0 {
+		return "", microerror.Mask(fieldNotFoundError)
+	} else if len(matchingNames) > 1 {
+		return "", microerror.Mask(multipleFieldsMatchingError)
+	}
+
+	return matchingNames[0], nil
 }
 
 func (t *Table) String() string {

--- a/pkg/table/table.go
+++ b/pkg/table/table.go
@@ -35,7 +35,7 @@ func (t *Table) SetRows(r [][]string) {
 }
 
 func (t *Table) SortByColumnName(n string, direction string) error {
-	if len(t.rows) < 2 {
+	if len(t.rows) < 2 || n == "" {
 		return nil
 	}
 

--- a/pkg/table/table.go
+++ b/pkg/table/table.go
@@ -90,9 +90,9 @@ func (t *Table) GetColumnNameFromInitials(i string) (string, error) {
 	}
 
 	if len(matchingNames) == 0 {
-		return "", microerror.Mask(fieldNotFoundError)
+		return "", microerror.Maskf(fieldNotFoundError, "available fields for sorting: %v", strings.Join(columnNames, ", "))
 	} else if len(matchingNames) > 1 {
-		return "", microerror.Mask(multipleFieldsMatchingError)
+		return "", microerror.Maskf(multipleFieldsMatchingError, "%v", strings.Join(matchingNames, ", "))
 	}
 
 	return matchingNames[0], nil

--- a/pkg/table/table.go
+++ b/pkg/table/table.go
@@ -35,6 +35,10 @@ func (t *Table) SetRows(r [][]string) {
 }
 
 func (t *Table) SortByColumnName(n string, direction string) error {
+	if len(t.rows) < 2 {
+		return nil
+	}
+
 	var (
 		colIndex int
 		column   Column

--- a/pkg/table/table.go
+++ b/pkg/table/table.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/giantswarm/columnize"
 	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/gsctl/pkg/sortable"
 )
 
 type Table struct {
@@ -74,11 +76,11 @@ func (t *Table) SortByColumnName(n string, direction string) error {
 	}
 
 	sortDir := direction
-	if sortDir != SortableDirections.ASC && sortDir != SortableDirections.DESC {
-		sortDir = SortableDirections.ASC
+	if sortDir != sortable.SortableDirections.ASC && sortDir != sortable.SortableDirections.DESC {
+		sortDir = sortable.SortableDirections.ASC
 	}
 
-	compareFunc := GetCompareFunc(column.SortType)
+	compareFunc := sortable.GetCompareFunc(column.SortType)
 	sort.Slice(t.rows, func(i, j int) bool {
 		return compareFunc(t.rows[i][colIndex], t.rows[j][colIndex], direction)
 	})

--- a/pkg/table/table.go
+++ b/pkg/table/table.go
@@ -75,18 +75,16 @@ func (t *Table) GetColumnByName(n string) (int, Column, error) {
 		colIndex int
 		column   Column
 	)
-	{
-		for i, col := range t.columns {
-			if col.Name == n {
-				colIndex = i
-				column = col
+	for i, col := range t.columns {
+		if col.Name == n {
+			colIndex = i
+			column = col
 
-				break
-			}
+			break
 		}
-		if column.Name == "" {
-			return 0, Column{}, microerror.Mask(fieldNotFoundError)
-		}
+	}
+	if column.Name == "" {
+		return 0, Column{}, microerror.Mask(fieldNotFoundError)
 	}
 
 	return colIndex, column, nil
@@ -105,8 +103,13 @@ func (t *Table) GetColumnNameFromInitials(i string) (string, error) {
 		if col.Name != "" {
 			columnNames = append(columnNames, col.Name)
 
-			if strings.HasPrefix(strings.ToLower(col.Name), i) {
+			nameLowerCased := strings.ToLower(col.Name)
+			if strings.HasPrefix(nameLowerCased, i) {
 				matchingNames = append(matchingNames, col.Name)
+
+				if nameLowerCased == i {
+					break
+				}
 			}
 		}
 	}

--- a/pkg/table/table.go
+++ b/pkg/table/table.go
@@ -86,14 +86,12 @@ func (t *Table) GetColumnNameFromInitials(i string) (string, error) {
 		columnNames   = make([]string, 0, len(t.columns))
 		matchingNames []string
 	)
-	{
-		for _, col := range t.columns {
-			if col.Name != "" {
-				columnNames = append(columnNames, col.Name)
+	for _, col := range t.columns {
+		if col.Name != "" {
+			columnNames = append(columnNames, col.Name)
 
-				if strings.HasPrefix(strings.ToLower(col.Name), i) {
-					matchingNames = append(matchingNames, col.Name)
-				}
+			if strings.HasPrefix(strings.ToLower(col.Name), i) {
+				matchingNames = append(matchingNames, col.Name)
 			}
 		}
 	}

--- a/pkg/table/table.go
+++ b/pkg/table/table.go
@@ -10,13 +10,16 @@ import (
 	"github.com/giantswarm/gsctl/pkg/sortable"
 )
 
+// Table represents a data structure that can hold and display the contents of a table.
 type Table struct {
 	columns []Column
 	rows    [][]string
 
+	// columnizeConfig represents the configuration of the table formatter.
 	columnizeConfig *columnize.Config
 }
 
+// New creates a new Table.
 func New() Table {
 	t := Table{}
 
@@ -26,15 +29,19 @@ func New() Table {
 	return t
 }
 
+// SetColumns sets the table's columns.
 func (t *Table) SetColumns(c []Column) {
 	t.columns = c[:]
 }
 
+// SetRows sets the table's rows.
 func (t *Table) SetRows(r [][]string) {
 	t.rows = r[:][:]
 }
 
+// SortByColumnName sorts the table by a column name, in the given direction.
 func (t *Table) SortByColumnName(n string, direction string) error {
+	// Skip if there is nothing to sort, or if there's no column name provided.
 	if len(t.rows) < 2 || n == "" {
 		return nil
 	}
@@ -44,11 +51,13 @@ func (t *Table) SortByColumnName(n string, direction string) error {
 		return microerror.Mask(err)
 	}
 
+	// Default to Ascending direction sorting.
 	sortDir := direction
 	if sortDir != sortable.Directions.ASC && sortDir != sortable.Directions.DESC {
 		sortDir = sortable.Directions.ASC
 	}
 
+	// Get the comparison algorithm for the current sorting type.
 	compareFunc := sortable.GetCompareFunc(column.SortType)
 	sort.Slice(t.rows, func(i, j int) bool {
 		return compareFunc(t.rows[i][colIndex], t.rows[j][colIndex], direction)
@@ -57,6 +66,7 @@ func (t *Table) SortByColumnName(n string, direction string) error {
 	return nil
 }
 
+// GetColumnByName fetches the index and data structure of a column, by knowing its name.
 func (t *Table) GetColumnByName(n string) (int, Column, error) {
 	var (
 		colIndex int
@@ -79,6 +89,8 @@ func (t *Table) GetColumnByName(n string) (int, Column, error) {
 	return colIndex, column, nil
 }
 
+// GetColumnNameFromInitials matches a given input with a name of an existent column,
+// without caring about casing, or if the given input is the complete name of the column.
 func (t *Table) GetColumnNameFromInitials(i string) (string, error) {
 	i = strings.ToLower(i)
 
@@ -105,6 +117,8 @@ func (t *Table) GetColumnNameFromInitials(i string) (string, error) {
 	return matchingNames[0], nil
 }
 
+// String makes the Table data structure implement the Stringer interface,
+// so we can easily pretty-print it.
 func (t *Table) String() string {
 	rows := make([]string, 0, len(t.rows)+1)
 

--- a/pkg/table/table.go
+++ b/pkg/table/table.go
@@ -60,8 +60,23 @@ func (t *Table) SortByColumnName(n string, direction string) error {
 	// Get the comparison algorithm for the current sorting type.
 	compareFunc := sortable.GetCompareFunc(column.SortType)
 	sort.Slice(t.rows, func(i, j int) bool {
-		iVal := RemoveColors(t.rows[i][colIndex])
-		jVal := RemoveColors(t.rows[j][colIndex])
+		var iVal string
+		{
+			if colIndex >= len(t.rows[i]) {
+				iVal = "n/a"
+			} else {
+				iVal = RemoveColors(t.rows[i][colIndex])
+			}
+		}
+
+		var jVal string
+		{
+			if colIndex >= len(t.rows[j]) {
+				jVal = "n/a"
+			} else {
+				jVal = RemoveColors(t.rows[j][colIndex])
+			}
+		}
 
 		return compareFunc(iVal, jVal, direction)
 	})
@@ -131,7 +146,9 @@ func (t *Table) String() string {
 	{
 		columns := make([]string, 0, len(t.columns))
 		for _, col := range t.columns {
-			columns = append(columns, col.GetHeader())
+			if !col.Hidden {
+				columns = append(columns, col.GetHeader())
+			}
 		}
 		rows = append(rows, strings.Join(columns, "|"))
 	}

--- a/pkg/table/table.go
+++ b/pkg/table/table.go
@@ -53,8 +53,8 @@ func (t *Table) SortByColumnName(n string, direction string) error {
 
 	// Default to Ascending direction sorting.
 	sortDir := direction
-	if sortDir != sortable.Directions.ASC && sortDir != sortable.Directions.DESC {
-		sortDir = sortable.Directions.ASC
+	if sortDir != sortable.ASC && sortDir != sortable.DESC {
+		sortDir = sortable.ASC
 	}
 
 	// Get the comparison algorithm for the current sorting type.

--- a/pkg/table/table.go
+++ b/pkg/table/table.go
@@ -1,0 +1,42 @@
+package table
+
+import (
+	"strings"
+
+	"github.com/giantswarm/columnize"
+)
+
+type Table struct {
+	columns []Column
+	rows    [][]string
+
+	columnizeConfig *columnize.Config
+}
+
+func New() Table {
+	t := Table{}
+
+	t.columnizeConfig = columnize.DefaultConfig()
+	t.columnizeConfig.Glue = "   "
+
+	return t
+}
+
+func (t *Table) SetColumns(c []Column) {
+	t.columns = c[:]
+}
+
+func (t *Table) SetRows(r [][]string) {
+	t.rows = r[:][:]
+}
+
+func (t *Table) String() string {
+	rows := make([]string, 0, len(t.rows))
+	for _, row := range t.rows {
+		rows = append(rows, strings.Join(row, "|"))
+	}
+
+	formattedTable := columnize.Format(rows, t.columnizeConfig)
+
+	return formattedTable
+}

--- a/pkg/table/table.go
+++ b/pkg/table/table.go
@@ -108,7 +108,7 @@ func (t *Table) GetColumnNameFromInitials(i string) (string, error) {
 				matchingNames = append(matchingNames, col.Name)
 
 				if nameLowerCased == i {
-					break
+					return matchingNames[0], nil
 				}
 			}
 		}

--- a/pkg/table/table.go
+++ b/pkg/table/table.go
@@ -60,7 +60,10 @@ func (t *Table) SortByColumnName(n string, direction string) error {
 	// Get the comparison algorithm for the current sorting type.
 	compareFunc := sortable.GetCompareFunc(column.SortType)
 	sort.Slice(t.rows, func(i, j int) bool {
-		return compareFunc(t.rows[i][colIndex], t.rows[j][colIndex], direction)
+		iVal := RemoveColor(t.rows[i][colIndex])
+		jVal := RemoveColor(t.rows[j][colIndex])
+
+		return compareFunc(iVal, jVal, direction)
 	})
 
 	return nil

--- a/pkg/table/table.go
+++ b/pkg/table/table.go
@@ -34,28 +34,6 @@ func (t *Table) SetRows(r [][]string) {
 	t.rows = r[:][:]
 }
 
-func (t *Table) String() string {
-	rows := make([]string, 0, len(t.rows)+1)
-
-	{
-		columns := make([]string, 0, len(t.columns))
-		for _, col := range t.columns {
-			columns = append(columns, col.GetHeader())
-		}
-		rows = append(rows, strings.Join(columns, "|"))
-	}
-
-	{
-		for _, row := range t.rows {
-			rows = append(rows, strings.Join(row, "|"))
-		}
-	}
-
-	formattedTable := columnize.Format(rows, t.columnizeConfig)
-
-	return formattedTable
-}
-
 func (t *Table) SortByColumnName(n string, direction string) error {
 	var (
 		colIndex int
@@ -86,4 +64,26 @@ func (t *Table) SortByColumnName(n string, direction string) error {
 	})
 
 	return nil
+}
+
+func (t *Table) String() string {
+	rows := make([]string, 0, len(t.rows)+1)
+
+	{
+		columns := make([]string, 0, len(t.columns))
+		for _, col := range t.columns {
+			columns = append(columns, col.GetHeader())
+		}
+		rows = append(rows, strings.Join(columns, "|"))
+	}
+
+	{
+		for _, row := range t.rows {
+			rows = append(rows, strings.Join(row, "|"))
+		}
+	}
+
+	formattedTable := columnize.Format(rows, t.columnizeConfig)
+
+	return formattedTable
 }

--- a/pkg/table/table.go
+++ b/pkg/table/table.go
@@ -31,9 +31,20 @@ func (t *Table) SetRows(r [][]string) {
 }
 
 func (t *Table) String() string {
-	rows := make([]string, 0, len(t.rows))
-	for _, row := range t.rows {
-		rows = append(rows, strings.Join(row, "|"))
+	rows := make([]string, 0, len(t.rows)+1)
+
+	{
+		columns := make([]string, 0, len(t.columns))
+		for _, col := range t.columns {
+			columns = append(columns, col.GetHeader())
+		}
+		rows = append(rows, strings.Join(columns, "|"))
+	}
+
+	{
+		for _, row := range t.rows {
+			rows = append(rows, strings.Join(row, "|"))
+		}
 	}
 
 	formattedTable := columnize.Format(rows, t.columnizeConfig)

--- a/pkg/table/table_test.go
+++ b/pkg/table/table_test.go
@@ -1,0 +1,703 @@
+package table
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/giantswarm/gsctl/pkg/sortable"
+)
+
+func Test_SetColumns(t *testing.T) {
+	testCases := []struct {
+		columns        []Column
+		expectedResult []Column
+	}{
+		{
+			columns: []Column{
+				{
+					Name: "some-col",
+				},
+				{
+					Name: "some-other-col",
+				},
+				{
+					Name: "some-random-col",
+				},
+			},
+			expectedResult: []Column{
+				{
+					Name: "some-col",
+				},
+				{
+					Name: "some-other-col",
+				},
+				{
+					Name: "some-random-col",
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			table := New()
+			table.SetColumns(tc.columns)
+
+			if diff := cmp.Diff(tc.expectedResult, table.columns); diff != "" {
+				t.Errorf("Case %d - Result did not match.\nOutput: %s", i, diff)
+			}
+		})
+	}
+}
+
+func Test_SetRows(t *testing.T) {
+	testCases := []struct {
+		rows           [][]string
+		expectedResult [][]string
+	}{
+		{
+			rows: [][]string{
+				{
+					"something",
+					"some other thing",
+					"a third thing",
+				},
+				{
+					"something",
+					"some other thing",
+					"a third thing",
+				},
+			},
+			expectedResult: [][]string{
+				{
+					"something",
+					"some other thing",
+					"a third thing",
+				},
+				{
+					"something",
+					"some other thing",
+					"a third thing",
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			table := New()
+			table.SetRows(tc.rows)
+
+			if diff := cmp.Diff(tc.expectedResult, table.rows); diff != "" {
+				t.Errorf("Case %d - Result did not match.\nOutput: %s", i, diff)
+			}
+		})
+	}
+}
+
+func Test_SortByColumnName(t *testing.T) {
+	testCases := []struct {
+		columns        []Column
+		rows           [][]string
+		sortBy         string
+		direction      string
+		expectedResult [][]string
+		errorMatcher   func(error) bool
+	}{
+		{
+			columns: []Column{
+				{
+					Name:        "some-col",
+					DisplayName: "SOME COLUMN",
+					Sortable: sortable.Sortable{
+						SortType: sortable.Types.String,
+					},
+				},
+				{
+					Name: "some-other-col",
+					Sortable: sortable.Sortable{
+						SortType: sortable.Types.Date,
+					},
+				},
+				{
+					Name:        "some-random-col",
+					DisplayName: "Some Random Column",
+					Sortable: sortable.Sortable{
+						SortType: sortable.Types.Semver,
+					},
+				},
+			},
+			rows: [][]string{
+				{
+					"Good dog",
+					"2016 Dec 05, 14:41 UTC",
+					"12.0.1",
+				},
+				{
+					"Good cat",
+					"2016 Dec 25, 14:41 UTC",
+					"12.0.1",
+				},
+				{
+					"Good parrot",
+					"2016 Dec 25, 15:41 UTC",
+					"9.0.1",
+				},
+			},
+			sortBy:    "some-col",
+			direction: sortable.Directions.ASC,
+			expectedResult: [][]string{
+				{
+					"Good cat",
+					"2016 Dec 25, 14:41 UTC",
+					"12.0.1",
+				},
+				{
+					"Good dog",
+					"2016 Dec 05, 14:41 UTC",
+					"12.0.1",
+				},
+				{
+					"Good parrot",
+					"2016 Dec 25, 15:41 UTC",
+					"9.0.1",
+				},
+			},
+			errorMatcher: nil,
+		},
+		{
+			columns: []Column{
+				{
+					Name:        "some-col",
+					DisplayName: "SOME COLUMN",
+					Sortable: sortable.Sortable{
+						SortType: sortable.Types.String,
+					},
+				},
+				{
+					Name: "some-other-col",
+					Sortable: sortable.Sortable{
+						SortType: sortable.Types.Date,
+					},
+				},
+				{
+					Name:        "some-random-col",
+					DisplayName: "Some Random Column",
+					Sortable: sortable.Sortable{
+						SortType: sortable.Types.Semver,
+					},
+				},
+			},
+			rows: [][]string{
+				{
+					"Good dog",
+					"2016 Dec 05, 14:41 UTC",
+					"12.0.1",
+				},
+				{
+					"Good cat",
+					"2016 Dec 25, 14:41 UTC",
+					"12.0.1",
+				},
+				{
+					"Good parrot",
+					"2016 Dec 25, 15:41 UTC",
+					"9.0.1",
+				},
+			},
+			sortBy:    "some-col",
+			direction: sortable.Directions.DESC,
+			expectedResult: [][]string{
+				{
+					"Good parrot",
+					"2016 Dec 25, 15:41 UTC",
+					"9.0.1",
+				},
+				{
+					"Good dog",
+					"2016 Dec 05, 14:41 UTC",
+					"12.0.1",
+				},
+				{
+					"Good cat",
+					"2016 Dec 25, 14:41 UTC",
+					"12.0.1",
+				},
+			},
+			errorMatcher: nil,
+		},
+		{
+			columns: []Column{
+				{
+					Name:        "some-col",
+					DisplayName: "SOME COLUMN",
+					Sortable: sortable.Sortable{
+						SortType: sortable.Types.String,
+					},
+				},
+				{
+					Name: "some-other-col",
+					Sortable: sortable.Sortable{
+						SortType: sortable.Types.Date,
+					},
+				},
+				{
+					Name:        "some-random-col",
+					DisplayName: "Some Random Column",
+					Sortable: sortable.Sortable{
+						SortType: sortable.Types.Semver,
+					},
+				},
+			},
+			rows: [][]string{
+				{
+					"Good dog",
+					"2016 Dec 05, 14:41 UTC",
+					"12.0.1",
+				},
+				{
+					"Good cat",
+					"2016 Dec 25, 14:41 UTC",
+					"12.0.1",
+				},
+				{
+					"Good parrot",
+					"2016 Dec 25, 15:41 UTC",
+					"9.0.1",
+				},
+			},
+			sortBy:    "some-other-col",
+			direction: sortable.Directions.ASC,
+			expectedResult: [][]string{
+				{
+					"Good dog",
+					"2016 Dec 05, 14:41 UTC",
+					"12.0.1",
+				},
+				{
+					"Good cat",
+					"2016 Dec 25, 14:41 UTC",
+					"12.0.1",
+				},
+				{
+					"Good parrot",
+					"2016 Dec 25, 15:41 UTC",
+					"9.0.1",
+				},
+			},
+			errorMatcher: nil,
+		},
+		{
+			columns: []Column{
+				{
+					Name:        "some-col",
+					DisplayName: "SOME COLUMN",
+					Sortable: sortable.Sortable{
+						SortType: sortable.Types.String,
+					},
+				},
+				{
+					Name: "some-other-col",
+					Sortable: sortable.Sortable{
+						SortType: sortable.Types.Date,
+					},
+				},
+				{
+					Name:        "some-random-col",
+					DisplayName: "Some Random Column",
+					Sortable: sortable.Sortable{
+						SortType: sortable.Types.Semver,
+					},
+				},
+			},
+			rows: [][]string{
+				{
+					"Good dog",
+					"2016 Dec 05, 14:41 UTC",
+					"12.0.1",
+				},
+				{
+					"Good cat",
+					"2016 Dec 25, 14:41 UTC",
+					"12.0.1",
+				},
+				{
+					"Good parrot",
+					"2016 Dec 25, 15:41 UTC",
+					"9.0.1",
+				},
+			},
+			sortBy:    "some-random-col",
+			direction: sortable.Directions.ASC,
+			expectedResult: [][]string{
+				{
+					"Good parrot",
+					"2016 Dec 25, 15:41 UTC",
+					"9.0.1",
+				},
+				{
+					"Good cat",
+					"2016 Dec 25, 14:41 UTC",
+					"12.0.1",
+				},
+				{
+					"Good dog",
+					"2016 Dec 05, 14:41 UTC",
+					"12.0.1",
+				},
+			},
+			errorMatcher: nil,
+		},
+		{
+			columns: []Column{
+				{
+					Name:        "some-col",
+					DisplayName: "SOME COLUMN",
+					Sortable: sortable.Sortable{
+						SortType: sortable.Types.String,
+					},
+				},
+				{
+					Name: "some-other-col",
+					Sortable: sortable.Sortable{
+						SortType: sortable.Types.Date,
+					},
+				},
+				{
+					Name:        "some-random-col",
+					DisplayName: "Some Random Column",
+					Sortable: sortable.Sortable{
+						SortType: sortable.Types.Semver,
+					},
+				},
+			},
+			rows: [][]string{
+				{
+					"Good dog",
+					"2016 Dec 05, 14:41 UTC",
+					"12.0.1",
+				},
+				{
+					"Good cat",
+					"2016 Dec 25, 14:41 UTC",
+					"12.0.1",
+				},
+				{
+					"Good parrot",
+					"2016 Dec 25, 15:41 UTC",
+					"9.0.1",
+				},
+			},
+			sortBy:    "naaah",
+			direction: sortable.Directions.ASC,
+			expectedResult: [][]string{
+				{
+					"Good parrot",
+					"2016 Dec 25, 15:41 UTC",
+					"9.0.1",
+				},
+				{
+					"Good cat",
+					"2016 Dec 25, 14:41 UTC",
+					"12.0.1",
+				},
+				{
+					"Good dog",
+					"2016 Dec 05, 14:41 UTC",
+					"12.0.1",
+				},
+			},
+			errorMatcher: IsFieldNotFoundError,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			table := New()
+			table.SetColumns(tc.columns)
+			table.SetRows(tc.rows)
+
+			err := table.SortByColumnName(tc.sortBy, tc.direction)
+
+			if tc.errorMatcher != nil {
+				if !tc.errorMatcher(err) {
+					t.Errorf("Case %d - Unexpected error: %s", i, err)
+				}
+			} else {
+				if diff := cmp.Diff(tc.expectedResult, tc.rows); diff != "" {
+					t.Errorf("Case %d - Result did not match.\nOutput: %s", i, diff)
+				}
+			}
+		})
+	}
+}
+
+func Test_GetColumnByName(t *testing.T) {
+	testCases := []struct {
+		columns             []Column
+		name                string
+		expectedResult      Column
+		expectedResultIndex int
+		errorMatcher        func(error) bool
+	}{
+		{
+			columns: []Column{
+				{
+					Name: "name",
+				},
+				{
+					Name: "date",
+				},
+				{
+					Name: "release",
+				},
+			},
+			name:                "name",
+			expectedResult:      Column{Name: "name"},
+			expectedResultIndex: 0,
+			errorMatcher:        nil,
+		},
+		{
+			columns: []Column{
+				{
+					Name: "name",
+				},
+				{
+					Name: "date",
+				},
+				{
+					Name: "release",
+				},
+			},
+			name:                "game",
+			expectedResult:      Column{},
+			expectedResultIndex: 0,
+			errorMatcher:        IsFieldNotFoundError,
+		},
+		{
+			columns: []Column{
+				{
+					Name: "name",
+				},
+				{
+					Name: "date",
+				},
+				{
+					Name: "release",
+				},
+			},
+			name:                "date",
+			expectedResult:      Column{Name: "date"},
+			expectedResultIndex: 1,
+			errorMatcher:        nil,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			table := New()
+			table.SetColumns(tc.columns)
+			index, result, err := table.GetColumnByName(tc.name)
+
+			if tc.errorMatcher != nil {
+				if !tc.errorMatcher(err) {
+					t.Errorf("Case %d - Unexpected error: %s", i, err)
+				}
+			} else {
+				if index != tc.expectedResultIndex {
+					t.Errorf("Case %d - Result index did not match.\nOutput: %d", i, index)
+				}
+
+				if diff := cmp.Diff(tc.expectedResult, result); diff != "" {
+					t.Errorf("Case %d - Result did not match.\nOutput: %s", i, diff)
+				}
+			}
+		})
+	}
+}
+
+func Test_GetColumnNameFromInitials(t *testing.T) {
+	testCases := []struct {
+		columns        []Column
+		initials       string
+		expectedResult string
+		errorMatcher   func(error) bool
+	}{
+		{
+			columns: []Column{
+				{
+					Name: "name",
+				},
+				{
+					Name: "dAtE",
+				},
+				{
+					Name: "Release",
+				},
+			},
+			initials:       "name",
+			expectedResult: "name",
+			errorMatcher:   nil,
+		},
+		{
+			columns: []Column{
+				{
+					Name: "name",
+				},
+				{
+					Name: "dAtE",
+				},
+				{
+					Name: "Release",
+				},
+			},
+			initials:       "n",
+			expectedResult: "name",
+			errorMatcher:   nil,
+		},
+		{
+			columns: []Column{
+				{
+					Name: "name",
+				},
+				{
+					Name: "dAtE",
+				},
+				{
+					Name: "Release",
+				},
+			},
+			initials:       "NaM",
+			expectedResult: "name",
+			errorMatcher:   nil,
+		},
+		{
+			columns: []Column{
+				{
+					Name: "name",
+				},
+				{
+					Name: "dAtE",
+				},
+				{
+					Name: "Release",
+				},
+			},
+			initials:       "d",
+			expectedResult: "dAtE",
+			errorMatcher:   nil,
+		},
+		{
+			columns: []Column{
+				{
+					Name: "name",
+				},
+				{
+					Name: "dAtE",
+				},
+				{
+					Name: "Release",
+				},
+			},
+			initials:       "flower",
+			expectedResult: "",
+			errorMatcher:   IsFieldNotFoundError,
+		},
+		{
+			columns: []Column{
+				{
+					Name: "name",
+				},
+				{
+					Name: "dAtE",
+				},
+				{
+					Name: "Release",
+				},
+				{
+					Name: "religion",
+				},
+			},
+			initials:       "r",
+			expectedResult: "",
+			errorMatcher:   IsMultipleFieldsMatchingError,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			table := New()
+			table.SetColumns(tc.columns)
+			result, err := table.GetColumnNameFromInitials(tc.initials)
+
+			if tc.errorMatcher != nil {
+				if !tc.errorMatcher(err) {
+					t.Errorf("Case %d - Unexpected error: %s", i, err)
+				}
+			} else if result != tc.expectedResult {
+				t.Errorf("Case %d - Expected %s, got %s", i, tc.expectedResult, result)
+			}
+		})
+	}
+}
+
+func Test_String(t *testing.T) {
+	testCases := []struct {
+		columns        []Column
+		rows           [][]string
+		expectedResult string
+	}{
+		{
+			columns: []Column{
+				{
+					Name:        "some-col",
+					DisplayName: "SOME COLUMN",
+				},
+				{
+					Name: "some-other-col",
+				},
+				{
+					Name:        "some-random-col",
+					DisplayName: "Some Random Column",
+				},
+			},
+			rows: [][]string{
+				{
+					"Good dog",
+					"2016 Dec 05, 14:41 UTC",
+					"12.0.1",
+				},
+				{
+					"Good cat",
+					"2016 Dec 25, 14:41 UTC",
+					"12.0.1",
+				},
+				{
+					"Good parrot",
+					"2016 Dec 25, 15:41 UTC",
+					"9.0.1",
+				},
+			},
+			expectedResult: `SOME COLUMN   some-other-col           Some Random Column
+Good dog      2016 Dec 05, 14:41 UTC   12.0.1
+Good cat      2016 Dec 25, 14:41 UTC   12.0.1
+Good parrot   2016 Dec 25, 15:41 UTC   9.0.1`,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			table := New()
+			table.SetColumns(tc.columns)
+			table.SetRows(tc.rows)
+
+			result := table.String()
+
+			if diff := cmp.Diff(tc.expectedResult, result); diff != "" {
+				t.Errorf("Case %d - Result did not match.\nOutput: %s", i, diff)
+			}
+		})
+	}
+}

--- a/pkg/table/table_test.go
+++ b/pkg/table/table_test.go
@@ -513,6 +513,124 @@ func Test_SortByColumnName(t *testing.T) {
 			},
 			errorMatcher: nil,
 		},
+		{
+			columns: []Column{
+				{
+					Name:        "some-col",
+					DisplayName: "SOME COLUMN",
+					Sortable: sortable.Sortable{
+						SortType: sortable.String,
+					},
+				},
+				{
+					Name: "some-other-col",
+					Sortable: sortable.Sortable{
+						SortType: sortable.Date,
+					},
+				},
+				{
+					Name:        "some-random-col",
+					DisplayName: "Some Random Column",
+					Sortable: sortable.Sortable{
+						SortType: sortable.Semver,
+					},
+					Hidden: true,
+				},
+			},
+			rows: [][]string{
+				{
+					"Good dog",
+					"2016 Dec 05, 14:41 UTC",
+				},
+				{
+					"Good cat",
+					"2016 Dec 25, 14:41 UTC",
+				},
+				{
+					"Good parrot",
+					"2016 Dec 25, 15:41 UTC",
+				},
+			},
+			sortBy:    "some-random-col",
+			direction: sortable.ASC,
+			expectedResult: [][]string{
+				{
+					"Good dog",
+					"2016 Dec 05, 14:41 UTC",
+				},
+				{
+					"Good cat",
+					"2016 Dec 25, 14:41 UTC",
+				},
+				{
+					"Good parrot",
+					"2016 Dec 25, 15:41 UTC",
+				},
+			},
+			errorMatcher: nil,
+		},
+		{
+			columns: []Column{
+				{
+					Name:        "some-col",
+					DisplayName: "SOME COLUMN",
+					Sortable: sortable.Sortable{
+						SortType: sortable.String,
+					},
+				},
+				{
+					Name: "some-other-col",
+					Sortable: sortable.Sortable{
+						SortType: sortable.Date,
+					},
+				},
+				{
+					Name:        "some-random-col",
+					DisplayName: "Some Random Column",
+					Sortable: sortable.Sortable{
+						SortType: sortable.Semver,
+					},
+					Hidden: true,
+				},
+			},
+			rows: [][]string{
+				{
+					"Good dog",
+					"2016 Dec 05, 14:41 UTC",
+					"12.0.1",
+				},
+				{
+					"Good cat",
+					"2016 Dec 25, 14:41 UTC",
+					"12.0.1",
+				},
+				{
+					"Good parrot",
+					"2016 Dec 25, 15:41 UTC",
+					"12.0.1",
+				},
+			},
+			sortBy:    "some-random-col",
+			direction: sortable.DESC,
+			expectedResult: [][]string{
+				{
+					"Good dog",
+					"2016 Dec 05, 14:41 UTC",
+					"12.0.1",
+				},
+				{
+					"Good cat",
+					"2016 Dec 25, 14:41 UTC",
+					"12.0.1",
+				},
+				{
+					"Good parrot",
+					"2016 Dec 25, 15:41 UTC",
+					"12.0.1",
+				},
+			},
+			errorMatcher: nil,
+		},
 	}
 
 	for i, tc := range testCases {

--- a/pkg/table/table_test.go
+++ b/pkg/table/table_test.go
@@ -726,6 +726,25 @@ func Test_GetColumnNameFromInitials(t *testing.T) {
 			expectedResult: "",
 			errorMatcher:   IsMultipleFieldsMatchingError,
 		},
+		{
+			columns: []Column{
+				{
+					Name: "name",
+				},
+				{
+					Name: "dAtE",
+				},
+				{
+					Name: "Release",
+				},
+				{
+					Name: "release-date",
+				},
+			},
+			initials:       "release",
+			expectedResult: "Release",
+			errorMatcher:   nil,
+		},
 	}
 
 	for i, tc := range testCases {

--- a/pkg/table/table_test.go
+++ b/pkg/table/table_test.go
@@ -112,20 +112,20 @@ func Test_SortByColumnName(t *testing.T) {
 					Name:        "some-col",
 					DisplayName: "SOME COLUMN",
 					Sortable: sortable.Sortable{
-						SortType: sortable.Types.String,
+						SortType: sortable.String,
 					},
 				},
 				{
 					Name: "some-other-col",
 					Sortable: sortable.Sortable{
-						SortType: sortable.Types.Date,
+						SortType: sortable.Date,
 					},
 				},
 				{
 					Name:        "some-random-col",
 					DisplayName: "Some Random Column",
 					Sortable: sortable.Sortable{
-						SortType: sortable.Types.Semver,
+						SortType: sortable.Semver,
 					},
 				},
 			},
@@ -147,7 +147,7 @@ func Test_SortByColumnName(t *testing.T) {
 				},
 			},
 			sortBy:    "some-col",
-			direction: sortable.Directions.ASC,
+			direction: sortable.ASC,
 			expectedResult: [][]string{
 				{
 					"Good cat",
@@ -173,20 +173,20 @@ func Test_SortByColumnName(t *testing.T) {
 					Name:        "some-col",
 					DisplayName: "SOME COLUMN",
 					Sortable: sortable.Sortable{
-						SortType: sortable.Types.String,
+						SortType: sortable.String,
 					},
 				},
 				{
 					Name: "some-other-col",
 					Sortable: sortable.Sortable{
-						SortType: sortable.Types.Date,
+						SortType: sortable.Date,
 					},
 				},
 				{
 					Name:        "some-random-col",
 					DisplayName: "Some Random Column",
 					Sortable: sortable.Sortable{
-						SortType: sortable.Types.Semver,
+						SortType: sortable.Semver,
 					},
 				},
 			},
@@ -234,20 +234,20 @@ func Test_SortByColumnName(t *testing.T) {
 					Name:        "some-col",
 					DisplayName: "SOME COLUMN",
 					Sortable: sortable.Sortable{
-						SortType: sortable.Types.String,
+						SortType: sortable.String,
 					},
 				},
 				{
 					Name: "some-other-col",
 					Sortable: sortable.Sortable{
-						SortType: sortable.Types.Date,
+						SortType: sortable.Date,
 					},
 				},
 				{
 					Name:        "some-random-col",
 					DisplayName: "Some Random Column",
 					Sortable: sortable.Sortable{
-						SortType: sortable.Types.Semver,
+						SortType: sortable.Semver,
 					},
 				},
 			},
@@ -269,7 +269,7 @@ func Test_SortByColumnName(t *testing.T) {
 				},
 			},
 			sortBy:    "some-col",
-			direction: sortable.Directions.DESC,
+			direction: sortable.DESC,
 			expectedResult: [][]string{
 				{
 					"Good parrot",
@@ -295,20 +295,20 @@ func Test_SortByColumnName(t *testing.T) {
 					Name:        "some-col",
 					DisplayName: "SOME COLUMN",
 					Sortable: sortable.Sortable{
-						SortType: sortable.Types.String,
+						SortType: sortable.String,
 					},
 				},
 				{
 					Name: "some-other-col",
 					Sortable: sortable.Sortable{
-						SortType: sortable.Types.Date,
+						SortType: sortable.Date,
 					},
 				},
 				{
 					Name:        "some-random-col",
 					DisplayName: "Some Random Column",
 					Sortable: sortable.Sortable{
-						SortType: sortable.Types.Semver,
+						SortType: sortable.Semver,
 					},
 				},
 			},
@@ -330,7 +330,7 @@ func Test_SortByColumnName(t *testing.T) {
 				},
 			},
 			sortBy:    "some-other-col",
-			direction: sortable.Directions.ASC,
+			direction: sortable.ASC,
 			expectedResult: [][]string{
 				{
 					"Good dog",
@@ -356,20 +356,20 @@ func Test_SortByColumnName(t *testing.T) {
 					Name:        "some-col",
 					DisplayName: "SOME COLUMN",
 					Sortable: sortable.Sortable{
-						SortType: sortable.Types.String,
+						SortType: sortable.String,
 					},
 				},
 				{
 					Name: "some-other-col",
 					Sortable: sortable.Sortable{
-						SortType: sortable.Types.Date,
+						SortType: sortable.Date,
 					},
 				},
 				{
 					Name:        "some-random-col",
 					DisplayName: "Some Random Column",
 					Sortable: sortable.Sortable{
-						SortType: sortable.Types.Semver,
+						SortType: sortable.Semver,
 					},
 				},
 			},
@@ -391,7 +391,7 @@ func Test_SortByColumnName(t *testing.T) {
 				},
 			},
 			sortBy:    "some-random-col",
-			direction: sortable.Directions.ASC,
+			direction: sortable.ASC,
 			expectedResult: [][]string{
 				{
 					"Good parrot",
@@ -417,20 +417,20 @@ func Test_SortByColumnName(t *testing.T) {
 					Name:        "some-col",
 					DisplayName: "SOME COLUMN",
 					Sortable: sortable.Sortable{
-						SortType: sortable.Types.String,
+						SortType: sortable.String,
 					},
 				},
 				{
 					Name: "some-other-col",
 					Sortable: sortable.Sortable{
-						SortType: sortable.Types.Date,
+						SortType: sortable.Date,
 					},
 				},
 				{
 					Name:        "some-random-col",
 					DisplayName: "Some Random Column",
 					Sortable: sortable.Sortable{
-						SortType: sortable.Types.Semver,
+						SortType: sortable.Semver,
 					},
 				},
 			},
@@ -452,7 +452,7 @@ func Test_SortByColumnName(t *testing.T) {
 				},
 			},
 			sortBy:    "naaah",
-			direction: sortable.Directions.ASC,
+			direction: sortable.ASC,
 			expectedResult: [][]string{
 				{
 					"Good parrot",
@@ -478,20 +478,20 @@ func Test_SortByColumnName(t *testing.T) {
 					Name:        "some-col",
 					DisplayName: "SOME COLUMN",
 					Sortable: sortable.Sortable{
-						SortType: sortable.Types.String,
+						SortType: sortable.String,
 					},
 				},
 				{
 					Name: "some-other-col",
 					Sortable: sortable.Sortable{
-						SortType: sortable.Types.Date,
+						SortType: sortable.Date,
 					},
 				},
 				{
 					Name:        "some-random-col",
 					DisplayName: "Some Random Column",
 					Sortable: sortable.Sortable{
-						SortType: sortable.Types.Semver,
+						SortType: sortable.Semver,
 					},
 				},
 			},
@@ -503,7 +503,7 @@ func Test_SortByColumnName(t *testing.T) {
 				},
 			},
 			sortBy:    "some-other-col",
-			direction: sortable.Directions.ASC,
+			direction: sortable.ASC,
 			expectedResult: [][]string{
 				{
 					"Good dog",

--- a/pkg/table/table_test.go
+++ b/pkg/table/table_test.go
@@ -208,6 +208,67 @@ func Test_SortByColumnName(t *testing.T) {
 				},
 			},
 			sortBy:    "some-col",
+			direction: "",
+			expectedResult: [][]string{
+				{
+					"Good cat",
+					"2016 Dec 25, 14:41 UTC",
+					"12.0.1",
+				},
+				{
+					"Good dog",
+					"2016 Dec 05, 14:41 UTC",
+					"12.0.1",
+				},
+				{
+					"Good parrot",
+					"2016 Dec 25, 15:41 UTC",
+					"9.0.1",
+				},
+			},
+			errorMatcher: nil,
+		},
+		{
+			columns: []Column{
+				{
+					Name:        "some-col",
+					DisplayName: "SOME COLUMN",
+					Sortable: sortable.Sortable{
+						SortType: sortable.Types.String,
+					},
+				},
+				{
+					Name: "some-other-col",
+					Sortable: sortable.Sortable{
+						SortType: sortable.Types.Date,
+					},
+				},
+				{
+					Name:        "some-random-col",
+					DisplayName: "Some Random Column",
+					Sortable: sortable.Sortable{
+						SortType: sortable.Types.Semver,
+					},
+				},
+			},
+			rows: [][]string{
+				{
+					"Good dog",
+					"2016 Dec 05, 14:41 UTC",
+					"12.0.1",
+				},
+				{
+					"Good cat",
+					"2016 Dec 25, 14:41 UTC",
+					"12.0.1",
+				},
+				{
+					"Good parrot",
+					"2016 Dec 25, 15:41 UTC",
+					"9.0.1",
+				},
+			},
+			sortBy:    "some-col",
 			direction: sortable.Directions.DESC,
 			expectedResult: [][]string{
 				{
@@ -410,6 +471,47 @@ func Test_SortByColumnName(t *testing.T) {
 				},
 			},
 			errorMatcher: IsFieldNotFoundError,
+		},
+		{
+			columns: []Column{
+				{
+					Name:        "some-col",
+					DisplayName: "SOME COLUMN",
+					Sortable: sortable.Sortable{
+						SortType: sortable.Types.String,
+					},
+				},
+				{
+					Name: "some-other-col",
+					Sortable: sortable.Sortable{
+						SortType: sortable.Types.Date,
+					},
+				},
+				{
+					Name:        "some-random-col",
+					DisplayName: "Some Random Column",
+					Sortable: sortable.Sortable{
+						SortType: sortable.Types.Semver,
+					},
+				},
+			},
+			rows: [][]string{
+				{
+					"Good dog",
+					"2016 Dec 05, 14:41 UTC",
+					"12.0.1",
+				},
+			},
+			sortBy:    "some-other-col",
+			direction: sortable.Directions.ASC,
+			expectedResult: [][]string{
+				{
+					"Good dog",
+					"2016 Dec 05, 14:41 UTC",
+					"12.0.1",
+				},
+			},
+			errorMatcher: nil,
 		},
 	}
 

--- a/util/datetime.go
+++ b/util/datetime.go
@@ -34,6 +34,8 @@ func ParseDate(dateString string) time.Time {
 	if err == nil {
 		l, _ := time.LoadLocation("UTC")
 		t = t.In(l)
+
+		return t
 	}
 
 	t = parseShortDate(dateString)

--- a/util/datetime.go
+++ b/util/datetime.go
@@ -1,7 +1,10 @@
 package util
 
 import (
+	"fmt"
 	"regexp"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -40,4 +43,30 @@ func ParseDate(dateString string) time.Time {
 // ShortDate reformats a time.Time to a short date
 func ShortDate(date time.Time) string {
 	return date.Format(shortFormat)
+}
+
+func ParseShortDate(dateStr string) time.Time {
+	newDate := time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC)
+
+	dateStr = strings.Replace(dateStr, ",", "", -1)
+	dateParts := strings.Split(dateStr, " ")
+
+	// [ YYYY MMM DD HH:MM UTC]
+	if len(dateParts) < 5 {
+		return newDate
+	}
+
+	// Only transform the last 4 digits of the year to int,
+	// as sometimes there may be some random utf8 chars before.
+	yearDigitsToTransform := len(dateParts[0]) - 4
+	year, _ := strconv.Atoi(dateParts[0][yearDigitsToTransform:])
+	month, _ := time.Parse("Jan", dateParts[1])
+	days, _ := strconv.Atoi(dateParts[2])
+	newDate = newDate.AddDate(year, int(month.Month()), days)
+
+	timeDigits := strings.Split(dateParts[3], ":")
+	timeDuration, _ := time.ParseDuration(fmt.Sprintf("%sh%sm", timeDigits[0], timeDigits[1]))
+	newDate = newDate.Add(timeDuration)
+
+	return newDate
 }

--- a/util/datetime.go
+++ b/util/datetime.go
@@ -46,6 +46,7 @@ func ShortDate(date time.Time) string {
 	return date.Format(shortFormat)
 }
 
+// parseShortDate parses a date encoded with the 'shortFormat' format.
 func parseShortDate(dateStr string) time.Time {
 	// 'YYYY MMM DD HH:MM LOC'
 	if len(dateStr) < 18 {

--- a/util/datetime.go
+++ b/util/datetime.go
@@ -37,6 +37,9 @@ func ParseDate(dateString string) time.Time {
 		l, _ := time.LoadLocation("UTC")
 		t = t.In(l)
 	}
+
+	t = parseShortDate(dateString)
+
 	return t
 }
 
@@ -45,7 +48,7 @@ func ShortDate(date time.Time) string {
 	return date.Format(shortFormat)
 }
 
-func ParseShortDate(dateStr string) time.Time {
+func parseShortDate(dateStr string) time.Time {
 	newDate := time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC)
 
 	dateStr = strings.Replace(dateStr, ",", "", -1)
@@ -57,7 +60,8 @@ func ParseShortDate(dateStr string) time.Time {
 	}
 
 	// Only transform the last 4 digits of the year to int,
-	// as sometimes there may be some random utf8 chars before.
+	// as sometimes (if the string content is colored)
+	// there may be some random utf8 chars before.
 	yearDigitsToTransform := len(dateParts[0]) - 4
 	year, _ := strconv.Atoi(dateParts[0][yearDigitsToTransform:])
 	month, _ := time.Parse("Jan", dateParts[1])

--- a/util/datetime.go
+++ b/util/datetime.go
@@ -1,10 +1,8 @@
 package util
 
 import (
-	"fmt"
 	"regexp"
 	"strconv"
-	"strings"
 	"time"
 )
 
@@ -49,28 +47,18 @@ func ShortDate(date time.Time) string {
 }
 
 func parseShortDate(dateStr string) time.Time {
-	newDate := time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC)
-
-	dateStr = strings.Replace(dateStr, ",", "", -1)
-	dateParts := strings.Split(dateStr, " ")
-
-	// [ YYYY MMM DD HH:MM UTC]
-	if len(dateParts) < 5 {
-		return newDate
+	// 'YYYY MMM DD HH:MM LOC'
+	if len(dateStr) < 18 {
+		return time.Time{}
 	}
 
-	// Only transform the last 4 digits of the year to int,
-	// as sometimes (if the string content is colored)
-	// there may be some random utf8 chars before.
-	yearDigitsToTransform := len(dateParts[0]) - 4
-	year, _ := strconv.Atoi(dateParts[0][yearDigitsToTransform:])
-	month, _ := time.Parse("Jan", dateParts[1])
-	days, _ := strconv.Atoi(dateParts[2])
-	newDate = newDate.AddDate(year, int(month.Month()), days)
+	year, _ := strconv.Atoi(dateStr[:4])
+	month, _ := time.Parse("Jan", dateStr[5:8])
+	days, _ := strconv.Atoi(dateStr[9:11])
+	hours, _ := strconv.Atoi(dateStr[13:15])
+	minutes, _ := strconv.Atoi(dateStr[16:18])
 
-	timeDigits := strings.Split(dateParts[3], ":")
-	timeDuration, _ := time.ParseDuration(fmt.Sprintf("%sh%sm", timeDigits[0], timeDigits[1]))
-	newDate = newDate.Add(timeDuration)
+	newDate := time.Date(year, month.Month(), days, hours, minutes, 0, 0, time.UTC)
 
 	return newDate
 }

--- a/util/datetime_test.go
+++ b/util/datetime_test.go
@@ -38,6 +38,16 @@ var tests = []Test{
 		time.Date(2016, time.December, 5, 14, 41, 46, 0, time.UTC),
 		"2016 Dec 05, 14:41 UTC",
 	},
+	{
+		"1999 Nov 24, 00:57 UTC",
+		time.Date(1999, time.November, 24, 0, 57, 00, 0, time.UTC),
+		"1999 Nov 24, 00:57 UTC",
+	},
+	{
+		"2016 Dec 05, 14:41 UTC",
+		time.Date(2016, time.December, 5, 14, 41, 00, 0, time.UTC),
+		"2016 Dec 05, 14:41 UTC",
+	},
 }
 
 func TestParseDate(t *testing.T) {


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/10811

## Changes

**generic**
* Created a generic `sortable` package that can be used for sorting stuff
* Created a custom `table` package that can be used for displaying data in a cool table, but that also supports sorting the data

**list clusters**
* Refactored the command to use the new table
* The command now accepts the `-s/--sort` flag, that works with any table column initials or part of words (doesn't matter in which casing)
  * If there are multiple columns matching with that token, an error is thrown
  * If there is no column matching with that token, an error is thrown
* Same sorting logic is adapted and applied to json output

## Help 

**Examples**

![image](https://user-images.githubusercontent.com/13508038/82197748-a4f5b200-98fb-11ea-85b0-4fcc43b4a255.png)

**Flags**

![image](https://user-images.githubusercontent.com/13508038/82197840-bfc82680-98fb-11ea-9619-34c371886ff3.png)

## Possible errors

**Attribute not found**

![image](https://user-images.githubusercontent.com/13508038/82075980-67b3d900-96dd-11ea-8f27-367f7be3ea9a.png)

**Multiple attributes found for token**

![image](https://user-images.githubusercontent.com/13508038/82076259-db55e600-96dd-11ea-8136-7bd2849b5e09.png)
