### PR TITLE
Validate if node pool is actually changed before trying to update it

### DIFF
--- a/commands/update/nodepool/command.go
+++ b/commands/update/nodepool/command.go
@@ -255,9 +255,10 @@ func handleError(err error) {
 	case errors.IsNodePoolIDMalformedError(err):
 		headline = "Bad format for Cluster name/ID or Node Pool ID argument"
 		subtext = "Please provide cluster name/ID and node pool ID separated by a slash. See --help for examples."
-
 	case errors.IsNoOpError(err):
 		headline = microerror.Pretty(err, false)
+	default:
+		headline = err.Error()
 	}
 
 	// print output

--- a/commands/update/nodepool/command_test.go
+++ b/commands/update/nodepool/command_test.go
@@ -345,6 +345,16 @@ func TestSuccess(t *testing.T) {
 				if r.Method == "PATCH" && r.URL.Path == "/v5/clusters/clusterid/nodepools/nodepoolid/" {
 					w.WriteHeader(http.StatusOK)
 					w.Write([]byte(tc.responseBody))
+				} else if r.Method == "GET" && r.URL.Path == "/v5/clusters/clusterid/nodepools/nodepoolid/" {
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte(`{
+						"id": "nodepoolid",
+						"name": "Some random name",
+						"scaling": {
+							"min": 999,
+							"max": 1000
+						}
+					}`))
 				} else if r.Method == "GET" && r.URL.Path == "/v4/clusters/" {
 					w.WriteHeader(http.StatusOK)
 					w.Write([]byte(`[
@@ -450,6 +460,16 @@ func TestExecuteWithError(t *testing.T) {
 				if r.Method == "PATCH" && r.URL.Path == "/v5/clusters/clusterid/nodepools/nodepoolid/" {
 					w.WriteHeader(tc.responseStatusCode)
 					w.Write([]byte(tc.responseBody))
+				} else if r.Method == "GET" && r.URL.Path == "/v5/clusters/clusterid/nodepools/nodepoolid/" {
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte(`{
+						"id": "nodepoolid",
+						"name": "Some random name",
+						"scaling": {
+							"min": 999,
+							"max": 1000
+						}
+					}`))
 				} else if r.Method == "GET" && r.URL.Path == "/v4/clusters/" {
 					w.WriteHeader(http.StatusOK)
 					w.Write([]byte(`[


### PR DESCRIPTION
This validates that the node pool is actually changed before trying to send an update request. If it isn't updated, it throws this error:

![image](https://user-images.githubusercontent.com/13508038/93475668-30f30700-f8f9-11ea-9e44-42f8e270193f.png)
