### PR TITLE
Allow version specification through arguments with v prefix

### DIFF
--- a/commands/create/cluster/command.go
+++ b/commands/create/cluster/command.go
@@ -68,6 +68,8 @@ func collectArguments(cmd *cobra.Command) Arguments {
 		haMasters = &flags.MasterHA
 	}
 
+	normalizedReleaseVersion := strings.TrimPrefix(flags.Release, "v")
+
 	return Arguments{
 		APIEndpoint:           endpoint,
 		AuthToken:             token,
@@ -77,7 +79,7 @@ func collectArguments(cmd *cobra.Command) Arguments {
 		InputYAMLFile:         flags.InputYAMLFile,
 		MasterHA:              haMasters,
 		Owner:                 flags.Owner,
-		ReleaseVersion:        flags.Release,
+		ReleaseVersion:        normalizedReleaseVersion,
 		Scheme:                scheme,
 		UserProvidedToken:     flags.Token,
 		Verbose:               flags.Verbose,

--- a/commands/create/cluster/command_test.go
+++ b/commands/create/cluster/command_test.go
@@ -73,6 +73,19 @@ func Test_CollectArgs(t *testing.T) {
 				MasterHA:              nil,
 			},
 		},
+		{
+			[]string{
+				"--release=v1.2.3",
+			},
+			Arguments{
+				APIEndpoint:           "https://foo",
+				AuthToken:             "some-token",
+				CreateDefaultNodePool: true,
+				ReleaseVersion:        "1.2.3",
+				Scheme:                "giantswarm",
+				MasterHA:              nil,
+			},
+		},
 	}
 
 	fs := afero.NewMemMapFs()


### PR DESCRIPTION
Resolves giantswarm/giantswarm#12770

This PR allows users to specify cluster version specification through command line flags with and without a preceding `v`.
