### PR TITLE
Use go 1.15.1 + clarify Release process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.14.2
+      - image: circleci/golang:1.15.1
 
     # We use 'large' because with 'medium' an 'medium#' we saw tests fail due to memory problems and too many threads.
     resource_class: large

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PROJECT=gsctl
 ORGANISATION=giantswarm
 BIN=$(PROJECT)
-GOVERSION := 1.14.2
+GOVERSION := 1.15.1
 BUILDDATE := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 COMMITHASH := $(shell git rev-parse HEAD)
 VERSION := $(shell (test -f VERSION && cat VERSION) || echo "")

--- a/docs/Release.md
+++ b/docs/Release.md
@@ -16,13 +16,19 @@ git tag -a ${VERSION} -m "Release version ${VERSION}"
 git push origin ${VERSION}
 ```
 
-Follow CircleCI's progress in https://circleci.com/gh/giantswarm/gsctl/.
+This will push your the new tag to the GitHub repository where it will show up as a tag without release.
+
+Follow CircleCI's progress in https://circleci.com/gh/giantswarm/gsctl/. Do not do anything until CI is finished.
+
+CircleCI should have created a new Release draft. Edit this draft.
 
 ## Edit the release draft and publish
 
 Open the [release draft](https://github.com/giantswarm/gsctl/releases/) on Github.
 
 Edit the description to inform about what has changed since the last release. Save and publish the release.
+
+The release draft will attach itself to the tag you've pushed in the first step.
 
 ## Prerequisites
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/giantswarm/gsctl
 
-go 1.14
+go 1.15
 
 require (
 	github.com/Jeffail/gabs v1.4.0


### PR DESCRIPTION
This PR updates gsctl to be compiled with go 1.15.1