### PR TITLE
Actually throw the error if v5 cluster upgrade fails

### DIFF
--- a/commands/upgrade/cluster/command.go
+++ b/commands/upgrade/cluster/command.go
@@ -342,6 +342,9 @@ func upgradeCluster(args Arguments) (*upgradeClusterResult, error) {
 		}
 
 		_, err = clientWrapper.ModifyClusterV5(result.clusterID, reqBody, auxParams)
+		if err != nil {
+			return nil, microerror.Maskf(errors.CouldNotUpgradeClusterError, err.Error())
+		}
 	} else {
 		if args.Verbose {
 			fmt.Println(color.WhiteString("Submitting cluster modification request to v4 endpoint."))

--- a/pkg/releaseinfo/releaseinfo_test.go
+++ b/pkg/releaseinfo/releaseinfo_test.go
@@ -58,6 +58,7 @@ func TestReleaseInfo_GetReleaseData(t *testing.T) {
 			releaseVersion:            "1.0.1",
 			expectedK8sVersion:        "15.0.1",
 			expectedK8sVersionEOLDate: "2020-10-20",
+			expectedIsK8sVersionEOL:   true,
 		},
 		{
 			name: "case 1: getting the information of an existing release, with a k8s version without an EOL date",


### PR DESCRIPTION
As seen on https://gigantic.slack.com/archives/CNUDS3AMU/p1605091559107400

Currently, if the V5 cluster upgrade fails (or is blocked by an admission controller), the app doesn't actually throw an error. With this PR, it does.