### PR TITLE
Enable config dir setting via env variable

### DIFF
--- a/commands/info/command.go
+++ b/commands/info/command.go
@@ -261,6 +261,7 @@ func getEnvironmentVariables() map[string]string {
 	vars := []string{
 		"GSCTL_CAFILE",
 		"GSCTL_CAPATH",
+		"GSCTL_CONFIG_DIR",
 		"GSCTL_DISABLE_CMDLINE_TRACKING",
 		"GSCTL_DISABLE_COLORS",
 		"GSCTL_ENDPOINT",

--- a/commands/root.go
+++ b/commands/root.go
@@ -56,8 +56,14 @@ func init() {
 	// if it exists.
 	tokenFromEnv := os.Getenv("GSCTL_AUTH_TOKEN")
 
+	defaultConfigDir := config.DefaultConfigDirPath
+	configDirFromEnv := os.Getenv("GSCTL_CONFIG_DIR")
+	if (configDirFromEnv != "") {
+		defaultConfigDir = configDirFromEnv
+	}
+
 	RootCommand.PersistentFlags().StringVarP(&flags.Token, "auth-token", "", tokenFromEnv, "Authorization token to use")
-	RootCommand.PersistentFlags().StringVarP(&flags.ConfigDirPath, "config-dir", "", config.DefaultConfigDirPath, "Configuration directory path to use")
+	RootCommand.PersistentFlags().StringVarP(&flags.ConfigDirPath, "config-dir", "", defaultConfigDir, "Configuration directory path to use")
 	RootCommand.PersistentFlags().BoolVarP(&flags.Verbose, "verbose", "v", false, "Print more information")
 	RootCommand.PersistentFlags().BoolVarP(&flags.SilenceHTTPEndpointWarning, "silence-http-endpoint-warning", "", false, "Dont't print warnings when deliberately using an insecure HTTP endpoint")
 	RootCommand.Flags().Bool("version", false, version.Command.Short)


### PR DESCRIPTION
I prefer to manage project specific configuration close to the project data that relates to it, eg. `projects/foo/.aws` instead of `~/.aws`. For tools that support settings configuration via environment variables, tools like direnv make this very convenient and more importantly, an automatism, as they expose environment variables based on the shell directory that the user is in.
This PR allows `gsctl` to support this workflow better. 