### PR TITLE
Allow user to set a specific timeout for network operations

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -139,11 +139,15 @@ func NewWithConfig(endpointString, token string) (*Wrapper, error) {
 	ClientConfig := &Configuration{
 		AuthHeaderGetter: config.Config.AuthHeaderGetter(endpoint, token),
 		Endpoint:         endpoint,
-		Timeout:          20 * time.Second,
 		UserAgent:        config.UserAgent(),
 	}
 
 	return New(ClientConfig)
+}
+
+// WithTimeout adds a timeout setting to the client.
+func (w *Wrapper) WithTimeout(timeoutSeconds int8) {
+	w.conf.Timeout = time.Duration(timeoutSeconds) * time.Second
 }
 
 type roundTripperWithUserAgent struct {

--- a/client/client.go
+++ b/client/client.go
@@ -35,9 +35,6 @@ import (
 )
 
 var (
-	// DefaultTimeout is the standard request timeout applied if not specified.
-	DefaultTimeout = 10 * time.Second
-
 	randomStringCharset = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
 	requestIDHeader string

--- a/commands/login/giantswarm_theme.go
+++ b/commands/login/giantswarm_theme.go
@@ -66,7 +66,7 @@ func loginGiantSwarm(args Arguments) (loginResult, error) {
 		fmt.Println(color.WhiteString("Fetching installation details"))
 	}
 
-	installationInfo, err := getInstallationInfo(args.apiEndpoint, "giantswarm", result.token)
+	installationInfo, err := getInstallationInfo(args.apiEndpoint, "giantswarm", result.token, args.timeout)
 	if err != nil {
 		return result, microerror.Mask(err)
 	}

--- a/commands/login/sso.go
+++ b/commands/login/sso.go
@@ -36,7 +36,7 @@ func loginSSO(args Arguments) (loginResult, error) {
 	}
 
 	// Check if the access token works by fetching the installation's name.
-	installationInfo, err := getInstallationInfo(args.apiEndpoint, "Bearer", pkceResponse.AccessToken)
+	installationInfo, err := getInstallationInfo(args.apiEndpoint, "Bearer", pkceResponse.AccessToken, args.timeout)
 	if err != nil {
 		if args.verbose {
 			fmt.Println(color.WhiteString("Attempt to use new token against the API failed."))

--- a/commands/ping/command_test.go
+++ b/commands/ping/command_test.go
@@ -45,7 +45,7 @@ func Test_Ping(t *testing.T) {
 	}))
 	defer mockServer.Close()
 
-	duration, err := ping(mockServer.URL)
+	duration, err := ping(Arguments{apiEndpoint: mockServer.URL})
 	if err != nil {
 		t.Error("Unexpected error:", err)
 	}
@@ -60,14 +60,14 @@ func Test_Ping_InternalServerError(t *testing.T) {
 	}))
 	defer mockServer.Close()
 
-	_, err := ping(mockServer.URL)
+	_, err := ping(Arguments{apiEndpoint: mockServer.URL})
 	if err == nil {
 		t.Error("Expected error, got nil")
 	}
 }
 
 func Test_Ping_NonexistingEndpoint(t *testing.T) {
-	_, err := ping("http://notexisting")
+	_, err := ping(Arguments{apiEndpoint: "http://notexisting"})
 	if err == nil {
 		t.Error("Expected 'no such host' error, got <nil>")
 	}

--- a/commands/root.go
+++ b/commands/root.go
@@ -39,6 +39,9 @@ const (
         fi
     fi
 	`
+
+	// Default network timeout in seconds.
+	timeoutSecondsDefault = 20
 )
 
 // RootCommand is the main command of the CLI
@@ -60,6 +63,7 @@ func init() {
 	RootCommand.PersistentFlags().StringVarP(&flags.ConfigDirPath, "config-dir", "", config.DefaultConfigDirPath, "Configuration directory path to use")
 	RootCommand.PersistentFlags().BoolVarP(&flags.Verbose, "verbose", "v", false, "Print more information")
 	RootCommand.PersistentFlags().BoolVarP(&flags.SilenceHTTPEndpointWarning, "silence-http-endpoint-warning", "", false, "Dont't print warnings when deliberately using an insecure HTTP endpoint")
+	RootCommand.PersistentFlags().Int8VarP(&flags.TimeoutSeconds, "timeout", "", timeoutSecondsDefault, "Timeout for network requests, in seconds")
 	RootCommand.Flags().Bool("version", false, version.Command.Short)
 
 	// add subcommands

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -87,6 +87,9 @@ var (
 	// used to generate kubeconfig
 	TenantInternal bool
 
+	// TimeoutSeconds is the network timeout duration in seconds.
+	TimeoutSeconds int8
+
 	// Token represents the auth token passed as a flag.
 	Token string
 


### PR DESCRIPTION
This PR introduces a global flag `--timeout` which configures the timeout for network operations. This way users can either extend or shorten the time gsctl waits for a result.
