### PR TITLE
Use new master nodes properties

### DIFF
--- a/commands/create/cluster/command.go
+++ b/commands/create/cluster/command.go
@@ -631,6 +631,7 @@ func addCluster(args Arguments) (*creationResult, error) {
 			releaseVersion: args.ReleaseVersion,
 			owner:          args.Owner,
 			isHAMaster:     args.MasterHA,
+			provider:       config.Config.Provider,
 		})
 
 		id, hasErrors, err := addClusterV5(result.DefinitionV5, args, clientWrapper, auxParams)

--- a/commands/create/cluster/command.go
+++ b/commands/create/cluster/command.go
@@ -683,7 +683,7 @@ func validateHAMasters(featureEnabled bool, args *Arguments, v5Definition *types
 
 	{
 		// HA master has been enabled by cluster definition.
-		hasHAMaster := v5Definition.MasterNodes != nil && v5Definition.MasterNodes.HighAvailability
+		hasHAMaster := v5Definition.MasterNodes != nil && v5Definition.MasterNodes.HighAvailability != nil && *v5Definition.MasterNodes.HighAvailability
 		// HA master has been enabled by command-line flag.
 		hasHAMasterFromFlag := args.MasterHA != nil && *args.MasterHA
 		if hasHAMaster || hasHAMasterFromFlag {

--- a/commands/create/cluster/command.go
+++ b/commands/create/cluster/command.go
@@ -491,17 +491,17 @@ func addCluster(args Arguments) (*creationResult, error) {
 	auxParams := clientWrapper.DefaultAuxiliaryParams()
 	auxParams.ActivityName = createClusterActivityName
 
+	if args.Verbose {
+		fmt.Println(color.WhiteString("Fetching installation information"))
+	}
+
+	info, err := clientWrapper.GetInfo(auxParams)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
 	// Ensure provider information is there.
 	if config.Config.Provider == "" {
-		if args.Verbose {
-			fmt.Println(color.WhiteString("Fetching installation information"))
-		}
-
-		info, err := clientWrapper.GetInfo(auxParams)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-
 		err = config.Config.SetProvider(info.Payload.General.Provider)
 		if err != nil {
 			return nil, microerror.Mask(err)
@@ -627,11 +627,12 @@ func addCluster(args Arguments) (*creationResult, error) {
 		}
 
 		updateDefinitionFromFlagsV5(result.DefinitionV5, definitionFromFlagsV5{
-			clusterName:    args.ClusterName,
-			releaseVersion: args.ReleaseVersion,
-			owner:          args.Owner,
-			isHAMaster:     args.MasterHA,
-			provider:       config.Config.Provider,
+			clusterName:     args.ClusterName,
+			releaseVersion:  args.ReleaseVersion,
+			owner:           args.Owner,
+			isHAMaster:      args.MasterHA,
+			provider:        config.Config.Provider,
+			maxSupportedAZs: *info.Payload.General.AvailabilityZones.Max,
 		})
 
 		id, hasErrors, err := addClusterV5(result.DefinitionV5, args, clientWrapper, auxParams)

--- a/commands/create/cluster/command_test.go
+++ b/commands/create/cluster/command_test.go
@@ -185,7 +185,7 @@ func Test_CreateClusterSuccessfully(t *testing.T) {
 				DefinitionV5: &types.ClusterDefinitionV5{
 					Owner: "acme",
 					MasterNodes: &types.MasterNodes{
-						HighAvailability: true,
+						HighAvailability: toBoolPtr(true),
 					},
 				},
 			},
@@ -288,7 +288,7 @@ func Test_CreateClusterSuccessfully(t *testing.T) {
 					Name:       "Cluster Name from Args",
 					Owner:      "acme",
 					MasterNodes: &types.MasterNodes{
-						HighAvailability: true,
+						HighAvailability: toBoolPtr(true),
 					},
 				},
 			},
@@ -360,7 +360,7 @@ func Test_CreateClusterSuccessfully(t *testing.T) {
 					Owner:          "acme",
 					ReleaseVersion: "11.5.0",
 					MasterNodes: &types.MasterNodes{
-						HighAvailability: true,
+						HighAvailability: toBoolPtr(true),
 					},
 					NodePools: []*types.NodePoolDefinition{
 						{
@@ -457,7 +457,7 @@ func Test_CreateClusterSuccessfully(t *testing.T) {
 					Name:       "Cluster Name from Args with Labels",
 					Owner:      "acme",
 					MasterNodes: &types.MasterNodes{
-						HighAvailability: true,
+						HighAvailability: toBoolPtr(true),
 					},
 					Labels: map[string]*string{"key": stringP("value"), "labelkey": stringP("labelvalue")},
 				},
@@ -481,7 +481,7 @@ func Test_CreateClusterSuccessfully(t *testing.T) {
 					Name:       "Cluster Name from Args with Labels",
 					Owner:      "acme",
 					MasterNodes: &types.MasterNodes{
-						HighAvailability: true,
+						HighAvailability: toBoolPtr(true),
 					},
 				},
 			},
@@ -505,7 +505,7 @@ func Test_CreateClusterSuccessfully(t *testing.T) {
 					Name:       "Cluster Name from Args with Labels",
 					Owner:      "acme",
 					MasterNodes: &types.MasterNodes{
-						HighAvailability: false,
+						HighAvailability: toBoolPtr(false),
 					},
 				},
 			},
@@ -931,7 +931,7 @@ func Test_validateHAMasters(t *testing.T) {
 			v5Definition: types.ClusterDefinitionV5{
 				Master: nil,
 				MasterNodes: &types.MasterNodes{
-					HighAvailability: true,
+					HighAvailability: toBoolPtr(true),
 				},
 			},
 			errorMatcher: IsHAMastersNotSupported,
@@ -948,7 +948,7 @@ func Test_validateHAMasters(t *testing.T) {
 			v5Definition: types.ClusterDefinitionV5{
 				Master: nil,
 				MasterNodes: &types.MasterNodes{
-					HighAvailability: true,
+					HighAvailability: toBoolPtr(true),
 				},
 			},
 			errorMatcher: nil,
@@ -967,7 +967,7 @@ func Test_validateHAMasters(t *testing.T) {
 					AvailabilityZone: "eu-something",
 				},
 				MasterNodes: &types.MasterNodes{
-					HighAvailability: true,
+					HighAvailability: toBoolPtr(true),
 				},
 			},
 			errorMatcher: IsMustProvideSingleMasterType,
@@ -986,7 +986,7 @@ func Test_validateHAMasters(t *testing.T) {
 					AvailabilityZone: "eu-something",
 				},
 				MasterNodes: &types.MasterNodes{
-					HighAvailability: true,
+					HighAvailability: toBoolPtr(true),
 				},
 			},
 			errorMatcher: IsMustProvideSingleMasterType,
@@ -1037,7 +1037,7 @@ func Test_validateHAMasters(t *testing.T) {
 			v5Definition: types.ClusterDefinitionV5{
 				Master: nil,
 				MasterNodes: &types.MasterNodes{
-					HighAvailability: false,
+					HighAvailability: toBoolPtr(false),
 				},
 			},
 			errorMatcher: nil,
@@ -1054,7 +1054,7 @@ func Test_validateHAMasters(t *testing.T) {
 			v5Definition: types.ClusterDefinitionV5{
 				Master: nil,
 				MasterNodes: &types.MasterNodes{
-					HighAvailability: false,
+					HighAvailability: toBoolPtr(false),
 				},
 			},
 			errorMatcher: nil,

--- a/commands/create/cluster/command_test.go
+++ b/commands/create/cluster/command_test.go
@@ -554,7 +554,11 @@ func Test_CreateClusterSuccessfully(t *testing.T) {
 					w.WriteHeader(http.StatusOK)
 					w.Write([]byte(`{
 					"general": {
-					  "provider": "aws"
+					  "provider": "aws",
+					  "availability_zones": {
+						  "default": 3,
+						  "max": 3
+					  }
 					},
 					"features": {
 					  "nodepools": {"release_version_minimum": "9.0.0"},
@@ -685,7 +689,11 @@ func Test_CreateClusterExecutionFailures(t *testing.T) {
 					w.WriteHeader(http.StatusOK)
 					w.Write([]byte(`{
 					"general": {
-					  "provider": "aws"
+					  "provider": "aws",
+					  "availability_zones": {
+						  "default": 3,
+						  "max": 3
+					  }
 					},
 					"features": {
 					  "nodepools": {"release_version_minimum": "9.0.0"}
@@ -1140,7 +1148,11 @@ func Test_jsonOutput(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(`{
 					"general": {
-					  "provider": "aws"
+					  "provider": "aws",
+					  "availability_zones": {
+						  "default": 3,
+						  "max": 3
+					  }
 					},
 					"features": {
 					  "nodepools": {"release_version_minimum": "9.0.0"},

--- a/commands/create/cluster/read_definition_test.go
+++ b/commands/create/cluster/read_definition_test.go
@@ -282,7 +282,7 @@ nodepools:
 			&types.ClusterDefinitionV5{
 				APIVersion:  "v5",
 				Owner:       "myorg",
-				MasterNodes: &types.MasterNodes{HighAvailability: true},
+				MasterNodes: &types.MasterNodes{HighAvailability: toBoolPtr(true)},
 				NodePools: []*types.NodePoolDefinition{
 					{
 						Name:              "General purpose",

--- a/commands/create/cluster/v5.go
+++ b/commands/create/cluster/v5.go
@@ -186,7 +186,7 @@ func addClusterV5(def *types.ClusterDefinitionV5, args Arguments, clientWrapper 
 
 		nodePoolRequestBody := &models.V5AddNodePoolRequest{}
 
-		if response.Payload.MasterNodes != nil && response.Payload.MasterNodes.AvailabilityZones == nil {
+		if response.Payload.MasterNodes != nil && len(response.Payload.MasterNodes.AvailabilityZones) < 1 {
 			nodePoolRequestBody.AvailabilityZones = &models.V5AddNodePoolRequestAvailabilityZones{
 				Number: -1,
 			}

--- a/commands/create/cluster/v5.go
+++ b/commands/create/cluster/v5.go
@@ -41,7 +41,7 @@ func updateDefinitionFromFlagsV5(def *types.ClusterDefinitionV5, flags definitio
 
 	if flags.isHAMaster != nil {
 		def.MasterNodes = &types.MasterNodes{
-			HighAvailability: *flags.isHAMaster,
+			HighAvailability: flags.isHAMaster,
 		}
 	}
 }
@@ -61,7 +61,21 @@ func createAddClusterBodyV5(def *types.ClusterDefinitionV5) *models.V5AddCluster
 
 	if def.MasterNodes != nil {
 		b.MasterNodes = &models.V5AddClusterRequestMasterNodes{
-			HighAvailability: &def.MasterNodes.HighAvailability,
+			HighAvailability:  def.MasterNodes.HighAvailability,
+			AvailabilityZones: def.MasterNodes.AvailabilityZones,
+		}
+
+		if def.MasterNodes.Azure != nil {
+			b.MasterNodes.Azure = &models.V5AddClusterRequestMasterNodesAzure{
+				AvailabilityZonesUnspecified: def.MasterNodes.Azure.AvailabilityZonesUnspecified,
+			}
+		}
+	} else {
+		b.MasterNodes = &models.V5AddClusterRequestMasterNodes{
+			// We default to unspecified AZs on azure to match happa's behaviour.
+			Azure: &models.V5AddClusterRequestMasterNodesAzure{
+				AvailabilityZonesUnspecified: true,
+			},
 		}
 	}
 

--- a/commands/types/types.go
+++ b/commands/types/types.go
@@ -79,7 +79,13 @@ type MasterDefinition struct {
 
 // MasterNodes defines an interface for configuring HA master nodes.
 type MasterNodes struct {
-	HighAvailability bool `yaml:"high_availability,omitempty"`
+	HighAvailability  *bool             `yaml:"high_availability,omitempty"`
+	AvailabilityZones []string          `yaml:"availability_zones,omitempty"`
+	Azure             *MasterNodesAzure `yaml:"azure,omitempty"`
+}
+
+type MasterNodesAzure struct {
+	AvailabilityZonesUnspecified bool `yaml:"availability_zones_unspecified"`
 }
 
 // AvailabilityZonesDefinition defines the availability zones for a node pool, as intgroduc ed in the V5 API.


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/14617

This PR makes use of the new master nodes fields in the cluster creation request:
* now on Azure, if there are no supported AZs in the installation, we set the new `AvailabilityZonesUnspecified` field to `true` - works great on `germanywestcentral` 👍🏻 
* if the `--create-default-nodepool` is set to `true`, and the cluster was created with no AZs, then the nodepool is also created with no AZs