### PR TITLE
Fix not being able to use the '--num-workers' flag for scaling clusters

### DIFF
--- a/client/clienterror/clienterror.go
+++ b/client/clienterror/clienterror.go
@@ -162,11 +162,6 @@ func New(err error) *APIError {
 			ae.ErrorDetails += "Details: " + modifyClusterFailedErr.Payload.Message
 		}
 
-		if modifyClusterFailedErr.Payload.Code == "INVALID_INPUT" {
-			ae.ErrorMessage = "Invalid parameters"
-			ae.ErrorDetails = "The cluster could not be updated. workers-min and workers-max must be equal without autoscaling."
-		}
-
 		return ae
 	}
 	if modifyClusterFailedErr, ok := err.(*clusters.ModifyClusterNotFound); ok {

--- a/commands/scale/cluster/command.go
+++ b/commands/scale/cluster/command.go
@@ -359,11 +359,15 @@ func scaleCluster(args Arguments) (*Result, error) {
 		minWorkers := int64(scalingResult.ScalingMinBefore)
 		if args.WorkersMinSet {
 			minWorkers = args.WorkersMin
+		} else if args.WorkersSet {
+			minWorkers = int64(args.Workers)
 		}
 
 		maxWorkers := int64(scalingResult.ScalingMaxBefore)
 		if args.WorkersMaxSet {
 			maxWorkers = args.WorkersMax
+		} else if args.WorkersSet {
+			maxWorkers = int64(args.Workers)
 		}
 
 		// Preparing API call.

--- a/commands/scale/cluster/command.go
+++ b/commands/scale/cluster/command.go
@@ -343,16 +343,6 @@ func scaleCluster(args Arguments) (*Result, error) {
 		}
 	}
 
-	// Ask for confirmation for the scaling action.
-	if !args.OppressConfirmation {
-		// get confirmation and handle result
-		err = getConfirmation(args, scalingResult.ScalingMaxBefore, scalingResult.ScalingMinBefore, statusWorkers)
-		if err != nil {
-			fmt.Println(color.GreenString("Scaling cancelled"))
-			os.Exit(0)
-		}
-	}
-
 	// Preparing API call.
 	var reqBody *models.V4ModifyClusterRequest
 	{
@@ -376,6 +366,16 @@ func scaleCluster(args Arguments) (*Result, error) {
 				Max: maxWorkers,
 				Min: minWorkers,
 			},
+		}
+	}
+
+	// Ask for confirmation for the scaling action.
+	if !args.OppressConfirmation {
+		// get confirmation and handle result
+		err = getConfirmation(args, int(reqBody.Scaling.Max), int(reqBody.Scaling.Min), statusWorkers)
+		if err != nil {
+			fmt.Println(color.GreenString("Scaling cancelled"))
+			os.Exit(0)
 		}
 	}
 


### PR DESCRIPTION
As seen in https://gigantic.slack.com/archives/CQ465CFG8/p1591177330001300

The `--num-workers` flag was not actually working for the 'scale cluster' command. It is now 👍 

Also, this fixes:
* There was a hard-coded error in the client that would always display the `The cluster could not be updated. workers-min and workers-max must be equal without autoscaling.` error whenever there was an `INVALID_INPUT` error code coming from the modify cluster response.
* If you wanted to downscale a cluster, the confirmation would not display the actual worker node counts in the scale request.