### PR TITLE
Terminology change: "tenant cluster" to "workload cluster"

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,16 +61,17 @@ Whenever you want to switch to using this context:
 
 #### Cluster acccess via internal networks
 
-The Internal Kubernetes API allows you to talk to Kubernetes via the internal load balancer. That can be useful for peered networks.
+The internal Kubernetes API endpoint allows you to talk to Kubernetes via the internal load balancer. That can be useful for peered networks.
 
-In case you want to use the internal Kubernetes API, pass `--tenant-internal=true` to gsctl:
+In case you want to use the internal Kubernetes API, pass `--internal-api=true` to gsctl when creating a kubectl config entry:
+
 ```nohighlight
-$ gsctl create kubeconfig -c h8d0j
+gsctl create kubeconfig -c h8d0j --internal-api=true
 ```
 
-This will render a kubeconfig with the internal Kubernetes API server address (`internal-api`).
+This will render a kubeconfig with the internal Kubernetes API host name `internal-api`, resolving to the internal load balancer.
 
-* Internal API is available only on AWS installations.
+**Note**: The internal API endpoint is available only on AWS installations.
 
 ## Install
 

--- a/capabilities/capabilities.go
+++ b/capabilities/capabilities.go
@@ -3,7 +3,7 @@ package capabilities
 import "github.com/Masterminds/semver"
 
 var (
-	// Autoscaling is the capability to scale tenant clusters automatically.
+	// Autoscaling is the capability to scale workload clusters automatically.
 	Autoscaling = CapabilityDefinition{
 		Name: "Autoscaling",
 		RequiredReleasePerProvider: []ReleaseProviderPair{
@@ -14,7 +14,7 @@ var (
 		},
 	}
 
-	// AvailabilityZones is the capability to spread the worker nodes of a tenant
+	// AvailabilityZones is the capability to spread the worker nodes of a workload
 	// cluster over multiple availability zones.
 	AvailabilityZones = CapabilityDefinition{
 		Name: "AvailabilityZones",
@@ -26,7 +26,7 @@ var (
 		},
 	}
 
-	// NodePools is the capabilitiy to group tenant cluster workers logically.
+	// NodePools is the capabilitiy to group workload cluster workers logically.
 	// Details get completed with API data, if the feature is available.
 	NodePools = CapabilityDefinition{
 		Name: "NodePools",

--- a/capabilities/service.go
+++ b/capabilities/service.go
@@ -1,5 +1,5 @@
 // Package capabilities provides an service to find out which capabilities/functions
-// a tenant cluster on the given installation will provide.
+// a workload cluster on the given installation will provide.
 package capabilities
 
 import (
@@ -10,7 +10,7 @@ import (
 )
 
 // Service provides methods to get more details on the installation's
-// and tenant cluster's capabilities.
+// and workload cluster's capabilities.
 type Service struct {
 	// allCapabilities is a list of all the capabilities this package knows about.
 	allCapabilities []CapabilityDefinition

--- a/commands/create/kubeconfig/command.go
+++ b/commands/create/kubeconfig/command.go
@@ -84,7 +84,7 @@ const (
 	// windows download page
 	kubectlWindowsInstallURL = "https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG.md"
 
-	// tenant internal api prefix
+	// workload cluster internal api prefix
 	tenantInternalAPIPrefix = "internal-api"
 
 	urlDelimiter = "."
@@ -430,7 +430,7 @@ func printJSONOutput(result createKubeconfigResult, creationErr error) {
 	}
 }
 
-// getClusterDetails fetches cluster details to get the tenant cluster API endpoint,
+// getClusterDetails fetches cluster details to get the workload cluster API endpoint,
 // and attempts first v5 and then falls back to v4.
 func getClusterDetails(clientWrapper *client.Wrapper, clusterID string, auxParams *client.AuxiliaryParams, verbose bool) (string, error) {
 	// Try v5 first, then fall back to v4.

--- a/commands/types/types.go
+++ b/commands/types/types.go
@@ -44,7 +44,7 @@ type NodeDefinition struct {
 	Azure   AzureSpecificDefinition `yaml:"azure,omitempty"`
 }
 
-// ClusterDefinitionV4 defines a tenant cluster spec compatible with the v4 API.
+// ClusterDefinitionV4 defines a workload cluster spec compatible with the v4 API.
 type ClusterDefinitionV4 struct {
 	Name              string            `yaml:"name,omitempty"`
 	Owner             string            `yaml:"owner,omitempty"`
@@ -54,7 +54,7 @@ type ClusterDefinitionV4 struct {
 	Workers           []NodeDefinition  `yaml:"workers,omitempty"`
 }
 
-// ClusterDefinitionV5 defines a tenant cluster spec compatible with the v5 API.
+// ClusterDefinitionV5 defines a workload cluster spec compatible with the v5 API.
 type ClusterDefinitionV5 struct {
 	APIVersion     string                `yaml:"api_version,omitempty"`
 	Name           string                `yaml:"name,omitempty"`
@@ -66,7 +66,7 @@ type ClusterDefinitionV5 struct {
 	Labels         map[string]*string    `yaml:"labels,omitempty"`
 }
 
-// ScalingDefinition defines how a tenant cluster can scale.
+// ScalingDefinition defines how a workload cluster can scale.
 type ScalingDefinition struct {
 	Min int64 `yaml:"min,omitempty"`
 	Max int64 `yaml:"max,omitempty"`

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -21,6 +21,10 @@ var (
 	// ConfigDirPath represents the configuration path to use temporarily passed as a flag.
 	ConfigDirPath string
 
+	// InternalAPI is a flag that causes the 'create kubeconfig' and 'create keypair'
+	// command to use the workload-cluster-internal API endpoint instead of the public one.
+	InternalAPI bool
+
 	// Verbose represents the verbosity switch passed as a flag.
 	Verbose bool
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/14961

Most changes in this PR are only comments, however one command is affected:

- The `gsctl create kubeconfig` command offers the `--tenant-internal` flag, which is deprecated in favor of `--internal-api`.
