### PR TITLE
azure v5: add support for null NP AZs

### DIFF
--- a/commands/create/nodepool/command_test.go
+++ b/commands/create/nodepool/command_test.go
@@ -375,6 +375,17 @@ func TestVerifyPreconditions(t *testing.T) {
 			},
 			errors.IsConflictingFlagsError,
 		},
+		// Availability zones number is negative on AWS.
+		{
+			Arguments{
+				AuthToken:            "token",
+				APIEndpoint:          "https://mock-url",
+				AvailabilityZonesNum: -1,
+				ClusterNameOrID:      "cluster-id",
+				Provider:             "aws",
+			},
+			IsInvalidAvailabilityZones,
+		},
 		// Scaling min and max are not plausible.
 		{
 			Arguments{

--- a/commands/create/nodepool/error.go
+++ b/commands/create/nodepool/error.go
@@ -4,11 +4,11 @@ import (
 	"github.com/giantswarm/microerror"
 )
 
-var invalidAvailabilityZones = &microerror.Error{
-	Kind: "invalidAvailabilityZones",
+var invalidAvailabilityZonesError = &microerror.Error{
+	Kind: "invalidAvailabilityZonesError",
 }
 
-// IsInvalidAvailabilityZones asserts invalidAvailabilityZones.
+// IsInvalidAvailabilityZones asserts invalidAvailabilityZonesError.
 func IsInvalidAvailabilityZones(err error) bool {
-	return microerror.Cause(err) == invalidAvailabilityZones
+	return microerror.Cause(err) == invalidAvailabilityZonesError
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/12860

This PR allows setting the number of AZs to `-1`.

### Screenshots

<details>
<summary>Trying to use the '-1' value on Azure</summary>

![image](https://user-images.githubusercontent.com/13508038/90749721-16b31280-e2d4-11ea-8c3e-a317fd523ca4.png)

</details>