### PR TITLE
Add deprecation notices to `create keypair`, `create kubeconfig`, and `list nodepools` commands

### DIFF
--- a/commands/create/cluster/command.go
+++ b/commands/create/cluster/command.go
@@ -203,7 +203,7 @@ suppress the creation of the default node pool by setting the flag
     --create-default-nodepool=false
 `,
 		Deprecated: `gsctl is being phased out in favour of our 'kubectl gs' plugin.
-We recommened you familiarize yourself with the 'kubectl gs template' command as a replacement for this.
+We recommend you familiarize yourself with the 'kubectl gs template cluster' command as a replacement for this.
 For more details see: https://docs.giantswarm.io/ui-api/kubectl-gs/template-cluster/
 `,
 		PreRun: printValidation,

--- a/commands/create/keypair/command.go
+++ b/commands/create/keypair/command.go
@@ -28,9 +28,14 @@ import (
 var (
 	// Command performs the "create keypair" function,
 	Command = &cobra.Command{
-		Use:    "keypair",
-		Short:  "Create key pair",
-		Long:   `Creates a new key pair for a cluster`,
+		Use:   "keypair",
+		Short: "Create key pair",
+		Long: `Creates a new key pair for a cluster
+`,
+		Deprecated: `gsctl is being phased out in favour of our 'kubectl gs' plugin.
+We recommend you familiarize yourself with the 'kubectl gs login' command as a replacement for this.
+For more details see: https://docs.giantswarm.io/ui-api/kubectl-gs/login/
+`,
 		PreRun: printValidation,
 		Run:    printResult,
 	}

--- a/commands/create/kubeconfig/command.go
+++ b/commands/create/kubeconfig/command.go
@@ -63,6 +63,10 @@ Examples:
 
   gsctl create kubeconfig -c "Development cluster" --certificate-organizations system:masters
 `,
+		Deprecated: `gsctl is being phased out in favour of our 'kubectl gs' plugin.
+We recommend you familiarize yourself with the 'kubectl gs login' command as a replacement for this.
+For more details see: https://docs.giantswarm.io/ui-api/kubectl-gs/login/
+`,
 		PreRun: createKubeconfigPreRunOutput,
 		Run:    createKubeconfigRunOutput,
 	}

--- a/commands/create/nodepool/command.go
+++ b/commands/create/nodepool/command.go
@@ -132,7 +132,7 @@ Examples:
 `,
 
 		Deprecated: `gsctl is being phased out in favour of our 'kubectl gs' plugin.
-We recommened you familiarize yourself with the 'kubectl gs template' command as a replacement for this.
+We recommend you familiarize yourself with the 'kubectl gs template nodepool' command as a replacement for this.
 For more details see: https://docs.giantswarm.io/ui-api/kubectl-gs/template-nodepool/
 `,
 

--- a/commands/list/clusters/command.go
+++ b/commands/list/clusters/command.go
@@ -48,7 +48,7 @@ Examples:
   gsctl list clusters --sort org
 `,
 		Deprecated: `gsctl is being phased out in favour of our 'kubectl gs' plugin.
-We recommened you familiarize yourself with the 'kubectl gs get' command as a replacement for this.
+We recommend you familiarize yourself with the 'kubectl gs get clusters' command as a replacement for this.
 For more details see: https://docs.giantswarm.io/ui-api/kubectl-gs/get-clusters/
 `,
 		PreRun: printValidation,

--- a/commands/list/nodepools/command.go
+++ b/commands/list/nodepools/command.go
@@ -56,7 +56,12 @@ columns:
 
 To see all available details for a cluster, use 'gsctl show nodepool <cluster-id>/<nodepool-id>'.
 
-To list all clusters you have access to, use 'gsctl list clusters'.`,
+To list all clusters you have access to, use 'gsctl list clusters'.
+`,
+		Deprecated: `gsctl is being phased out in favour of our 'kubectl gs' plugin.
+We recommend you familiarize yourself with the 'kubectl gs get nodepools' command as a replacement for this.
+For more details see: https://docs.giantswarm.io/ui-api/kubectl-gs/get-nodepools/
+`,
 		PreRun: printValidation,
 		Run:    printResult,
 	}

--- a/commands/list/releases/command.go
+++ b/commands/list/releases/command.go
@@ -63,7 +63,7 @@ Output
 - CALICO: The Project Calico version provided.
 `,
 		Deprecated: `gsctl is being phased out in favour of our 'kubectl gs' plugin.
-We recommened you familiarize yourself with the 'kubectl gs get releases' command as a replacement for this.
+We recommend you familiarize yourself with the 'kubectl gs get releases' command as a replacement for this.
 For more details see: https://docs.giantswarm.io/ui-api/kubectl-gs/get-releases/
 `,
 		PreRun: printValidation,


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/17907.

This PR adds deprecation notices to the following commands:
`gsctl create keypair`
`gsctl create kubeconfig`
`gsctl list nodepools`

It also updates the existing deprecation notices by fixing a small typo and aligning the replacement `kubectl gs` commands suggested.