### PR TITLE
In 'gsctl show cluster', use "n/a" placeholder when cluster has no labels

### DIFF
--- a/commands/show/cluster/command.go
+++ b/commands/show/cluster/command.go
@@ -54,6 +54,9 @@ Examples:
 
 const (
 	activityName = "show-cluster"
+
+	// A string we use to express "no information available here"
+	naString = "n/a"
 )
 
 // Arguments specifies all the arguments to be used for our business function.
@@ -538,7 +541,7 @@ func formatDate(dt string) string {
 // if string is empty, or the "n/a" placeholder.
 func stringOrPlaceholder(s string) string {
 	if s == "" {
-		return "n/a"
+		return naString
 	}
 	return s
 }
@@ -611,7 +614,7 @@ func formatNodePoolDetails(nodePools *models.V5GetNodePoolsResponse) []string {
 }
 
 func formatClusterLabels(labels map[string]string) []string {
-	formattedClusterLabels := []string{color.YellowString("Labels:|") + "-"}
+	formattedClusterLabels := []string{color.YellowString("Labels:|") + naString}
 
 	isFirstLine := true
 

--- a/commands/show/cluster/command_test.go
+++ b/commands/show/cluster/command_test.go
@@ -449,7 +449,7 @@ func TestShowAWSBYOCClusterV4(t *testing.T) {
 						}
 					]
 				}`))
-				
+
 			case "/v4/organizations/acmeorg/credentials/credential-id/":
 				w.WriteHeader(http.StatusOK)
 				w.Write([]byte(`{
@@ -518,8 +518,8 @@ func TestFormatClusterLabels(t *testing.T) {
 		t.Errorf("formatted cluster labels result has invalid length. Expected %d got %d", 1, len(result))
 	}
 
-	if result[0] != "Labels:|-" {
-		t.Errorf("formatted cluster labels result expected '%s' got '%s'", "Labels:|-", result[0])
+	if result[0] != "Labels:|n/a" {
+		t.Errorf("formatted cluster labels result expected '%s' got '%s'", "Labels:|n/a", result[0])
 	}
 
 	mockLabels["testkey"] = "testvalue"


### PR DESCRIPTION
This changes the labels placeholder from `-` to `n/a`.

Before:

![image](https://user-images.githubusercontent.com/273727/83123628-6fa84b80-a0d5-11ea-9a1f-d28410cf3026.png)

After:

![image](https://user-images.githubusercontent.com/273727/83123653-78991d00-a0d5-11ea-95a3-6f1f694c01fd.png)
