### PR TITLE
Update terminology, help, and URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 Call `gsctl` without any arguments to get an overview on commands. Some usage examples:
 
-#### Log in using your Giant Swarm credentials
+### Log in using your Giant Swarm credentials
 
 ```nohighlight
 $ gsctl login demo@example.com -e <giant-swarm-api-endpoint>
@@ -19,7 +19,7 @@ Password for demo@example.com at <giant-swarm-api-endpoint>:
 Successfully logged in!
 ```
 
-#### Show your clusters
+### Show your clusters
 
 ```nohighlight
 $ gsctl list clusters
@@ -28,7 +28,7 @@ ID     NAME                CREATED                 ORGANIZATION
 xl8t1  Staging Cluster     2017 May 11, 09:30 UTC  acme
 ```
 
-#### Create a cluster
+### Create a cluster
 
 ```nohighlight
 $ gsctl create cluster --owner acme --name "Test Cluster" --num-workers 5
@@ -36,9 +36,9 @@ Requesting new cluster for organization 'acme'
 New cluster with ID 'h8d0j' is launching.
 ```
 
-More in the [docs](https://docs.giantswarm.io/reference/gsctl/create-cluster/)
+More in the [docs](https://docs.giantswarm.io/ui-api/gsctl/create-cluster/)
 
-#### Configure `kubectl` to access a cluster
+### Configure `kubectl` to access a cluster
 
 ```nohighlight
 $ gsctl create kubeconfig -c h8d0j
@@ -61,7 +61,7 @@ Whenever you want to switch to using this context:
 
 Note: You can launch the context using Kubie by using `--kubie` switch
 
-#### Cluster acccess via internal networks
+### Cluster acccess via internal networks
 
 The internal Kubernetes API endpoint allows you to talk to Kubernetes via the internal load balancer. That can be useful for peered networks.
 
@@ -77,15 +77,15 @@ This will render a kubeconfig with the internal Kubernetes API host name `intern
 
 ## Install
 
-See the [`gsctl` reference docs](https://docs.giantswarm.io/reference/gsctl/#install)
+See the [`gsctl` reference docs](https://docs.giantswarm.io/ui-api/gsctl/#install)
 
 ## Configuration
 
-See the [`gsctl` reference docs](https://docs.giantswarm.io/reference/gsctl/#configuration)
+See the [`gsctl` reference docs](https://docs.giantswarm.io/ui-api/gsctl/#configuration)
 
 ## Changelog
 
-See [Releases](https://github.com/giantswarm/gsctl/releases)
+See [Releases](https://docs.giantswarm.io/changes/gsctl/)
 
 ## Development
 
@@ -98,4 +98,3 @@ We welcome contributions! Please read our additional information on [how to cont
 ## Publishing a Release
 
 See [docs/Release.md](https://github.com/giantswarm/gsctl/blob/master/docs/Release.md)
-

--- a/commands/list/releases/command.go
+++ b/commands/list/releases/command.go
@@ -31,10 +31,37 @@ var (
 	// Command performs the "list releases" function
 	Command = &cobra.Command{
 		Use:   "releases",
-		Short: "List releases to be used with clusters",
-		Long: `Prints detail on all available releases.
+		Short: "List workload cluster releases",
+		Long: `Prints all available workload cluster releases.
 
-A release is a software bundle that constitutes a cluster. It is identified by its semantic version number.`,
+A workload cluster release is a software bundle that constitutes a cluster. It is identified
+by its semantic version number. To learn more about the concept, please visit
+
+    https://docs.giantswarm.io/general/releases/
+
+Output
+------
+
+- VERSION: The version number identifying the workload cluster release.
+
+- STATUS: The release status. Possible values:
+  - active: The release can be used to create new clusters and the clusters can be upgraded
+    to this release.
+  - inactive: Clusters cannot be upgraded to this release. New clusters can only be created
+    with this release if there are still other clusters running using this release.
+
+- CREATED: Date and time of creation
+
+- KUBERNETES: The Kubernetes version provided. After the Kubernetes version is considered
+  "end of life", and indicator "EOL" is also shown.
+
+- CONTAINERLINUX: The Flatcar Container Linux version provided as an operating system in
+  Kubernetes nodes.
+
+- COREDNS: The CodeDNS version provided.
+
+- CALICO: The Project Calico version provided.
+`,
 		PreRun: printValidation,
 		Run:    printResult,
 	}

--- a/commands/show/cluster/command.go
+++ b/commands/show/cluster/command.go
@@ -424,7 +424,7 @@ func printV4Result(
 	output = append(output, color.YellowString("Created:")+"|"+formatDate(clusterDetails.CreateDate))
 	output = append(output, color.YellowString("Organization:")+"|"+clusterDetails.Owner)
 	output = append(output, color.YellowString("Kubernetes API endpoint:")+"|"+clusterDetails.APIEndpoint)
-	output = append(output, color.YellowString("Release version:")+"|"+stringOrPlaceholder(clusterDetails.ReleaseVersion))
+	output = append(output, color.YellowString("Workload cluster release:")+"|"+stringOrPlaceholder(clusterDetails.ReleaseVersion))
 
 	{
 		kubernetesVersion := formatKubernetesVersion(releaseInfo, clusterDetails.ReleaseVersion)

--- a/commands/show/release/command.go
+++ b/commands/show/release/command.go
@@ -24,11 +24,11 @@ var (
 	ShowReleaseCommand = &cobra.Command{
 		Use:   "release",
 		Short: "Show release details",
-		Long: `Display details of a release
+		Long: `Display details of a workload cluster release
 
 Examples:
 
-  gsctl show release 4.2.2
+  gsctl show release 14.0.0
 `,
 
 		// PreRun checks a few general things, like authentication.

--- a/commands/update/organization/setcredentials/command.go
+++ b/commands/update/organization/setcredentials/command.go
@@ -35,8 +35,8 @@ credentials are set for an organization, this currently cannot be undone.
 
 For details on how to prepare the account/subscription, consult the documentation at
 
-  - https://docs.giantswarm.io/guides/prepare-aws-account-for-tenant-clusters/ (AWS)
-  - https://docs.giantswarm.io/guides/prepare-azure-subscription-for-tenant-clusters/ (Azure)
+  - https://docs.giantswarm.io/getting-started/cloud-provider-accounts/aws/ (AWS)
+  - https://docs.giantswarm.io/getting-started/cloud-provider-accounts/azure/ (Azure)
 
 `,
 		Example: `

--- a/commands/upgrade/cluster/command.go
+++ b/commands/upgrade/cluster/command.go
@@ -26,7 +26,7 @@ const (
 	// upgradeClusterActivityName assigns API requests to named activities
 	upgradeClusterActivityName = "upgrade-cluster"
 
-	upgradeDocsURL = "https://docs.giantswarm.io/reference/cluster-upgrades/"
+	upgradeDocsURL = "https://docs.giantswarm.io/general/cluster-upgrades/"
 )
 
 var (

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Supplemental documentation on gsctl
 
-For user documentation, please see the [gsctl reference](https://docs.giantswarm.io/reference/gsctl/).
+For user documentation, please see the [gsctl reference](https://docs.giantswarm.io/ui-api/gsctl/).
 
 ## Contents
 

--- a/docs/Release.md
+++ b/docs/Release.md
@@ -8,7 +8,7 @@ All you have to do is create and push a new tag.
 
 In the command below, replace `<MAJOR.MINOR.PATCH>` with the actual version number you want to publish.
 
-```
+```nohighlight
 export VERSION=<MAJOR.MINOR.PATCH>
 git checkout master
 git pull
@@ -18,7 +18,7 @@ git push origin ${VERSION}
 
 This will push your the new tag to the GitHub repository where it will show up as a tag without release.
 
-Follow CircleCI's progress in https://circleci.com/gh/giantswarm/gsctl/. Do not do anything until CI is finished.
+Follow CircleCI's progress in [https://circleci.com/gh/giantswarm/gsctl/](https://circleci.com/gh/giantswarm/gsctl/). Do not do anything until CI is finished.
 
 CircleCI should have created a new Release draft. Edit this draft.
 
@@ -32,7 +32,7 @@ The release draft will attach itself to the tag you've pushed in the first step.
 
 ## Release docs
 
-The gsctl reference hosted at [https://docs.giantswarm.io/reference/gsctl/](https://docs.giantswarm.io/reference/gsctl/) contains the latest releasd gsctl version. ([Relevant code](https://github.com/giantswarm/docs/blob/master/Makefile#L49))
+The gsctl reference hosted at [https://docs.giantswarm.io/ui-api/gsctl/](https://docs.giantswarm.io/ui-api/gsctl/) contains the latest releasd gsctl version. ([Relevant code](https://github.com/giantswarm/docs/blob/master/Makefile#L49))
 
 To update this, read the [Deploying](https://github.com/giantswarm/docs#deploying) section in the giantswarm/docs Readme.
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/14339

This updates terminology around the term "release" (full: workload cluster release). In addition, it updates more help texts and URLs "while at it".

## Note

The command `gsctl show cluster` is changed. The line formerly labelled `Release version:` is now labelled `Workload cluster release:`.