### PR TITLE
json output to create cluster, create kubeconfig, delete cluster

### DIFF
--- a/commands/create/cluster/command_test.go
+++ b/commands/create/cluster/command_test.go
@@ -1214,17 +1214,17 @@ selected_endpoint: ` + mockServer.URL
 
 	t.Log(jsonRepresentation)
 
-	if strings.Contains(jsonRepresentation, `"id": "f6e8r"`) == false {
+	if !strings.Contains(jsonRepresentation, `"id": "f6e8r"`) {
 		t.Errorf("Returned json representation '%s' does not contain expected '%s'", jsonRepresentation, `"id": "f6e8r"`)
 	}
 
-	if strings.Contains(jsonRepresentation, `"result": "created"`) == false {
+	if !strings.Contains(jsonRepresentation, `"result": "created"`) {
 		t.Errorf("Returned json representation '%s' does not contain expected '%s'", jsonRepresentation, `"result": "created"`)
 	}
 
-	if strings.Contains(jsonRepresentation, "Requesting new cluster for organization 'giantswarm'") == true ||
-		strings.Contains(jsonRepresentation, "Adding node pool") == true ||
-		strings.Contains(jsonRepresentation, "Adding a default node pool") == true {
+	if strings.Contains(jsonRepresentation, "Requesting new cluster for organization 'giantswarm'") ||
+		strings.Contains(jsonRepresentation, "Adding node pool") ||
+		strings.Contains(jsonRepresentation, "Adding a default node pool") {
 		t.Errorf("Expected no additional output for json output, got '%s'", jsonRepresentation)
 	}
 }

--- a/commands/create/cluster/command_test.go
+++ b/commands/create/cluster/command_test.go
@@ -86,6 +86,17 @@ func Test_CollectArgs(t *testing.T) {
 				MasterHA:              nil,
 			},
 		},
+		{
+			[]string{"--output=json"},
+			Arguments{
+				APIEndpoint:           "https://foo",
+				AuthToken:             "some-token",
+				CreateDefaultNodePool: true,
+				Scheme:                "giantswarm",
+				MasterHA:              nil,
+				OutputFormat:          "json",
+			},
+		},
 	}
 
 	fs := afero.NewMemMapFs()
@@ -122,6 +133,15 @@ func Test_verifyPreconditions(t *testing.T) {
 				APIEndpoint: "https://mock-url",
 			},
 			errors.IsNotLoggedInError,
+		},
+		// unknown output format
+		{
+			Arguments{
+				APIEndpoint:  "https://mock-url",
+				AuthToken:    "mock-token",
+				OutputFormat: "not-json",
+			},
+			errors.IsOutputFormatInvalid,
 		},
 	}
 
@@ -1092,5 +1112,142 @@ func Test_validateHAMasters(t *testing.T) {
 				t.Errorf("Case %d - Resulting args unequal. (-expected +got):\n%s", i, diff)
 			}
 		})
+	}
+}
+
+func Test_jsonOutput(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Log("mockServer request: ", r.Method, r.URL)
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == "POST" && r.URL.String() == "/v5/clusters/" {
+			w.Header().Set("Location", "/v5/clusters/f6e8r/")
+			w.WriteHeader(http.StatusCreated)
+			w.Write([]byte(`{
+					"id": "f6e8r",
+					"owner": "acme",
+					"release_version": "9.0.0",
+					"name": "Node Pool Cluster",
+					"master": {
+						"availability_zone": "eu-central-1c"
+					},
+					"nodepools": [],
+					"labels": {
+						"key": "value",
+						"labelkey": "labelvalue"
+					}
+				}`))
+		} else if r.Method == "GET" && r.URL.String() == "/v4/info/" {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+					"general": {
+					  "provider": "aws"
+					},
+					"features": {
+					  "nodepools": {"release_version_minimum": "9.0.0"},
+					  "ha_masters": {"release_version_minimum": "11.5.0"}
+					}
+				  }`))
+		} else if r.Method == "GET" && r.URL.String() == "/v4/releases/" {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`[
+					{
+						"timestamp": "2019-01-01T12:00:00Z",
+						"version": "1.0.0",
+						"active": true,
+						"changelog": [],
+						"components": []
+					},
+					{
+						"timestamp": "2019-09-23T12:00:00Z",
+						"version": "9.0.0",
+						"active": true,
+						"changelog": [],
+						"components": []
+					},
+					{
+						"timestamp": "2019-10-23T12:00:00Z",
+						"version": "11.5.0",
+						"active": true,
+						"changelog": [],
+						"components": []
+					}
+				]`))
+		}
+	}))
+	defer mockServer.Close()
+
+	fs := afero.NewMemMapFs()
+	// config
+	yamlText := `last_version_check: 0001-01-01T00:00:00Z
+updated: 2017-09-29T11:23:15+02:00
+endpoints:
+  ` + mockServer.URL + `:
+    email: email@example.com
+    token: some-token
+selected_endpoint: ` + mockServer.URL
+	_, err := testutils.TempConfig(fs, yamlText)
+	if err != nil {
+		t.Error(err)
+	}
+
+	flags.APIEndpoint = mockServer.URL // required to make InitClient() work
+	args := Arguments{
+		APIEndpoint:  mockServer.URL,
+		AuthToken:    "testtoken",
+		ClusterName:  "json-output-cluster",
+		Owner:        "giantswarm",
+		OutputFormat: "json",
+	}
+
+	err = verifyPreconditions(args)
+	if err != nil {
+		t.Error(err)
+	}
+
+	addClusterFunc := addCluster
+	print := printJSONOutput
+
+	jsonRepresentation := testutils.CaptureOutput(func() {
+		// output
+		print(addClusterFunc(args))
+	})
+
+	t.Log(jsonRepresentation)
+
+	if strings.Contains(jsonRepresentation, `"id": "f6e8r"`) == false {
+		t.Errorf("Returned json representation '%s' does not contain expected '%s'", jsonRepresentation, `"id": "f6e8r"`)
+	}
+
+	if strings.Contains(jsonRepresentation, `"result": "created"`) == false {
+		t.Errorf("Returned json representation '%s' does not contain expected '%s'", jsonRepresentation, `"result": "created"`)
+	}
+
+	if strings.Contains(jsonRepresentation, "Requesting new cluster for organization 'giantswarm'") == true ||
+		strings.Contains(jsonRepresentation, "Adding node pool") == true ||
+		strings.Contains(jsonRepresentation, "Adding a default node pool") == true {
+		t.Errorf("Expected no additional output for json output, got '%s'", jsonRepresentation)
+	}
+}
+
+// Test_collectArguments tests the hack for ensuring empty
+// flags.OutputFormat when its set to "table"
+func Test_collectArguments(t *testing.T) {
+	// set flags.OutputFormat to "table"
+	flags.OutputFormat = "table"
+
+	argsEmptyOutputFormat := collectArguments(Command)
+
+	if argsEmptyOutputFormat.OutputFormat != "" {
+		t.Errorf("Expected OutputFormat argument to be empty. Received '%s'", argsEmptyOutputFormat.OutputFormat)
+	}
+
+	// Check verbose flag false for flags.OutputFormat == "json" && flags.Verbose == true
+	flags.OutputFormat = "json"
+	flags.Verbose = true
+
+	argsVerboseFalse := collectArguments(Command)
+
+	if argsVerboseFalse.Verbose == true {
+		t.Errorf("Expected Verbose argument to be false. Got '%t'", argsVerboseFalse.Verbose)
 	}
 }

--- a/commands/create/cluster/v4.go
+++ b/commands/create/cluster/v4.go
@@ -14,6 +14,7 @@ import (
 	"github.com/giantswarm/gsctl/client"
 	"github.com/giantswarm/gsctl/commands/errors"
 	"github.com/giantswarm/gsctl/commands/types"
+	"github.com/giantswarm/gsctl/formatting"
 )
 
 // updateDefinitionFromFlagsV4 extend/overwrites a clusterDefinition based on the
@@ -104,7 +105,9 @@ func addClusterV4(def *types.ClusterDefinitionV4, args Arguments, clientWrapper 
 		fmt.Println()
 	}
 
-	fmt.Printf("Requesting new cluster for organization '%s'\n", color.CyanString(def.Owner))
+	if args.OutputFormat != formatting.OutputFormatJSON {
+		fmt.Printf("Requesting new cluster for organization '%s'\n", color.CyanString(def.Owner))
+	}
 
 	// perform API call
 	response, err := clientWrapper.CreateClusterV4(addClusterBody, auxParams)

--- a/commands/create/cluster/v5.go
+++ b/commands/create/cluster/v5.go
@@ -10,6 +10,7 @@ import (
 	"github.com/giantswarm/gsctl/client"
 	"github.com/giantswarm/gsctl/commands/errors"
 	"github.com/giantswarm/gsctl/commands/types"
+	"github.com/giantswarm/gsctl/formatting"
 )
 
 type definitionFromFlagsV5 struct {
@@ -130,7 +131,9 @@ func addClusterV5(def *types.ClusterDefinitionV5, args Arguments, clientWrapper 
 
 	clusterRequestBody := createAddClusterBodyV5(def)
 
-	fmt.Printf("Requesting new cluster for organization '%s'\n", color.CyanString(def.Owner))
+	if args.OutputFormat != formatting.OutputFormatJSON {
+		fmt.Printf("Requesting new cluster for organization '%s'\n", color.CyanString(def.Owner))
+	}
 
 	response, err := clientWrapper.CreateClusterV5(clusterRequestBody, auxParams)
 	if err != nil {
@@ -144,7 +147,9 @@ func addClusterV5(def *types.ClusterDefinitionV5, args Arguments, clientWrapper 
 		for i, np := range def.NodePools {
 			nodePoolRequestBody := createAddNodePoolBody(np)
 
-			fmt.Printf("Adding node pool %d\n", i+1)
+			if args.OutputFormat != formatting.OutputFormatJSON {
+				fmt.Printf("Adding node pool %d\n", i+1)
+			}
 
 			npResponse, err := clientWrapper.CreateNodePool(response.Payload.ID, nodePoolRequestBody, auxParams)
 			if err != nil {
@@ -155,7 +160,9 @@ func addClusterV5(def *types.ClusterDefinitionV5, args Arguments, clientWrapper 
 			}
 		}
 	} else if args.CreateDefaultNodePool {
-		fmt.Println("Adding a default node pool")
+		if args.OutputFormat != formatting.OutputFormatJSON {
+			fmt.Println("Adding a default node pool")
+		}
 
 		nodePoolRequestBody := &models.V5AddNodePoolRequest{}
 		npResponse, err := clientWrapper.CreateNodePool(response.Payload.ID, nodePoolRequestBody, auxParams)

--- a/commands/create/kubeconfig/command_test.go
+++ b/commands/create/kubeconfig/command_test.go
@@ -313,3 +313,65 @@ func Test_CreateKubeconfigNoConnection(t *testing.T) {
 	}
 
 }
+
+func Test_CreateKubeconfigJSONOutput(t *testing.T) {
+	mockServer := makeMockServer()
+	defer mockServer.Close()
+
+	// temporary config
+	fs := afero.NewMemMapFs()
+	_, err := testutils.TempConfig(fs, "")
+	if err != nil {
+		t.Error(err)
+	}
+
+	args := Arguments{
+		apiEndpoint:     mockServer.URL,
+		authToken:       "auth-token",
+		clusterNameOrID: "Name of the cluster",
+		contextName:     "giantswarm-test-cluster-id",
+		fileSystem:      fs,
+		outputFormat:    "json",
+	}
+
+	err = verifyCreateKubeconfigPreconditions(args, []string{})
+	if err != nil {
+		t.Error(err)
+	}
+
+	result, err := createKubeconfig(context.Background(), args)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// check result object contents
+	if len(result.selfContainedYAMLBytes) == 0 {
+		t.Error("Expected non-empty result.selfContainedYAMLBytes, got empty slice")
+	}
+
+	print := printJSONOutput
+
+	jsonRepresentation := testutils.CaptureOutput(func() {
+		// output
+		print(result, err)
+	})
+
+	// t.Error(jsonRepresentation)
+
+	if !strings.Contains(jsonRepresentation, `"result": "ok"`) {
+		t.Error("JSON representation doesn't contain the expected result: ok key value pair")
+	}
+
+	if !strings.Contains(jsonRepresentation, "current-context: giantswarm-test-cluster-id") {
+		t.Error("Kubeconfig doesn't contain the expected current-context value")
+	}
+	if !strings.Contains(jsonRepresentation, "client-certificate-data:") {
+		t.Error("Kubeconfig doesn't contain the key client-certificate-data")
+	}
+	if !strings.Contains(jsonRepresentation, "client-key-data:") {
+		t.Error("Kubeconfig doesn't contain the key client-key-data")
+	}
+	if !strings.Contains(jsonRepresentation, "certificate-authority-data:") {
+		t.Error("Kubeconfig doesn't contain the key certificate-authority-data")
+	}
+}

--- a/commands/delete/cluster/command.go
+++ b/commands/delete/cluster/command.go
@@ -2,12 +2,14 @@
 package cluster
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 
 	"github.com/fatih/color"
 	"github.com/giantswarm/gscliauth/config"
 	"github.com/giantswarm/gsctl/clustercache"
+	"github.com/giantswarm/gsctl/formatting"
 	"github.com/giantswarm/microerror"
 	"github.com/spf13/cobra"
 
@@ -36,6 +38,18 @@ type Arguments struct {
 	userProvidedToken string
 	// verbosity
 	verbose bool
+	// outputFormat
+	outputFormat string
+}
+
+// JSONOutput contains the fields included in JSON output of the delete cluster command when called with json output flag
+type JSONOutput struct {
+	// Result of the command. should be 'deletion scheduled'
+	Result string `json:"result"`
+	// ID of the cluster
+	ID string `json:"id"`
+	// Error which occured
+	Error error `json:"error,omitempty"`
 }
 
 func collectArguments(positionalArgs []string) Arguments {
@@ -48,6 +62,13 @@ func collectArguments(positionalArgs []string) Arguments {
 		clusterNameOrID = positionalArgs[0]
 	}
 
+	// hack..
+	// cobra sets defaults from other commands to the OutputFormat flag
+	// but we don't have "table" here, so if it's "table", set it to empty string
+	if flags.OutputFormat == "table" {
+		flags.OutputFormat = ""
+	}
+
 	return Arguments{
 		apiEndpoint:       endpoint,
 		clusterNameOrID:   clusterNameOrID,
@@ -57,6 +78,7 @@ func collectArguments(positionalArgs []string) Arguments {
 		token:             token,
 		userProvidedToken: flags.Token,
 		verbose:           flags.Verbose,
+		outputFormat:      flags.OutputFormat,
 	}
 }
 
@@ -85,6 +107,7 @@ Example:
 func init() {
 	Command.Flags().StringVarP(&flags.ClusterID, "cluster", "c", "", "Name or ID of the cluster to delete")
 	Command.Flags().BoolVarP(&flags.Force, "force", "", false, "If set, no interactive confirmation will be required (risky!).")
+	Command.Flags().StringVarP(&flags.OutputFormat, "output", "", "", fmt.Sprintf("Output format. Specifying '%s' will change output to be JSON formatted. It also disables any confirmations.", formatting.OutputFormatJSON))
 
 	Command.Flags().MarkDeprecated("cluster", "You no longer need to pass the cluster ID with -c/--cluster. Use --help for details.")
 }
@@ -142,12 +165,26 @@ func validatePreconditions(args Arguments) error {
 	if config.Config.Token == "" && args.token == "" {
 		return microerror.Mask(errors.NotLoggedInError)
 	}
+	if args.outputFormat != "" && args.outputFormat != formatting.OutputFormatJSON {
+		return microerror.Maskf(errors.OutputFormatInvalidError, fmt.Sprintf("Output format '%s' is invalid for gsctl delete cluster. Valid options: '%s'", args.outputFormat, formatting.OutputFormatJSON))
+	}
 	return nil
 }
 
 // interprets arguments/flags, eventually submits delete request
 func printResult(cmd *cobra.Command, args []string) {
+	clusterID := arguments.legacyClusterID
+	if arguments.clusterNameOrID != "" {
+		clusterID = arguments.clusterNameOrID
+	}
+
 	deleted, err := deleteCluster(arguments)
+
+	if arguments.outputFormat == formatting.OutputFormatJSON {
+		printJSONOutput(deleted, clusterID, err)
+		return
+	}
+
 	if err != nil {
 		client.HandleErrors(err)
 		errors.HandleCommonErrors(err)
@@ -172,15 +209,35 @@ func printResult(cmd *cobra.Command, args []string) {
 
 	// non-error output
 	if deleted {
-		clusterID := arguments.legacyClusterID
-		if arguments.clusterNameOrID != "" {
-			clusterID = arguments.clusterNameOrID
-		}
 		fmt.Println(color.GreenString("The cluster '%s' will be deleted as soon as all workloads are terminated.", clusterID))
 	} else {
 		if arguments.verbose {
 			fmt.Println(color.GreenString("Aborted."))
 		}
+	}
+}
+
+func printJSONOutput(deleted bool, clusterID string, creationErr error) {
+	var outputBytes []byte
+	var err error
+	var jsonResult JSONOutput
+
+	// handle errors
+	if creationErr != nil {
+		jsonResult = JSONOutput{Result: "error", Error: creationErr}
+	} else {
+		jsonResult = JSONOutput{Result: "deletion scheduled", ID: clusterID}
+	}
+
+	outputBytes, err = json.MarshalIndent(jsonResult, formatting.OutputJSONPrefix, formatting.OutputJSONIndent)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	fmt.Println(string(outputBytes))
+	if creationErr != nil {
+		os.Exit(1)
 	}
 }
 
@@ -205,8 +262,13 @@ func deleteCluster(args Arguments) (bool, error) {
 		}
 	}
 
-	// confirmation
-	if !args.force {
+	requireConfirmation := true
+
+	if args.force || args.outputFormat == formatting.OutputFormatJSON {
+		requireConfirmation = false
+	}
+
+	if requireConfirmation {
 		confirmed := confirm.AskStrict(
 			fmt.Sprintf("Do you really want to delete cluster '%s'? Please type '%s' to confirm", args.clusterNameOrID, args.clusterNameOrID),
 			args.clusterNameOrID,

--- a/commands/delete/cluster/command_test.go
+++ b/commands/delete/cluster/command_test.go
@@ -97,6 +97,15 @@ func TestDeleteClusterFailures(t *testing.T) {
 			},
 			errorMatcher: errors.IsClusterNameOrIDMissingError,
 		},
+		{
+			arguments: Arguments{
+				apiEndpoint:     "https://mock-url",
+				token:           "some token",
+				clusterNameOrID: "somecluster",
+				outputFormat:    "not-json",
+			},
+			errorMatcher: errors.IsOutputFormatInvalid,
+		},
 	}
 
 	fs := afero.NewMemMapFs()

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/fatih/color v1.9.0
 	github.com/giantswarm/apiextensions v0.0.0-20191213075442-71155aa0f5b7
 	github.com/giantswarm/columnize v2.0.3-0.20190718092621-cc99d98ffb29+incompatible
-	github.com/giantswarm/gscliauth v0.2.1
+	github.com/giantswarm/gscliauth v0.2.2
 	github.com/giantswarm/gsclientgen/v2 v2.0.7
 	github.com/giantswarm/k8sclient v0.0.0-20191213144452-f75fead2ae06
 	github.com/giantswarm/kubeconfig v0.0.0-20191209121754-c5784ae65a49

--- a/go.sum
+++ b/go.sum
@@ -97,8 +97,8 @@ github.com/giantswarm/apiextensions v0.0.0-20191213075442-71155aa0f5b7 h1:IgncMK
 github.com/giantswarm/apiextensions v0.0.0-20191213075442-71155aa0f5b7/go.mod h1:zHLSgCszRMdZUzwmfOibzcyfRC89ygwAQlpXcukgZuc=
 github.com/giantswarm/columnize v2.0.3-0.20190718092621-cc99d98ffb29+incompatible h1:PVeLghTCfbUCfYE8h+W2L8zDrMO+mxLvEWyYEKCL2HA=
 github.com/giantswarm/columnize v2.0.3-0.20190718092621-cc99d98ffb29+incompatible/go.mod h1:V/9Aa/R3o321yAbarEACmGhTg0SiPge6nFDtIH7CTvE=
-github.com/giantswarm/gscliauth v0.2.1 h1:DPO3dido3306/mgPs9DMz5V6IP3rXNc/s5mVh7YZ5yw=
-github.com/giantswarm/gscliauth v0.2.1/go.mod h1:Ys1puKDjd31rt6VDUwbJg8G3RkoLNLwisOwHxTjyKIc=
+github.com/giantswarm/gscliauth v0.2.2 h1:jbEvecocO+yGsR793JbEdTx7+A7pgCTDOSZrHVV3LmI=
+github.com/giantswarm/gscliauth v0.2.2/go.mod h1:Ys1puKDjd31rt6VDUwbJg8G3RkoLNLwisOwHxTjyKIc=
 github.com/giantswarm/gsclientgen/v2 v2.0.7 h1:fvuOOYFOI7Pn89B5/j1WXIg9PylL1ia8nsyYE0ktuws=
 github.com/giantswarm/gsclientgen/v2 v2.0.7/go.mod h1:ZADsWfynt29F7HV1AeKfZCdMxAPw8O5hHSSY+Z6Hx3U=
 github.com/giantswarm/k8sclient v0.0.0-20191213144452-f75fead2ae06 h1:ARogDNpItRylPLIYWQqHLne7Cv1PnHahcGxx8/Zm+l4=


### PR DESCRIPTION
This PR adds handling of `--output=json` flag `create cluster`, `create kubeconfig` and `delete cluster` used by [`standup`](https://github.com/giantswarm/standup).

**`gsctl create cluster`**

Success output is `{"id":"asd91","result":"created"}`. Field `result` can be `created`, `created-with-errors`, `error`. 

In case of `"result": "error"` an extra `error` field will contain the marshalled error.

**`gsctl create kubeconfig`**

Success output is `{"result":"ok","kubeconfig":"apiVersion: v1\nkind: Config\nclusters:\n- name: ......."}`. Field `result` can be `ok`, `error`.

In case of `"result": "error"` an extra `error` field will contain the marshalled error.

**`gsctl delete cluster`**

Success output is  `{"result":"deletion scheduled","id":"jkp0v"}`. Field `result` can be `deletion scheduled`, `error`.

In case of `"result": "error"` an extra `error` field will contain the marshalled error.

**Summary of other changes:**

- Use updated `gscliauth` library to handle `--endpoint` and `--auth-token` flags without needing to `gsctl login` first (Changes from [this PR](https://github.com/giantswarm/gscliauth/pull/22))