### PR TITLE
Extend cluster definition to support spot instances

### DIFF
--- a/commands/create/cluster/command_test.go
+++ b/commands/create/cluster/command_test.go
@@ -284,7 +284,7 @@ func Test_CreateClusterSuccessfully(t *testing.T) {
 							AvailabilityZones: &types.AvailabilityZonesDefinition{Number: 2},
 						},
 						{
-							Name: "Node pool with 3 specific AZs A, B, C, scaling 3-10, m5.xlarge",
+							Name: "Node pool with 3 specific AZs A, B, C, scaling 3-10, m5.xlarge, spot",
 							AvailabilityZones: &types.AvailabilityZonesDefinition{
 								Zones: []string{"eu-central-1a", "eu-central-1b", "eu-central-1c"},
 							},
@@ -295,11 +295,109 @@ func Test_CreateClusterSuccessfully(t *testing.T) {
 							NodeSpec: &types.NodeSpec{
 								AWS: &types.AWSSpecificDefinition{
 									InstanceType: "m5.xlarge",
+									InstanceDistribution: &types.AWSInstanceDistribution{
+										OnDemandBaseCapacity:                1,
+										OnDemandPercentageAboveBaseCapacity: 10,
+									},
+									UseAlikeInstanceTypes: true,
 								},
 							},
 						},
 						{
 							Name: "Node pool using defaults only",
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "Definition with several spot-related node pool setups (v5_instance_distribution.yaml)",
+			inputArgs: &Arguments{
+				CreateDefaultNodePool: false,
+				FileSystem:            afero.NewOsFs(),
+				InputYAMLFile:         "testdata/v5_instance_distribution.yaml",
+				AuthToken:             "fake token",
+				Verbose:               true,
+			},
+			expectedResult: &creationResult{
+				ID: "f6e8r",
+				DefinitionV5: &types.ClusterDefinitionV5{
+					APIVersion:     "v5",
+					Name:           "Cluster with several node pools testing various instance distribution combinations",
+					Owner:          "acme",
+					ReleaseVersion: "11.5.0",
+					NodePools: []*types.NodePoolDefinition{
+						{
+							Name: "Node pool with 0 on-demand, 100% spot, no alike instance types",
+							NodeSpec: &types.NodeSpec{
+								AWS: &types.AWSSpecificDefinition{
+									InstanceDistribution: &types.AWSInstanceDistribution{
+										OnDemandBaseCapacity:                0,
+										OnDemandPercentageAboveBaseCapacity: 100,
+									},
+									UseAlikeInstanceTypes: false,
+								},
+							},
+						},
+						{
+							Name: "Node pool with 3 on-demand, 100% spot, no alike instance types",
+							NodeSpec: &types.NodeSpec{
+								AWS: &types.AWSSpecificDefinition{
+									InstanceDistribution: &types.AWSInstanceDistribution{
+										OnDemandBaseCapacity:                3,
+										OnDemandPercentageAboveBaseCapacity: 100,
+									},
+									UseAlikeInstanceTypes: false,
+								},
+							},
+						},
+						{
+							Name: "Node pool with 3 on-demand, 50% spot, no alike instance types",
+							NodeSpec: &types.NodeSpec{
+								AWS: &types.AWSSpecificDefinition{
+									InstanceDistribution: &types.AWSInstanceDistribution{
+										OnDemandBaseCapacity:                3,
+										OnDemandPercentageAboveBaseCapacity: 50,
+									},
+									UseAlikeInstanceTypes: false,
+								},
+							},
+						},
+						{
+							Name: "Node pool with 0 on-demand, 100% spot, use alike instance types",
+							NodeSpec: &types.NodeSpec{
+								AWS: &types.AWSSpecificDefinition{
+									InstanceDistribution: &types.AWSInstanceDistribution{
+										OnDemandBaseCapacity:                0,
+										OnDemandPercentageAboveBaseCapacity: 100,
+									},
+									UseAlikeInstanceTypes: true,
+								},
+							},
+						},
+						{
+							Name: "Node pool with 3 on-demand, 100% spot, use alike instance types",
+							NodeSpec: &types.NodeSpec{
+								AWS: &types.AWSSpecificDefinition{
+									InstanceDistribution: &types.AWSInstanceDistribution{
+										OnDemandBaseCapacity:                3,
+										OnDemandPercentageAboveBaseCapacity: 100,
+									},
+									UseAlikeInstanceTypes: true,
+								},
+							},
+						},
+						{
+							Name: "Node pool with 3 on-demand, 50% spot, use alike instance types",
+							NodeSpec: &types.NodeSpec{
+								AWS: &types.AWSSpecificDefinition{
+									InstanceDistribution: &types.AWSInstanceDistribution{
+										OnDemandBaseCapacity:                3,
+										OnDemandPercentageAboveBaseCapacity: 50,
+									},
+									UseAlikeInstanceTypes: true,
+								},
+							},
 						},
 					},
 				},

--- a/commands/create/cluster/command_test.go
+++ b/commands/create/cluster/command_test.go
@@ -284,7 +284,7 @@ func Test_CreateClusterSuccessfully(t *testing.T) {
 							AvailabilityZones: &types.AvailabilityZonesDefinition{Number: 2},
 						},
 						{
-							Name: "Node pool with 3 specific AZs A, B, C, scaling 3-10, m5.xlarge, spot",
+							Name: "Node pool with 3 specific AZs A, B, C, scaling 3-10, m5.xlarge",
 							AvailabilityZones: &types.AvailabilityZonesDefinition{
 								Zones: []string{"eu-central-1a", "eu-central-1b", "eu-central-1c"},
 							},
@@ -296,8 +296,8 @@ func Test_CreateClusterSuccessfully(t *testing.T) {
 								AWS: &types.AWSSpecificDefinition{
 									InstanceType: "m5.xlarge",
 									InstanceDistribution: &types.AWSInstanceDistribution{
-										OnDemandBaseCapacity:                1,
-										OnDemandPercentageAboveBaseCapacity: 10,
+										OnDemandBaseCapacity:                0,
+										OnDemandPercentageAboveBaseCapacity: 100,
 									},
 									UseAlikeInstanceTypes: true,
 								},
@@ -326,6 +326,9 @@ func Test_CreateClusterSuccessfully(t *testing.T) {
 					Name:           "Cluster with several node pools testing various instance distribution combinations",
 					Owner:          "acme",
 					ReleaseVersion: "11.5.0",
+					MasterNodes: &types.MasterNodes{
+						HighAvailability: true,
+					},
 					NodePools: []*types.NodePoolDefinition{
 						{
 							Name: "Node pool with 0 on-demand, 100% spot, no alike instance types",

--- a/commands/create/cluster/command_test.go
+++ b/commands/create/cluster/command_test.go
@@ -215,19 +215,19 @@ func Test_CreateClusterSuccessfully(t *testing.T) {
 					ReleaseVersion:    "1.2.3",
 					AvailabilityZones: 1,
 					Workers: []types.NodeDefinition{
-						types.NodeDefinition{
+						{
 							Memory:  types.MemoryDefinition{SizeGB: 2},
 							CPU:     types.CPUDefinition{Cores: 2},
 							Storage: types.StorageDefinition{SizeGB: 20},
 							Labels:  map[string]string{"nodetype": "standard"},
 						},
-						types.NodeDefinition{
+						{
 							Memory:  types.MemoryDefinition{SizeGB: 8},
 							CPU:     types.CPUDefinition{Cores: 2},
 							Storage: types.StorageDefinition{SizeGB: 20},
 							Labels:  map[string]string{"nodetype": "hiram"},
 						},
-						types.NodeDefinition{
+						{
 							Memory:  types.MemoryDefinition{SizeGB: 2},
 							CPU:     types.CPUDefinition{Cores: 6},
 							Storage: types.StorageDefinition{SizeGB: 20},
@@ -279,11 +279,11 @@ func Test_CreateClusterSuccessfully(t *testing.T) {
 					ReleaseVersion: "9.0.0",
 					Master:         &types.MasterDefinition{AvailabilityZone: "eu-central-1a"},
 					NodePools: []*types.NodePoolDefinition{
-						&types.NodePoolDefinition{
+						{
 							Name:              "Node pool with 2 random AZs",
 							AvailabilityZones: &types.AvailabilityZonesDefinition{Number: 2},
 						},
-						&types.NodePoolDefinition{
+						{
 							Name: "Node pool with 3 specific AZs A, B, C, scaling 3-10, m5.xlarge",
 							AvailabilityZones: &types.AvailabilityZonesDefinition{
 								Zones: []string{"eu-central-1a", "eu-central-1b", "eu-central-1c"},
@@ -298,7 +298,7 @@ func Test_CreateClusterSuccessfully(t *testing.T) {
 								},
 							},
 						},
-						&types.NodePoolDefinition{
+						{
 							Name: "Node pool using defaults only",
 						},
 					},

--- a/commands/create/cluster/read_definition_test.go
+++ b/commands/create/cluster/read_definition_test.go
@@ -138,12 +138,12 @@ workers:
 			expectedOutput: &types.ClusterDefinitionV4{
 				Owner: "myorg",
 				Workers: []types.NodeDefinition{
-					types.NodeDefinition{
+					{
 						Memory:  types.MemoryDefinition{SizeGB: 16.5},
 						CPU:     types.CPUDefinition{Cores: 4},
 						Storage: types.StorageDefinition{SizeGB: 100},
 					},
-					types.NodeDefinition{
+					{
 						Memory:  types.MemoryDefinition{SizeGB: 32},
 						CPU:     types.CPUDefinition{Cores: 8},
 						Storage: types.StorageDefinition{SizeGB: 50},
@@ -231,17 +231,17 @@ nodepools:
 				Owner:      "myorg",
 				Master:     &types.MasterDefinition{AvailabilityZone: "my-zone-1a"},
 				NodePools: []*types.NodePoolDefinition{
-					&types.NodePoolDefinition{
+					{
 						Name:              "General purpose",
 						AvailabilityZones: &types.AvailabilityZonesDefinition{Number: 2},
 					},
-					&types.NodePoolDefinition{
+					{
 						Name:              "Database",
 						AvailabilityZones: &types.AvailabilityZonesDefinition{Zones: []string{"my-zone-1a", "my-zone-1b", "my-zone-1c"}},
 						Scaling:           &types.ScalingDefinition{Min: 3, Max: 10},
 						NodeSpec:          &types.NodeSpec{AWS: &types.AWSSpecificDefinition{InstanceType: "m5.superlarge"}},
 					},
-					&types.NodePoolDefinition{
+					{
 						Name: "Batch",
 					},
 				},
@@ -276,17 +276,17 @@ nodepools:
 				Owner:       "myorg",
 				MasterNodes: &types.MasterNodes{HighAvailability: true},
 				NodePools: []*types.NodePoolDefinition{
-					&types.NodePoolDefinition{
+					{
 						Name:              "General purpose",
 						AvailabilityZones: &types.AvailabilityZonesDefinition{Number: 2},
 					},
-					&types.NodePoolDefinition{
+					{
 						Name:              "Database",
 						AvailabilityZones: &types.AvailabilityZonesDefinition{Zones: []string{"my-zone-1a", "my-zone-1b", "my-zone-1c"}},
 						Scaling:           &types.ScalingDefinition{Min: 3, Max: 10},
 						NodeSpec:          &types.NodeSpec{AWS: &types.AWSSpecificDefinition{InstanceType: "m5.superlarge"}},
 					},
-					&types.NodePoolDefinition{
+					{
 						Name: "Batch",
 					},
 				},

--- a/commands/create/cluster/read_definition_test.go
+++ b/commands/create/cluster/read_definition_test.go
@@ -296,6 +296,139 @@ nodepools:
 				},
 			},
 		},
+		{
+			// like testdata/v5_instance_distribution.yaml
+			[]byte(`api_version: v5
+release_version: "11.5.0"
+owner: acme
+name: Cluster with several node pools testing various instance distribution combinations
+nodepools:
+- name: Node pool with 0 on-demand, 100% spot, no alike instance types
+  node_spec:
+    aws:
+      instance_distribution:
+        on_demand_base_capacity: 0
+        on_demand_percentage_above_base_capacity: 100
+      use_alike_instance_types: false
+- name: Node pool with 3 on-demand, 100% spot, no alike instance types
+  node_spec:
+    aws:
+      instance_distribution:
+        on_demand_base_capacity: 3
+        on_demand_percentage_above_base_capacity: 100
+      use_alike_instance_types: false
+- name: Node pool with 3 on-demand, 50% spot, no alike instance types
+  node_spec:
+    aws:
+      instance_distribution:
+        on_demand_base_capacity: 3
+        on_demand_percentage_above_base_capacity: 50
+      use_alike_instance_types: false
+- name: Node pool with 0 on-demand, 100% spot, use alike instance types
+  node_spec:
+    aws:
+      instance_distribution:
+        on_demand_base_capacity: 0
+        on_demand_percentage_above_base_capacity: 100
+      use_alike_instance_types: true
+- name: Node pool with 3 on-demand, 100% spot, use alike instance types
+  node_spec:
+    aws:
+      instance_distribution:
+        on_demand_base_capacity: 3
+        on_demand_percentage_above_base_capacity: 100
+      use_alike_instance_types: true
+- name: Node pool with 3 on-demand, 50% spot, use alike instance types
+  node_spec:
+    aws:
+      instance_distribution:
+        on_demand_base_capacity: 3
+        on_demand_percentage_above_base_capacity: 50
+      use_alike_instance_types: true
+`),
+			&types.ClusterDefinitionV5{
+				APIVersion:     "v5",
+				ReleaseVersion: "11.5.0",
+				Name:           "Cluster with several node pools testing various instance distribution combinations",
+				Owner:          "acme",
+				Master:         nil,
+				MasterNodes:    nil,
+				NodePools: []*types.NodePoolDefinition{
+					{
+						Name: "Node pool with 0 on-demand, 100% spot, no alike instance types",
+						NodeSpec: &types.NodeSpec{
+							AWS: &types.AWSSpecificDefinition{
+								InstanceDistribution: &types.AWSInstanceDistribution{
+									OnDemandBaseCapacity:                0,
+									OnDemandPercentageAboveBaseCapacity: 100,
+								},
+								UseAlikeInstanceTypes: false,
+							},
+						},
+					},
+					{
+						Name: "Node pool with 3 on-demand, 100% spot, no alike instance types",
+						NodeSpec: &types.NodeSpec{
+							AWS: &types.AWSSpecificDefinition{
+								InstanceDistribution: &types.AWSInstanceDistribution{
+									OnDemandBaseCapacity:                3,
+									OnDemandPercentageAboveBaseCapacity: 100,
+								},
+								UseAlikeInstanceTypes: false,
+							},
+						},
+					},
+					{
+						Name: "Node pool with 3 on-demand, 50% spot, no alike instance types",
+						NodeSpec: &types.NodeSpec{
+							AWS: &types.AWSSpecificDefinition{
+								InstanceDistribution: &types.AWSInstanceDistribution{
+									OnDemandBaseCapacity:                3,
+									OnDemandPercentageAboveBaseCapacity: 50,
+								},
+								UseAlikeInstanceTypes: false,
+							},
+						},
+					},
+					{
+						Name: "Node pool with 0 on-demand, 100% spot, use alike instance types",
+						NodeSpec: &types.NodeSpec{
+							AWS: &types.AWSSpecificDefinition{
+								InstanceDistribution: &types.AWSInstanceDistribution{
+									OnDemandBaseCapacity:                0,
+									OnDemandPercentageAboveBaseCapacity: 100,
+								},
+								UseAlikeInstanceTypes: true,
+							},
+						},
+					},
+					{
+						Name: "Node pool with 3 on-demand, 100% spot, use alike instance types",
+						NodeSpec: &types.NodeSpec{
+							AWS: &types.AWSSpecificDefinition{
+								InstanceDistribution: &types.AWSInstanceDistribution{
+									OnDemandBaseCapacity:                3,
+									OnDemandPercentageAboveBaseCapacity: 100,
+								},
+								UseAlikeInstanceTypes: true,
+							},
+						},
+					},
+					{
+						Name: "Node pool with 3 on-demand, 50% spot, use alike instance types",
+						NodeSpec: &types.NodeSpec{
+							AWS: &types.AWSSpecificDefinition{
+								InstanceDistribution: &types.AWSInstanceDistribution{
+									OnDemandBaseCapacity:                3,
+									OnDemandPercentageAboveBaseCapacity: 50,
+								},
+								UseAlikeInstanceTypes: true,
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for i, tc := range testCases {

--- a/commands/create/cluster/read_definition_test.go
+++ b/commands/create/cluster/read_definition_test.go
@@ -50,6 +50,10 @@ func Test_readDefinitionFromFile(t *testing.T) {
 			errorMatcher: nil,
 		},
 		{
+			fileName:     "v5_instance_distribution.yaml",
+			errorMatcher: nil,
+		},
+		{
 			fileName:     "invalid01.yaml",
 			errorMatcher: IsInvalidDefinitionYAML,
 		},

--- a/commands/create/cluster/testdata/v5_instance_distribution.yaml
+++ b/commands/create/cluster/testdata/v5_instance_distribution.yaml
@@ -1,0 +1,47 @@
+api_version: v5
+release_version: "11.5.0"
+owner: acme
+name: Cluster with several node pools testing various instance distribution combinations
+nodepools:
+- name: Node pool with 0 on-demand, 100% spot, no alike instance types
+  node_spec:
+    aws:
+      instance_distribution:
+        on_demand_base_capacity: 0
+        on_demand_percentage_above_base_capacity: 100
+      use_alike_instance_types: false
+- name: Node pool with 3 on-demand, 100% spot, no alike instance types
+  node_spec:
+    aws:
+      instance_distribution:
+        on_demand_base_capacity: 3
+        on_demand_percentage_above_base_capacity: 100
+      use_alike_instance_types: false
+- name: Node pool with 3 on-demand, 50% spot, no alike instance types
+  node_spec:
+    aws:
+      instance_distribution:
+        on_demand_base_capacity: 3
+        on_demand_percentage_above_base_capacity: 50
+      use_alike_instance_types: false
+- name: Node pool with 0 on-demand, 100% spot, use alike instance types
+  node_spec:
+    aws:
+      instance_distribution:
+        on_demand_base_capacity: 0
+        on_demand_percentage_above_base_capacity: 100
+      use_alike_instance_types: true
+- name: Node pool with 3 on-demand, 100% spot, use alike instance types
+  node_spec:
+    aws:
+      instance_distribution:
+        on_demand_base_capacity: 3
+        on_demand_percentage_above_base_capacity: 100
+      use_alike_instance_types: true
+- name: Node pool with 3 on-demand, 50% spot, use alike instance types
+  node_spec:
+    aws:
+      instance_distribution:
+        on_demand_base_capacity: 3
+        on_demand_percentage_above_base_capacity: 50
+      use_alike_instance_types: true

--- a/commands/create/cluster/testdata/v5_three_nodepools.yaml
+++ b/commands/create/cluster/testdata/v5_three_nodepools.yaml
@@ -7,7 +7,7 @@ nodepools:
 - name: Node pool with 2 random AZs
   availability_zones:
     number: 2
-- name: Node pool with 3 specific AZs A, B, C, scaling 3-10, m5.xlarge
+- name: Node pool with 3 specific AZs A, B, C, scaling 3-10, m5.xlarge, spot
   availability_zones:
     zones:
     - eu-central-1a
@@ -19,4 +19,8 @@ nodepools:
   node_spec:
     aws:
       instance_type: m5.xlarge
+      instance_distribution:
+        on_demand_base_capacity: 0
+        on_demand_percentage_above_base_capacity: 0
+      use_alike_instance_types: true
 - name: Node pool using defaults only

--- a/commands/create/cluster/testdata/v5_three_nodepools.yaml
+++ b/commands/create/cluster/testdata/v5_three_nodepools.yaml
@@ -7,7 +7,7 @@ nodepools:
 - name: Node pool with 2 random AZs
   availability_zones:
     number: 2
-- name: Node pool with 3 specific AZs A, B, C, scaling 3-10, m5.xlarge, spot
+- name: Node pool with 3 specific AZs A, B, C, scaling 3-10, m5.xlarge
   availability_zones:
     zones:
     - eu-central-1a
@@ -21,6 +21,6 @@ nodepools:
       instance_type: m5.xlarge
       instance_distribution:
         on_demand_base_capacity: 0
-        on_demand_percentage_above_base_capacity: 0
+        on_demand_percentage_above_base_capacity: 100
       use_alike_instance_types: true
 - name: Node pool using defaults only

--- a/commands/types/types.go
+++ b/commands/types/types.go
@@ -18,15 +18,15 @@ type StorageDefinition struct {
 
 // AWSSpecificDefinition defines worker node specs for AWS.
 type AWSSpecificDefinition struct {
-	InstanceDistribution  AWSInstanceDistribution `yaml:"instance_distribution,omitempty"`
-	InstanceType          string                  `yaml:"instance_type,omitempty"`
-	UseAlikeInstanceTypes bool                    `yaml:"use_alike_instance_types,omitempty"`
+	InstanceDistribution  *AWSInstanceDistribution `yaml:"instance_distribution,omitempty"`
+	InstanceType          string                   `yaml:"instance_type,omitempty"`
+	UseAlikeInstanceTypes bool                     `yaml:"use_alike_instance_types,omitempty"`
 }
 
 // AWSInstanceDistribution defines the distribution between on-demand and spot instances.
 type AWSInstanceDistribution struct {
-	OnDemandBaseCapacity                int8 `yaml:"on_demand_base_capacity,omitempty"`
-	OnDemandPercentageAboveBaseCapacity int8 `yaml:"on_demand_percentage_above_base_capacity,omitempty"`
+	OnDemandBaseCapacity                int8 `yaml:"on_demand_base_capacity"`
+	OnDemandPercentageAboveBaseCapacity int8 `yaml:"on_demand_percentage_above_base_capacity"`
 }
 
 // AzureSpecificDefinition defines worker node specs for Azure.

--- a/commands/types/types.go
+++ b/commands/types/types.go
@@ -18,7 +18,15 @@ type StorageDefinition struct {
 
 // AWSSpecificDefinition defines worker node specs for AWS.
 type AWSSpecificDefinition struct {
-	InstanceType string `yaml:"instance_type,omitempty"`
+	InstanceDistribution  AWSInstanceDistribution `yaml:"instance_distribution,omitempty"`
+	InstanceType          string                  `yaml:"instance_type,omitempty"`
+	UseAlikeInstanceTypes bool                    `yaml:"use_alike_instance_types,omitempty"`
+}
+
+// AWSInstanceDistribution defines the distribution between on-demand and spot instances.
+type AWSInstanceDistribution struct {
+	OnDemandBaseCapacity                int8 `yaml:"on_demand_base_capacity,omitempty"`
+	OnDemandPercentageAboveBaseCapacity int8 `yaml:"on_demand_percentage_above_base_capacity,omitempty"`
 }
 
 // AzureSpecificDefinition defines worker node specs for Azure.

--- a/commands/types/types.go
+++ b/commands/types/types.go
@@ -69,7 +69,7 @@ type MasterDefinition struct {
 	AvailabilityZone string `yaml:"availability_zone,omitempty"`
 }
 
-// MasterDefinition defines an interface for configuring HA master nodes.
+// MasterNodes defines an interface for configuring HA master nodes.
 type MasterNodes struct {
 	HighAvailability bool `yaml:"high_availability,omitempty"`
 }


### PR DESCRIPTION
The goal of this PR is to add to `gsctl create cluster` the missing support for node pool attributes that got added witt spot instances, in the case that a YAML cluster definition is used.