### PR TITLE
add --silence-http-endpoint-warning flag

### DIFF
--- a/commands/root.go
+++ b/commands/root.go
@@ -59,7 +59,7 @@ func init() {
 	RootCommand.PersistentFlags().StringVarP(&flags.Token, "auth-token", "", tokenFromEnv, "Authorization token to use")
 	RootCommand.PersistentFlags().StringVarP(&flags.ConfigDirPath, "config-dir", "", config.DefaultConfigDirPath, "Configuration directory path to use")
 	RootCommand.PersistentFlags().BoolVarP(&flags.Verbose, "verbose", "v", false, "Print more information")
-	RootCommand.PersistentFlags().BoolVarP(&flags.SilenceHTTPEndpointWarning, "silence-http-endpoint-warning", "", false, "Dont't print warnings when deliberately using an insecure http endpoint")
+	RootCommand.PersistentFlags().BoolVarP(&flags.SilenceHTTPEndpointWarning, "silence-http-endpoint-warning", "", false, "Dont't print warnings when deliberately using an insecure HTTP endpoint")
 	RootCommand.Flags().Bool("version", false, version.Command.Short)
 
 	// add subcommands
@@ -95,7 +95,7 @@ func initConfig(cmd *cobra.Command, args []string) error {
 	fs := afero.NewOsFs()
 
 	var configLogger io.Writer
-	if flags.SilenceHTTPEndpointWarning == true {
+	if flags.SilenceHTTPEndpointWarning {
 		configLogger = ioutil.Discard
 	} else {
 		configLogger = os.Stdout

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -77,6 +77,9 @@ var (
 	// Release sets a release to use, provided as a command line flag.
 	Release string
 
+	// SilenceHTTPEndpointWarning represents
+	SilenceHTTPEndpointWarning bool
+
 	// MasterHA enables or disabled master node high availability.
 	MasterHA bool
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/fatih/color v1.9.0
 	github.com/giantswarm/apiextensions v0.0.0-20191213075442-71155aa0f5b7
 	github.com/giantswarm/columnize v2.0.3-0.20190718092621-cc99d98ffb29+incompatible
-	github.com/giantswarm/gscliauth v0.2.3-0.20200904095311-f318b08b969c
+	github.com/giantswarm/gscliauth v0.2.3-0.20200904104131-700c031e40d2
 	github.com/giantswarm/gsclientgen/v2 v2.0.7
 	github.com/giantswarm/k8sclient v0.0.0-20191213144452-f75fead2ae06
 	github.com/giantswarm/kubeconfig v0.0.0-20191209121754-c5784ae65a49

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/fatih/color v1.9.0
 	github.com/giantswarm/apiextensions v0.0.0-20191213075442-71155aa0f5b7
 	github.com/giantswarm/columnize v2.0.3-0.20190718092621-cc99d98ffb29+incompatible
-	github.com/giantswarm/gscliauth v0.2.2
+	github.com/giantswarm/gscliauth v0.2.3-0.20200904095311-f318b08b969c
 	github.com/giantswarm/gsclientgen/v2 v2.0.7
 	github.com/giantswarm/k8sclient v0.0.0-20191213144452-f75fead2ae06
 	github.com/giantswarm/kubeconfig v0.0.0-20191209121754-c5784ae65a49

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/fatih/color v1.9.0
 	github.com/giantswarm/apiextensions v0.0.0-20191213075442-71155aa0f5b7
 	github.com/giantswarm/columnize v2.0.3-0.20190718092621-cc99d98ffb29+incompatible
-	github.com/giantswarm/gscliauth v0.2.3-0.20200904104131-700c031e40d2
+	github.com/giantswarm/gscliauth v0.2.3
 	github.com/giantswarm/gsclientgen/v2 v2.0.7
 	github.com/giantswarm/k8sclient v0.0.0-20191213144452-f75fead2ae06
 	github.com/giantswarm/kubeconfig v0.0.0-20191209121754-c5784ae65a49

--- a/go.sum
+++ b/go.sum
@@ -97,8 +97,8 @@ github.com/giantswarm/apiextensions v0.0.0-20191213075442-71155aa0f5b7 h1:IgncMK
 github.com/giantswarm/apiextensions v0.0.0-20191213075442-71155aa0f5b7/go.mod h1:zHLSgCszRMdZUzwmfOibzcyfRC89ygwAQlpXcukgZuc=
 github.com/giantswarm/columnize v2.0.3-0.20190718092621-cc99d98ffb29+incompatible h1:PVeLghTCfbUCfYE8h+W2L8zDrMO+mxLvEWyYEKCL2HA=
 github.com/giantswarm/columnize v2.0.3-0.20190718092621-cc99d98ffb29+incompatible/go.mod h1:V/9Aa/R3o321yAbarEACmGhTg0SiPge6nFDtIH7CTvE=
-github.com/giantswarm/gscliauth v0.2.3-0.20200904104131-700c031e40d2 h1:I7XzwhH0RJm3ov0XM0vrHan/B5+AOPCt05/4uWXTxW8=
-github.com/giantswarm/gscliauth v0.2.3-0.20200904104131-700c031e40d2/go.mod h1:Ys1puKDjd31rt6VDUwbJg8G3RkoLNLwisOwHxTjyKIc=
+github.com/giantswarm/gscliauth v0.2.3 h1:ptDvNh8OUf4FzWR5mPq8BX2iwliYj1aijsrI5N51pls=
+github.com/giantswarm/gscliauth v0.2.3/go.mod h1:Ys1puKDjd31rt6VDUwbJg8G3RkoLNLwisOwHxTjyKIc=
 github.com/giantswarm/gsclientgen/v2 v2.0.7 h1:fvuOOYFOI7Pn89B5/j1WXIg9PylL1ia8nsyYE0ktuws=
 github.com/giantswarm/gsclientgen/v2 v2.0.7/go.mod h1:ZADsWfynt29F7HV1AeKfZCdMxAPw8O5hHSSY+Z6Hx3U=
 github.com/giantswarm/k8sclient v0.0.0-20191213144452-f75fead2ae06 h1:ARogDNpItRylPLIYWQqHLne7Cv1PnHahcGxx8/Zm+l4=

--- a/go.sum
+++ b/go.sum
@@ -97,8 +97,8 @@ github.com/giantswarm/apiextensions v0.0.0-20191213075442-71155aa0f5b7 h1:IgncMK
 github.com/giantswarm/apiextensions v0.0.0-20191213075442-71155aa0f5b7/go.mod h1:zHLSgCszRMdZUzwmfOibzcyfRC89ygwAQlpXcukgZuc=
 github.com/giantswarm/columnize v2.0.3-0.20190718092621-cc99d98ffb29+incompatible h1:PVeLghTCfbUCfYE8h+W2L8zDrMO+mxLvEWyYEKCL2HA=
 github.com/giantswarm/columnize v2.0.3-0.20190718092621-cc99d98ffb29+incompatible/go.mod h1:V/9Aa/R3o321yAbarEACmGhTg0SiPge6nFDtIH7CTvE=
-github.com/giantswarm/gscliauth v0.2.3-0.20200904095311-f318b08b969c h1:SNIjU2rf7PQtf0cqSPtkqaJUYwhHMfHn7I5JfBUzxOI=
-github.com/giantswarm/gscliauth v0.2.3-0.20200904095311-f318b08b969c/go.mod h1:Ys1puKDjd31rt6VDUwbJg8G3RkoLNLwisOwHxTjyKIc=
+github.com/giantswarm/gscliauth v0.2.3-0.20200904104131-700c031e40d2 h1:I7XzwhH0RJm3ov0XM0vrHan/B5+AOPCt05/4uWXTxW8=
+github.com/giantswarm/gscliauth v0.2.3-0.20200904104131-700c031e40d2/go.mod h1:Ys1puKDjd31rt6VDUwbJg8G3RkoLNLwisOwHxTjyKIc=
 github.com/giantswarm/gsclientgen/v2 v2.0.7 h1:fvuOOYFOI7Pn89B5/j1WXIg9PylL1ia8nsyYE0ktuws=
 github.com/giantswarm/gsclientgen/v2 v2.0.7/go.mod h1:ZADsWfynt29F7HV1AeKfZCdMxAPw8O5hHSSY+Z6Hx3U=
 github.com/giantswarm/k8sclient v0.0.0-20191213144452-f75fead2ae06 h1:ARogDNpItRylPLIYWQqHLne7Cv1PnHahcGxx8/Zm+l4=

--- a/go.sum
+++ b/go.sum
@@ -97,8 +97,8 @@ github.com/giantswarm/apiextensions v0.0.0-20191213075442-71155aa0f5b7 h1:IgncMK
 github.com/giantswarm/apiextensions v0.0.0-20191213075442-71155aa0f5b7/go.mod h1:zHLSgCszRMdZUzwmfOibzcyfRC89ygwAQlpXcukgZuc=
 github.com/giantswarm/columnize v2.0.3-0.20190718092621-cc99d98ffb29+incompatible h1:PVeLghTCfbUCfYE8h+W2L8zDrMO+mxLvEWyYEKCL2HA=
 github.com/giantswarm/columnize v2.0.3-0.20190718092621-cc99d98ffb29+incompatible/go.mod h1:V/9Aa/R3o321yAbarEACmGhTg0SiPge6nFDtIH7CTvE=
-github.com/giantswarm/gscliauth v0.2.2 h1:jbEvecocO+yGsR793JbEdTx7+A7pgCTDOSZrHVV3LmI=
-github.com/giantswarm/gscliauth v0.2.2/go.mod h1:Ys1puKDjd31rt6VDUwbJg8G3RkoLNLwisOwHxTjyKIc=
+github.com/giantswarm/gscliauth v0.2.3-0.20200904095311-f318b08b969c h1:SNIjU2rf7PQtf0cqSPtkqaJUYwhHMfHn7I5JfBUzxOI=
+github.com/giantswarm/gscliauth v0.2.3-0.20200904095311-f318b08b969c/go.mod h1:Ys1puKDjd31rt6VDUwbJg8G3RkoLNLwisOwHxTjyKIc=
 github.com/giantswarm/gsclientgen/v2 v2.0.7 h1:fvuOOYFOI7Pn89B5/j1WXIg9PylL1ia8nsyYE0ktuws=
 github.com/giantswarm/gsclientgen/v2 v2.0.7/go.mod h1:ZADsWfynt29F7HV1AeKfZCdMxAPw8O5hHSSY+Z6Hx3U=
 github.com/giantswarm/k8sclient v0.0.0-20191213144452-f75fead2ae06 h1:ARogDNpItRylPLIYWQqHLne7Cv1PnHahcGxx8/Zm+l4=


### PR DESCRIPTION
Towards giantswarm/giantswarm#12975
Requires https://github.com/giantswarm/gscliauth/pull/25

This PR adds a `--silence-http-endpoint-warnings` flag which disables `Warning: endpoint URL uses an insecure protocol` messages printed when using gsctl with a http endpoint.