### PR TITLE
Account for empty AZ labels in node pools lister

### DIFF
--- a/formatting/availability_zones.go
+++ b/formatting/availability_zones.go
@@ -9,11 +9,16 @@ import (
 // as one string consisting of uppercase letters only, separated by comma.
 // Example: "A,B,C".
 func AvailabilityZonesList(az []string) string {
-	shortened := []string{}
+	var shortened []string
 
-	for _, az := range az {
+	for _, zone := range az {
+		lastLetterIndex := len(zone) - 1
+		if lastLetterIndex < 0 {
+			lastLetterIndex = 0
+		}
+
 		// last character of each item
-		shortened = append(shortened, az[len(az)-1:])
+		shortened = append(shortened, zone[lastLetterIndex:])
 	}
 
 	sort.Strings(shortened)


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/11150

We were slicing a string with the starting index of `-1` if the string was empty.