### PR TITLE
azure v5: add support for showing NP stats in the cluster details

### DIFF
--- a/commands/show/cluster/command_test.go
+++ b/commands/show/cluster/command_test.go
@@ -229,6 +229,124 @@ func TestShowAWSClusterV5(t *testing.T) {
 
 }
 
+func TestShowAzureClusterV5(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == "GET" {
+			switch uri := r.URL.Path; uri {
+			case "/v4/clusters/":
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`[
+					{
+						"id": "cluster-id",
+						"name": "Name of the cluster",
+						"owner": "acme"
+					}
+				]`))
+
+			case "/v5/clusters/cluster-id/":
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{
+					"id": "cluster-id",
+					"name": "AWS v5 cluster",
+					"api_endpoint": "https://api.foo.bar",
+					"create_date": "2019-07-09T12:00:00.000000Z",
+					"owner": "acmeorg",
+					"release_version": "13.0.0",
+					"credential_id": "",
+					"master_nodes": {
+						"availability_zones": ["1"],
+						"high_availability": false,
+						"num_ready": 1
+					}
+				}`))
+
+			case "/v5/clusters/cluster-id/nodepools/":
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`[
+					{
+						"id": "a7r",
+						"name": "Node pool name",
+						"availability_zones": [
+							"1"
+						],
+						"scaling": {
+							"min": 2,
+							"max": 5
+						},
+						"node_spec": {
+							"azure": {
+								"vm_size": "Standard_D4s_v3"
+							},
+							"volume_sizes_gb": {
+								"docker": 100,
+								"kubelet": 100
+							}
+						},
+						"status": {
+							"nodes": 2,
+							"nodes_ready": 2
+						}
+					}
+				]`))
+
+			case "/v4/clusters/cluster-id/":
+				w.WriteHeader(http.StatusNotFound)
+				w.Write([]byte(`{"code": "RESOURCE_NOT_FOUND", "message": "Cluster does not exist or is not accessible."}`))
+
+			default:
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte(`{"code": "INTERNAL_ERROR", "message": "We do this to notice any unexpected endpoint being called."}`))
+			}
+		}
+	}))
+	defer mockServer.Close()
+
+	// temp config
+	fs := afero.NewMemMapFs()
+	configDir := testutils.TempDir(fs)
+	config.Initialize(fs, configDir)
+
+	testArgs := Arguments{
+		apiEndpoint:     mockServer.URL,
+		clusterNameOrID: "cluster-id",
+		scheme:          "giantswarm",
+		authToken:       "my-token",
+		verbose:         true,
+	}
+
+	err := verifyPreconditions(testArgs, []string{testArgs.clusterNameOrID})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+
+	detailsV4, detailsV5, _, statusV4, credentials, err := getClusterDetails(testArgs)
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+
+	if detailsV4 != nil {
+		t.Errorf("Expected detailsV4 to be nil, got %#v", detailsV5)
+	}
+
+	if statusV4 != nil {
+		t.Errorf("Expected statusV4 to be nil, got %v", statusV4)
+	}
+
+	if credentials != nil {
+		t.Errorf("Expected credentials to be nil, got %v", credentials)
+	}
+
+	if detailsV5 == nil {
+		t.Fatal("Expected V5 cluster details, got nil")
+	}
+
+	if detailsV5.ID != testArgs.clusterNameOrID {
+		t.Errorf("Expected cluster ID '%s', got '%s'", testArgs.clusterNameOrID, detailsV5.ID)
+	}
+
+}
+
 // TestShowAWSClusterV5NoHAMasters tests fetching V5 cluster details for AWS,
 // without HA Masters support.
 func TestShowAWSClusterV5NoHAMasters(t *testing.T) {

--- a/commands/show/cluster/error.go
+++ b/commands/show/cluster/error.go
@@ -1,0 +1,21 @@
+package cluster
+
+import "github.com/giantswarm/microerror"
+
+var unknownProviderError = &microerror.Error{
+	Kind: "unknownProviderError",
+}
+
+// IsUnknownProvider asserts unknownProviderError.
+func IsUnknownProvider(err error) bool {
+	return microerror.Cause(err) == unknownProviderError
+}
+
+var providerInfoCorruptError = &microerror.Error{
+	Kind: "providerInfoCorruptError",
+}
+
+// IsProviderInfoCorrupt asserts providerInfoCorruptError.
+func IsProviderInfoCorrupt(err error) bool {
+	return microerror.Cause(err) == providerInfoCorruptError
+}


### PR DESCRIPTION
Looks like we missed this somehow.

This adds support for printing node pool stats (such as total memory in nodes, or total CPUs in nodes) when viewing cluster details for a cluster (`gsctl show cluster <id>`)