### PR TITLE
Upgrade release

### DIFF
--- a/commands/errors/errors.go
+++ b/commands/errors/errors.go
@@ -27,6 +27,16 @@ func IsCouldNotCreateClientError(err error) bool {
 	return microerror.Cause(err) == CouldNotCreateClientError
 }
 
+// InvalidReleaseError means that the customer entered an invalid release.
+var InvalidReleaseError = &microerror.Error{
+	Kind: "InvalidReleaseError",
+}
+
+// IsInvalidReleaseError asserts InvalidReleaseError.
+func IsInvalidReleaseError(err error) bool {
+	return microerror.Cause(err) == InvalidReleaseError
+}
+
 // NotLoggedInError means that the user is currently not authenticated
 var NotLoggedInError = &microerror.Error{
 	Kind: "NotLoggedInError",

--- a/commands/upgrade/cluster/command.go
+++ b/commands/upgrade/cluster/command.go
@@ -285,10 +285,8 @@ func upgradeCluster(args Arguments) (*upgradeClusterResult, error) {
 
 	var targetVersion string
 	{
-		fmt.Printf("args.Release = %s, result.versionBefore = %s, releaseVersions = %v\n", args.Release, result.versionBefore, releaseVersions)
 		if args.Release == "" {
 			targetVersion = successorReleaseVersion(result.versionBefore, releaseVersions)
-			fmt.Printf("targetVersion = %s\n", targetVersion)
 			if targetVersion == "" {
 				return nil, microerror.Mask(errors.NoUpgradeAvailableError)
 			}

--- a/commands/upgrade/cluster/command.go
+++ b/commands/upgrade/cluster/command.go
@@ -116,7 +116,7 @@ func initFlags() {
 	Command.ResetFlags()
 
 	Command.Flags().BoolVarP(&flags.Force, "force", "", false, "If set, no interactive confirmation will be required (risky!).")
-	Command.Flags().StringVarP(&flags.Release, "release", "", "", "If set, the release the cluster should be upgraded to.")
+	Command.Flags().StringVarP(&flags.Release, "release", "", "", "The target release version for the upgrade. If no version is specified, the latest production version will be used.")
 }
 
 // Prints results of our pre-validation

--- a/commands/upgrade/cluster/command.go
+++ b/commands/upgrade/cluster/command.go
@@ -116,7 +116,7 @@ func initFlags() {
 	Command.ResetFlags()
 
 	Command.Flags().BoolVarP(&flags.Force, "force", "", false, "If set, no interactive confirmation will be required (risky!).")
-	Command.Flags().StringVarP(&flags.Release, "release", "", "", "The target release version for the upgrade. If no version is specified, the latest production version will be used.")
+	Command.Flags().StringVarP(&flags.Release, "release", "", "", "The target release version for the upgrade. If no version is specified, the first version following the running one is selected..")
 }
 
 // Prints results of our pre-validation

--- a/commands/upgrade/cluster/command.go
+++ b/commands/upgrade/cluster/command.go
@@ -306,7 +306,7 @@ func upgradeCluster(args Arguments) (*upgradeClusterResult, error) {
 
 	if targetRelease.Version == nil {
 		// Release was not found.
-		return nil, microerror.Maskf(errors.InvalidReleaseError, fmt.Sprintf("Release %s was not found", targetVersion))
+		return nil, microerror.Maskf(errors.InvalidReleaseError, fmt.Sprintf("Can't upgrade to non existing release %s", targetVersion))
 	}
 
 	// Show some details independent of confirmation

--- a/commands/upgrade/cluster/command_test.go
+++ b/commands/upgrade/cluster/command_test.go
@@ -183,6 +183,23 @@ func Test_collectArguments(t *testing.T) {
 			resultingArgs: Arguments{
 				ClusterNameOrID: "clusterid",
 				Force:           true,
+				Release:         "",
+			},
+		},
+		{
+			name:                "Test 2: Specify release",
+			positionalArguments: []string{"clusterid"},
+			commandExecution: func() {
+				initFlags()
+				Command.ParseFlags([]string{
+					"clusterid",
+					"--release=1.2.3",
+				})
+			},
+			resultingArgs: Arguments{
+				ClusterNameOrID: "clusterid",
+				Release:         "1.2.3",
+				Force:           false,
 			},
 		},
 	}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/14345#issuecomment-728850246

This PR adds support for specifying the desired version to upgrade to when upgrading a tenant cluster with `gsctl upgrade`.