### PR TITLE
Added deprecated notice to commands with direct replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 `gsctl` is the cross-platform command line utility to manage your Kubernetes clusters at Giant Swarm.
 
+> gsctl and the [REST API](https://docs.giantswarm.io/ui-api/rest-api/) are being phased out. We don't have an end-of-life date yet. However, we recommend to familiarize yourself with our [Management API](https://docs.giantswarm.io/ui-api/management-api/) and the [kubectl gs](https://docs.giantswarm.io/ui-api/kubectl-gs/) plugin as a future-proof replacement.
+
 ## Usage
 
 Call `gsctl` without any arguments to get an overview on commands. Some usage examples:

--- a/commands/create/cluster/command.go
+++ b/commands/create/cluster/command.go
@@ -202,6 +202,10 @@ suppress the creation of the default node pool by setting the flag
     --owner acme \
     --create-default-nodepool=false
 `,
+		Deprecated: `gsctl is being phased out in favour of our 'kubectl gs' plugin.
+We recommened you familiarize yourself with the 'kubectl gs template' command as a replacement for this.
+For more details see: https://docs.giantswarm.io/ui-api/kubectl-gs/template-cluster/
+`,
 		PreRun: printValidation,
 		Run:    printResult,
 	}

--- a/commands/create/nodepool/command.go
+++ b/commands/create/nodepool/command.go
@@ -131,6 +131,11 @@ Examples:
 
 `,
 
+		Deprecated: `gsctl is being phased out in favour of our 'kubectl gs' plugin.
+We recommened you familiarize yourself with the 'kubectl gs template' command as a replacement for this.
+For more details see: https://docs.giantswarm.io/ui-api/kubectl-gs/template-nodepool/
+`,
+
 		// PreRun checks a few general things, like authentication.
 		PreRun: printValidation,
 

--- a/commands/list/clusters/command.go
+++ b/commands/list/clusters/command.go
@@ -47,6 +47,10 @@ Examples:
 
   gsctl list clusters --sort org
 `,
+		Deprecated: `gsctl is being phased out in favour of our 'kubectl gs' plugin.
+We recommened you familiarize yourself with the 'kubectl gs get' command as a replacement for this.
+For more details see: https://docs.giantswarm.io/ui-api/kubectl-gs/get-clusters/
+`,
 		PreRun: printValidation,
 		Run:    printResult,
 	}


### PR DESCRIPTION
A deprecated notice is added to those commands that have an equivalent command in the 'kubectl gs' plugin.

A general notice of deprecation of `gsctl` has been added to the readme to match the message on the docs pages.
