### PR TITLE
add deprecated notice to list releases command

### DIFF
--- a/commands/list/releases/command.go
+++ b/commands/list/releases/command.go
@@ -62,6 +62,10 @@ Output
 
 - CALICO: The Project Calico version provided.
 `,
+		Deprecated: `gsctl is being phased out in favour of our 'kubectl gs' plugin.
+We recommened you familiarize yourself with the 'kubectl gs get releases' command as a replacement for this.
+For more details see: https://docs.giantswarm.io/ui-api/kubectl-gs/get-releases/
+`,
 		PreRun: printValidation,
 		Run:    printResult,
 	}


### PR DESCRIPTION
With the `kubectl gs get releases` now available we can mark the `gsctl list releases` as deprecated with a direct replacement available.