### PR TITLE
Fix node pool creation based on cluster definition

### DIFF
--- a/commands/create/cluster/command_test.go
+++ b/commands/create/cluster/command_test.go
@@ -336,7 +336,7 @@ func Test_CreateClusterSuccessfully(t *testing.T) {
 								AWS: &types.AWSSpecificDefinition{
 									InstanceDistribution: &types.AWSInstanceDistribution{
 										OnDemandBaseCapacity:                0,
-										OnDemandPercentageAboveBaseCapacity: 100,
+										OnDemandPercentageAboveBaseCapacity: 0,
 									},
 									UseAlikeInstanceTypes: false,
 								},
@@ -348,7 +348,7 @@ func Test_CreateClusterSuccessfully(t *testing.T) {
 								AWS: &types.AWSSpecificDefinition{
 									InstanceDistribution: &types.AWSInstanceDistribution{
 										OnDemandBaseCapacity:                3,
-										OnDemandPercentageAboveBaseCapacity: 100,
+										OnDemandPercentageAboveBaseCapacity: 0,
 									},
 									UseAlikeInstanceTypes: false,
 								},
@@ -372,7 +372,7 @@ func Test_CreateClusterSuccessfully(t *testing.T) {
 								AWS: &types.AWSSpecificDefinition{
 									InstanceDistribution: &types.AWSInstanceDistribution{
 										OnDemandBaseCapacity:                0,
-										OnDemandPercentageAboveBaseCapacity: 100,
+										OnDemandPercentageAboveBaseCapacity: 0,
 									},
 									UseAlikeInstanceTypes: true,
 								},
@@ -384,7 +384,7 @@ func Test_CreateClusterSuccessfully(t *testing.T) {
 								AWS: &types.AWSSpecificDefinition{
 									InstanceDistribution: &types.AWSInstanceDistribution{
 										OnDemandBaseCapacity:                3,
-										OnDemandPercentageAboveBaseCapacity: 100,
+										OnDemandPercentageAboveBaseCapacity: 0,
 									},
 									UseAlikeInstanceTypes: true,
 								},

--- a/commands/create/cluster/read_definition_test.go
+++ b/commands/create/cluster/read_definition_test.go
@@ -308,14 +308,14 @@ nodepools:
     aws:
       instance_distribution:
         on_demand_base_capacity: 0
-        on_demand_percentage_above_base_capacity: 100
+        on_demand_percentage_above_base_capacity: 0
       use_alike_instance_types: false
 - name: Node pool with 3 on-demand, 100% spot, no alike instance types
   node_spec:
     aws:
       instance_distribution:
         on_demand_base_capacity: 3
-        on_demand_percentage_above_base_capacity: 100
+        on_demand_percentage_above_base_capacity: 0
       use_alike_instance_types: false
 - name: Node pool with 3 on-demand, 50% spot, no alike instance types
   node_spec:
@@ -329,14 +329,14 @@ nodepools:
     aws:
       instance_distribution:
         on_demand_base_capacity: 0
-        on_demand_percentage_above_base_capacity: 100
+        on_demand_percentage_above_base_capacity: 0
       use_alike_instance_types: true
 - name: Node pool with 3 on-demand, 100% spot, use alike instance types
   node_spec:
     aws:
       instance_distribution:
         on_demand_base_capacity: 3
-        on_demand_percentage_above_base_capacity: 100
+        on_demand_percentage_above_base_capacity: 0
       use_alike_instance_types: true
 - name: Node pool with 3 on-demand, 50% spot, use alike instance types
   node_spec:
@@ -360,7 +360,7 @@ nodepools:
 							AWS: &types.AWSSpecificDefinition{
 								InstanceDistribution: &types.AWSInstanceDistribution{
 									OnDemandBaseCapacity:                0,
-									OnDemandPercentageAboveBaseCapacity: 100,
+									OnDemandPercentageAboveBaseCapacity: 0,
 								},
 								UseAlikeInstanceTypes: false,
 							},
@@ -372,7 +372,7 @@ nodepools:
 							AWS: &types.AWSSpecificDefinition{
 								InstanceDistribution: &types.AWSInstanceDistribution{
 									OnDemandBaseCapacity:                3,
-									OnDemandPercentageAboveBaseCapacity: 100,
+									OnDemandPercentageAboveBaseCapacity: 0,
 								},
 								UseAlikeInstanceTypes: false,
 							},
@@ -396,7 +396,7 @@ nodepools:
 							AWS: &types.AWSSpecificDefinition{
 								InstanceDistribution: &types.AWSInstanceDistribution{
 									OnDemandBaseCapacity:                0,
-									OnDemandPercentageAboveBaseCapacity: 100,
+									OnDemandPercentageAboveBaseCapacity: 0,
 								},
 								UseAlikeInstanceTypes: true,
 							},
@@ -408,7 +408,7 @@ nodepools:
 							AWS: &types.AWSSpecificDefinition{
 								InstanceDistribution: &types.AWSInstanceDistribution{
 									OnDemandBaseCapacity:                3,
-									OnDemandPercentageAboveBaseCapacity: 100,
+									OnDemandPercentageAboveBaseCapacity: 0,
 								},
 								UseAlikeInstanceTypes: true,
 							},

--- a/commands/create/cluster/testdata/v5_instance_distribution.yaml
+++ b/commands/create/cluster/testdata/v5_instance_distribution.yaml
@@ -8,14 +8,14 @@ nodepools:
     aws:
       instance_distribution:
         on_demand_base_capacity: 0
-        on_demand_percentage_above_base_capacity: 100
+        on_demand_percentage_above_base_capacity: 0
       use_alike_instance_types: false
 - name: Node pool with 3 on-demand, 100% spot, no alike instance types
   node_spec:
     aws:
       instance_distribution:
         on_demand_base_capacity: 3
-        on_demand_percentage_above_base_capacity: 100
+        on_demand_percentage_above_base_capacity: 0
       use_alike_instance_types: false
 - name: Node pool with 3 on-demand, 50% spot, no alike instance types
   node_spec:
@@ -29,14 +29,14 @@ nodepools:
     aws:
       instance_distribution:
         on_demand_base_capacity: 0
-        on_demand_percentage_above_base_capacity: 100
+        on_demand_percentage_above_base_capacity: 0
       use_alike_instance_types: true
 - name: Node pool with 3 on-demand, 100% spot, use alike instance types
   node_spec:
     aws:
       instance_distribution:
         on_demand_base_capacity: 3
-        on_demand_percentage_above_base_capacity: 100
+        on_demand_percentage_above_base_capacity: 0
       use_alike_instance_types: true
 - name: Node pool with 3 on-demand, 50% spot, use alike instance types
   node_spec:

--- a/commands/create/cluster/v5.go
+++ b/commands/create/cluster/v5.go
@@ -93,9 +93,22 @@ func createAddNodePoolBody(def *types.NodePoolDefinition) *models.V5AddNodePoolR
 		}
 	}
 
-	if def.NodeSpec != nil && def.NodeSpec.AWS != nil {
-		b.NodeSpec.Aws = &models.V5AddNodePoolRequestNodeSpecAws{
-			InstanceType: def.NodeSpec.AWS.InstanceType,
+	if def.NodeSpec != nil {
+		if def.NodeSpec.AWS != nil {
+			b.NodeSpec.Aws = &models.V5AddNodePoolRequestNodeSpecAws{}
+
+			if def.NodeSpec.AWS.InstanceDistribution != nil {
+				b.NodeSpec.Aws.InstanceDistribution = &models.V5AddNodePoolRequestNodeSpecAwsInstanceDistribution{
+					OnDemandBaseCapacity:                &def.NodeSpec.AWS.InstanceDistribution.OnDemandBaseCapacity,
+					OnDemandPercentageAboveBaseCapacity: &def.NodeSpec.AWS.InstanceDistribution.OnDemandPercentageAboveBaseCapacity,
+				}
+			}
+
+			if def.NodeSpec.AWS.InstanceType != "" {
+				b.NodeSpec.Aws.InstanceType = def.NodeSpec.AWS.InstanceType
+			}
+
+			b.NodeSpec.Aws.UseAlikeInstanceTypes = &def.NodeSpec.AWS.UseAlikeInstanceTypes
 		}
 	}
 

--- a/commands/types/types.go
+++ b/commands/types/types.go
@@ -25,8 +25,8 @@ type AWSSpecificDefinition struct {
 
 // AWSInstanceDistribution defines the distribution between on-demand and spot instances.
 type AWSInstanceDistribution struct {
-	OnDemandBaseCapacity                int8 `yaml:"on_demand_base_capacity"`
-	OnDemandPercentageAboveBaseCapacity int8 `yaml:"on_demand_percentage_above_base_capacity"`
+	OnDemandBaseCapacity                int64 `yaml:"on_demand_base_capacity"`
+	OnDemandPercentageAboveBaseCapacity int64 `yaml:"on_demand_percentage_above_base_capacity"`
 }
 
 // AzureSpecificDefinition defines worker node specs for Azure.


### PR DESCRIPTION
Follow-up to https://github.com/giantswarm/gsctl/pull/564

This ensures that spot-related attributes are applied when creating node pools based on a cluster definition.

It also fixes a misunderstanding regarding `on_demand_percentage_above_base_capacity` in unit tests, which I introduced in the last PR.