### PR TITLE
Improve 'gsctl info' printing of environment variables

### DIFF
--- a/commands/info/command.go
+++ b/commands/info/command.go
@@ -214,6 +214,8 @@ func info(args Arguments) (infoResult, error) {
 		result.apiEndpoint = args.apiEndpoint
 	}
 
+	result.environmentVariables = getEnvironmentVariables()
+
 	result.email = config.Config.Email
 	result.token = config.Config.ChooseToken(result.apiEndpoint, args.userProvidedToken)
 	result.version = buildinfo.Version
@@ -250,8 +252,6 @@ func info(args Arguments) (infoResult, error) {
 
 		result.infoResponse = response
 	}
-
-	result.environmentVariables = getEnvironmentVariables()
 
 	return result, nil
 }

--- a/commands/info/command.go
+++ b/commands/info/command.go
@@ -267,8 +267,8 @@ func getEnvironmentVariables() map[string]string {
 		"GSCTL_AUTH_TOKEN",
 		"HTTP_PROXY",
 		"HTTPS_PROXY",
-		"KUBECONFIG",
 		"NO_PROXY",
+		"KUBECONFIG",
 	}
 
 	out := make(map[string]string)

--- a/commands/info/command.go
+++ b/commands/info/command.go
@@ -274,8 +274,8 @@ func getEnvironmentVariables() map[string]string {
 	out := make(map[string]string)
 
 	for _, name := range vars {
-		val := os.Getenv(name)
-		if val != "" {
+		val, ok := os.LookupEnv(name)
+		if ok {
 			out[name] = val
 		}
 	}

--- a/commands/info/command.go
+++ b/commands/info/command.go
@@ -266,7 +266,9 @@ func getEnvironmentVariables() map[string]string {
 		"GSCTL_ENDPOINT",
 		"GSCTL_AUTH_TOKEN",
 		"HTTP_PROXY",
+		"HTTPS_PROXY",
 		"KUBECONFIG",
+		"NO_PROXY",
 	}
 
 	out := make(map[string]string)


### PR DESCRIPTION
This PR fixes and improves the printing of relevant environment variables in `gsctl info`.

1. Environment variables are now also printed if API access fails. (In this case it's actually most important!)
2. We also show the relevant environment variables `HTTPS_PROXY` and `NO_PROXY`.
3. We show the variables if set, even if the value is an empty string. Before they would only be shown if non-empty.

## Background

gsctl's HTTP client is configured using Go's [`net/http.ProxyFromEnvironment`](https://golang.org/pkg/net/http/#ProxyFromEnvironment) function. This means the proxy behaviour is influenced by the environment variables

- HTTP_PROXY
- HTTPS_PROXY
- NO_PROXY

So far we listed only showed the first of the three in the `gsctl info` command, and only in the case that the API call to the info endpoint succeeded.
