### PR TITLE
Avoid printing deprecation notices on KVM

### DIFF
--- a/commands/create/cluster/command.go
+++ b/commands/create/cluster/command.go
@@ -39,6 +39,8 @@ import (
 	"github.com/giantswarm/gsctl/commands/types"
 	"github.com/giantswarm/gsctl/flags"
 	"github.com/giantswarm/gsctl/formatting"
+	"github.com/giantswarm/gsctl/pkg/provider"
+	"github.com/giantswarm/gsctl/util"
 )
 
 // Arguments contains all possible input parameter needed
@@ -202,13 +204,11 @@ suppress the creation of the default node pool by setting the flag
     --owner acme \
     --create-default-nodepool=false
 `,
-		Deprecated: `gsctl is being phased out in favour of our 'kubectl gs' plugin.
-We recommend you familiarize yourself with the 'kubectl gs template cluster' command as a replacement for this.
-For more details see: https://docs.giantswarm.io/ui-api/kubectl-gs/template-cluster/
-`,
 		PreRun: printValidation,
 		Run:    printResult,
 	}
+
+	deprecated = util.Deprecated("create cluster", "template cluster", "https://docs.giantswarm.io/ui-api/kubectl-gs/template-cluster/")
 
 	// the client wrapper we will use in this command.
 	clientWrapper *client.Wrapper
@@ -236,6 +236,10 @@ func initFlags() {
 // If errors occur, error info is printed to STDOUT/STDERR
 // and the program will exit with non-zero exit codes.
 func printValidation(cmd *cobra.Command, positionalArgs []string) {
+	if config.Config.Provider != provider.KVM {
+		fmt.Println(deprecated)
+	}
+
 	arguments = collectArguments(cmd)
 
 	headline := ""

--- a/commands/create/cluster/command.go
+++ b/commands/create/cluster/command.go
@@ -39,7 +39,6 @@ import (
 	"github.com/giantswarm/gsctl/commands/types"
 	"github.com/giantswarm/gsctl/flags"
 	"github.com/giantswarm/gsctl/formatting"
-	"github.com/giantswarm/gsctl/pkg/provider"
 	"github.com/giantswarm/gsctl/util"
 )
 
@@ -208,8 +207,6 @@ suppress the creation of the default node pool by setting the flag
 		Run:    printResult,
 	}
 
-	deprecated = util.Deprecated("create cluster", "template cluster", "https://docs.giantswarm.io/ui-api/kubectl-gs/template-cluster/")
-
 	// the client wrapper we will use in this command.
 	clientWrapper *client.Wrapper
 
@@ -236,9 +233,7 @@ func initFlags() {
 // If errors occur, error info is printed to STDOUT/STDERR
 // and the program will exit with non-zero exit codes.
 func printValidation(cmd *cobra.Command, positionalArgs []string) {
-	if config.Config.Provider != provider.KVM {
-		fmt.Println(deprecated)
-	}
+	fmt.Print(util.GetDeprecatedNotice(config.Config.Provider, "create cluster", "template cluster", "https://docs.giantswarm.io/ui-api/kubectl-gs/template-cluster/"))
 
 	arguments = collectArguments(cmd)
 

--- a/commands/create/keypair/command.go
+++ b/commands/create/keypair/command.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/giantswarm/gsctl/clustercache"
 	"github.com/giantswarm/gsctl/confirm"
-	"github.com/giantswarm/gsctl/pkg/provider"
 
 	"github.com/giantswarm/microerror"
 	"github.com/spf13/afero"
@@ -36,8 +35,6 @@ var (
 		PreRun: printValidation,
 		Run:    printResult,
 	}
-
-	deprecated = util.Deprecated("create keypair", "login", "https://docs.giantswarm.io/ui-api/kubectl-gs/login/")
 
 	arguments Arguments
 )
@@ -130,9 +127,7 @@ func init() {
 }
 
 func printValidation(cmd *cobra.Command, cmdLineArgs []string) {
-	if config.Config.Provider != provider.KVM {
-		fmt.Println(deprecated)
-	}
+	fmt.Print(util.GetDeprecatedNotice(config.Config.Provider, "create keypair", "login", "https://docs.giantswarm.io/ui-api/kubectl-gs/login/"))
 
 	var argsErr error
 

--- a/commands/create/keypair/command.go
+++ b/commands/create/keypair/command.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/giantswarm/gsctl/clustercache"
 	"github.com/giantswarm/gsctl/confirm"
+	"github.com/giantswarm/gsctl/pkg/provider"
 
 	"github.com/giantswarm/microerror"
 	"github.com/spf13/afero"
@@ -32,13 +33,11 @@ var (
 		Short: "Create key pair",
 		Long: `Creates a new key pair for a cluster
 `,
-		Deprecated: `gsctl is being phased out in favour of our 'kubectl gs' plugin.
-We recommend you familiarize yourself with the 'kubectl gs login' command as a replacement for this.
-For more details see: https://docs.giantswarm.io/ui-api/kubectl-gs/login/
-`,
 		PreRun: printValidation,
 		Run:    printResult,
 	}
+
+	deprecated = util.Deprecated("create keypair", "login", "https://docs.giantswarm.io/ui-api/kubectl-gs/login/")
 
 	arguments Arguments
 )
@@ -131,6 +130,10 @@ func init() {
 }
 
 func printValidation(cmd *cobra.Command, cmdLineArgs []string) {
+	if config.Config.Provider != provider.KVM {
+		fmt.Println(deprecated)
+	}
+
 	var argsErr error
 
 	arguments, argsErr = collectArguments()

--- a/commands/create/kubeconfig/command.go
+++ b/commands/create/kubeconfig/command.go
@@ -18,6 +18,7 @@ import (
 	"github.com/giantswarm/gsclientgen/v2/client/key_pairs"
 	"github.com/giantswarm/gsclientgen/v2/models"
 	"github.com/giantswarm/gsctl/clustercache"
+	"github.com/giantswarm/gsctl/pkg/provider"
 	"github.com/giantswarm/k8sclient/v4/pkg/k8srestconfig"
 	kubeconfig "github.com/giantswarm/kubeconfig/v2"
 	"github.com/giantswarm/microerror"
@@ -63,13 +64,11 @@ Examples:
 
   gsctl create kubeconfig -c "Development cluster" --certificate-organizations system:masters
 `,
-		Deprecated: `gsctl is being phased out in favour of our 'kubectl gs' plugin.
-We recommend you familiarize yourself with the 'kubectl gs login' command as a replacement for this.
-For more details see: https://docs.giantswarm.io/ui-api/kubectl-gs/login/
-`,
 		PreRun: createKubeconfigPreRunOutput,
 		Run:    createKubeconfigRunOutput,
 	}
+
+	deprecated = util.Deprecated("create kubeconfig", "login", "https://docs.giantswarm.io/ui-api/kubectl-gs/login/")
 
 	// cmdKubeconfigSelfContained is the command line flag for output of a
 	// self-contained kubeconfig file
@@ -239,6 +238,10 @@ func init() {
 
 // createKubeconfigPreRunOutput shows our pre-check results
 func createKubeconfigPreRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
+	if config.Config.Provider != provider.KVM {
+		fmt.Println(deprecated)
+	}
+
 	var argsErr error
 
 	arguments, argsErr = collectArguments(cmd)

--- a/commands/create/kubeconfig/command.go
+++ b/commands/create/kubeconfig/command.go
@@ -18,7 +18,6 @@ import (
 	"github.com/giantswarm/gsclientgen/v2/client/key_pairs"
 	"github.com/giantswarm/gsclientgen/v2/models"
 	"github.com/giantswarm/gsctl/clustercache"
-	"github.com/giantswarm/gsctl/pkg/provider"
 	"github.com/giantswarm/k8sclient/v4/pkg/k8srestconfig"
 	kubeconfig "github.com/giantswarm/kubeconfig/v2"
 	"github.com/giantswarm/microerror"
@@ -67,8 +66,6 @@ Examples:
 		PreRun: createKubeconfigPreRunOutput,
 		Run:    createKubeconfigRunOutput,
 	}
-
-	deprecated = util.Deprecated("create kubeconfig", "login", "https://docs.giantswarm.io/ui-api/kubectl-gs/login/")
 
 	// cmdKubeconfigSelfContained is the command line flag for output of a
 	// self-contained kubeconfig file
@@ -238,9 +235,7 @@ func init() {
 
 // createKubeconfigPreRunOutput shows our pre-check results
 func createKubeconfigPreRunOutput(cmd *cobra.Command, cmdLineArgs []string) {
-	if config.Config.Provider != provider.KVM {
-		fmt.Println(deprecated)
-	}
+	fmt.Print(util.GetDeprecatedNotice(config.Config.Provider, "create kubeconfig", "login", "https://docs.giantswarm.io/ui-api/kubectl-gs/login/"))
 
 	var argsErr error
 

--- a/commands/create/nodepool/command.go
+++ b/commands/create/nodepool/command.go
@@ -138,8 +138,6 @@ Examples:
 		Run: printResult,
 	}
 
-	deprecated = util.Deprecated("create nodepool", "template nodepool", "https://docs.giantswarm.io/ui-api/kubectl-gs/template-nodepool/")
-
 	cmdAwsEc2InstanceType   string
 	cmdAvailabilityZonesNum int
 	cmdAvailabilityZones    []string
@@ -343,9 +341,7 @@ func verifyPreconditions(args Arguments) error {
 }
 
 func printValidation(cmd *cobra.Command, positionalArgs []string) {
-	if config.Config.Provider != provider.KVM {
-		fmt.Println(deprecated)
-	}
+	fmt.Print(util.GetDeprecatedNotice(config.Config.Provider, "create nodepool", "template nodepool", "https://docs.giantswarm.io/ui-api/kubectl-gs/template-nodepool/"))
 
 	var err error
 

--- a/commands/create/nodepool/command.go
+++ b/commands/create/nodepool/command.go
@@ -20,6 +20,7 @@ import (
 	"github.com/giantswarm/gsctl/commands/errors"
 	"github.com/giantswarm/gsctl/flags"
 	"github.com/giantswarm/gsctl/pkg/provider"
+	"github.com/giantswarm/gsctl/util"
 )
 
 var (
@@ -130,18 +131,14 @@ Examples:
   to the on-demand price of the instance.
 
 `,
-
-		Deprecated: `gsctl is being phased out in favour of our 'kubectl gs' plugin.
-We recommend you familiarize yourself with the 'kubectl gs template nodepool' command as a replacement for this.
-For more details see: https://docs.giantswarm.io/ui-api/kubectl-gs/template-nodepool/
-`,
-
 		// PreRun checks a few general things, like authentication.
 		PreRun: printValidation,
 
 		// Run calls the business function and prints results and errors.
 		Run: printResult,
 	}
+
+	deprecated = util.Deprecated("create nodepool", "template nodepool", "https://docs.giantswarm.io/ui-api/kubectl-gs/template-nodepool/")
 
 	cmdAwsEc2InstanceType   string
 	cmdAvailabilityZonesNum int
@@ -346,6 +343,10 @@ func verifyPreconditions(args Arguments) error {
 }
 
 func printValidation(cmd *cobra.Command, positionalArgs []string) {
+	if config.Config.Provider != provider.KVM {
+		fmt.Println(deprecated)
+	}
+
 	var err error
 
 	arguments, err = collectArguments(cmd, positionalArgs)

--- a/commands/list/clusters/command.go
+++ b/commands/list/clusters/command.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/giantswarm/gsctl/clustercache"
 	"github.com/giantswarm/gsctl/formatting"
+	"github.com/giantswarm/gsctl/pkg/provider"
 	"github.com/giantswarm/gsctl/pkg/sortable"
 	"github.com/giantswarm/gsctl/pkg/table"
 
@@ -47,13 +48,11 @@ Examples:
 
   gsctl list clusters --sort org
 `,
-		Deprecated: `gsctl is being phased out in favour of our 'kubectl gs' plugin.
-We recommend you familiarize yourself with the 'kubectl gs get clusters' command as a replacement for this.
-For more details see: https://docs.giantswarm.io/ui-api/kubectl-gs/get-clusters/
-`,
 		PreRun: printValidation,
 		Run:    printResult,
 	}
+
+	deprecated = util.Deprecated("list clusters", "get clusters", "https://docs.giantswarm.io/ui-api/kubectl-gs/get-clusters/")
 
 	cmdShowDeleted bool
 
@@ -125,6 +124,10 @@ func collectArguments() Arguments {
 }
 
 func printValidation(cmd *cobra.Command, cmdLineArgs []string) {
+	if config.Config.Provider != provider.KVM {
+		fmt.Println(deprecated)
+	}
+
 	arguments = collectArguments()
 	err := verifyListClusterPreconditions(arguments)
 

--- a/commands/list/clusters/command.go
+++ b/commands/list/clusters/command.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/giantswarm/gsctl/clustercache"
 	"github.com/giantswarm/gsctl/formatting"
-	"github.com/giantswarm/gsctl/pkg/provider"
 	"github.com/giantswarm/gsctl/pkg/sortable"
 	"github.com/giantswarm/gsctl/pkg/table"
 
@@ -51,8 +50,6 @@ Examples:
 		PreRun: printValidation,
 		Run:    printResult,
 	}
-
-	deprecated = util.Deprecated("list clusters", "get clusters", "https://docs.giantswarm.io/ui-api/kubectl-gs/get-clusters/")
 
 	cmdShowDeleted bool
 
@@ -124,9 +121,7 @@ func collectArguments() Arguments {
 }
 
 func printValidation(cmd *cobra.Command, cmdLineArgs []string) {
-	if config.Config.Provider != provider.KVM {
-		fmt.Println(deprecated)
-	}
+	fmt.Print(util.GetDeprecatedNotice(config.Config.Provider, "list clusters", "get clusters", "https://docs.giantswarm.io/ui-api/kubectl-gs/get-clusters/"))
 
 	arguments = collectArguments()
 	err := verifyListClusterPreconditions(arguments)

--- a/commands/list/nodepools/command.go
+++ b/commands/list/nodepools/command.go
@@ -17,7 +17,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/giantswarm/gsctl/clustercache"
-	"github.com/giantswarm/gsctl/pkg/provider"
 	"github.com/giantswarm/gsctl/util"
 
 	"github.com/giantswarm/gsctl/client"
@@ -63,7 +62,6 @@ To list all clusters you have access to, use 'gsctl list clusters'.
 		PreRun: printValidation,
 		Run:    printResult,
 	}
-	deprecated = util.Deprecated("list nodepools", "get nodepools", "https://docs.giantswarm.io/ui-api/kubectl-gs/get-nodepools/")
 
 	arguments Arguments
 )
@@ -120,9 +118,7 @@ func verifyPreconditions(args Arguments, positionalArgs []string) error {
 }
 
 func printValidation(cmd *cobra.Command, positionalArgs []string) {
-	if config.Config.Provider != provider.KVM {
-		fmt.Println(deprecated)
-	}
+	fmt.Print(util.GetDeprecatedNotice(config.Config.Provider, "list nodepools", "get nodepools", "https://docs.giantswarm.io/ui-api/kubectl-gs/get-nodepools/"))
 
 	arguments = collectArguments(positionalArgs)
 	err := verifyPreconditions(arguments, positionalArgs)

--- a/commands/list/nodepools/command.go
+++ b/commands/list/nodepools/command.go
@@ -17,6 +17,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/giantswarm/gsctl/clustercache"
+	"github.com/giantswarm/gsctl/pkg/provider"
+	"github.com/giantswarm/gsctl/util"
 
 	"github.com/giantswarm/gsctl/client"
 	"github.com/giantswarm/gsctl/commands/errors"
@@ -58,13 +60,10 @@ To see all available details for a cluster, use 'gsctl show nodepool <cluster-id
 
 To list all clusters you have access to, use 'gsctl list clusters'.
 `,
-		Deprecated: `gsctl is being phased out in favour of our 'kubectl gs' plugin.
-We recommend you familiarize yourself with the 'kubectl gs get nodepools' command as a replacement for this.
-For more details see: https://docs.giantswarm.io/ui-api/kubectl-gs/get-nodepools/
-`,
 		PreRun: printValidation,
 		Run:    printResult,
 	}
+	deprecated = util.Deprecated("list nodepools", "get nodepools", "https://docs.giantswarm.io/ui-api/kubectl-gs/get-nodepools/")
 
 	arguments Arguments
 )
@@ -121,6 +120,10 @@ func verifyPreconditions(args Arguments, positionalArgs []string) error {
 }
 
 func printValidation(cmd *cobra.Command, positionalArgs []string) {
+	if config.Config.Provider != provider.KVM {
+		fmt.Println(deprecated)
+	}
+
 	arguments = collectArguments(positionalArgs)
 	err := verifyPreconditions(arguments, positionalArgs)
 	if err != nil {

--- a/commands/list/releases/command.go
+++ b/commands/list/releases/command.go
@@ -13,6 +13,7 @@ import (
 	"github.com/giantswarm/columnize"
 	"github.com/giantswarm/gscliauth/config"
 	"github.com/giantswarm/gsclientgen/v2/models"
+	"github.com/giantswarm/gsctl/pkg/provider"
 	"github.com/giantswarm/gsctl/pkg/releaseinfo"
 	"github.com/giantswarm/microerror"
 	"github.com/spf13/cobra"
@@ -62,13 +63,11 @@ Output
 
 - CALICO: The Project Calico version provided.
 `,
-		Deprecated: `gsctl is being phased out in favour of our 'kubectl gs' plugin.
-We recommend you familiarize yourself with the 'kubectl gs get releases' command as a replacement for this.
-For more details see: https://docs.giantswarm.io/ui-api/kubectl-gs/get-releases/
-`,
 		PreRun: printValidation,
 		Run:    printResult,
 	}
+
+	deprecated = util.Deprecated("list releases", "get releases", "https://docs.giantswarm.io/ui-api/kubectl-gs/get-releases/")
 
 	arguments Arguments
 )
@@ -112,6 +111,10 @@ func collectArguments() Arguments {
 // printValidation does our pre-checks and shows errors, in case
 // something is missing.
 func printValidation(cmd *cobra.Command, extraArgs []string) {
+	if config.Config.Provider != provider.KVM {
+		fmt.Println(deprecated)
+	}
+
 	arguments = collectArguments()
 	err := listReleasesPreconditions(&arguments)
 

--- a/commands/list/releases/command.go
+++ b/commands/list/releases/command.go
@@ -13,7 +13,6 @@ import (
 	"github.com/giantswarm/columnize"
 	"github.com/giantswarm/gscliauth/config"
 	"github.com/giantswarm/gsclientgen/v2/models"
-	"github.com/giantswarm/gsctl/pkg/provider"
 	"github.com/giantswarm/gsctl/pkg/releaseinfo"
 	"github.com/giantswarm/microerror"
 	"github.com/spf13/cobra"
@@ -67,8 +66,6 @@ Output
 		Run:    printResult,
 	}
 
-	deprecated = util.Deprecated("list releases", "get releases", "https://docs.giantswarm.io/ui-api/kubectl-gs/get-releases/")
-
 	arguments Arguments
 )
 
@@ -111,9 +108,7 @@ func collectArguments() Arguments {
 // printValidation does our pre-checks and shows errors, in case
 // something is missing.
 func printValidation(cmd *cobra.Command, extraArgs []string) {
-	if config.Config.Provider != provider.KVM {
-		fmt.Println(deprecated)
-	}
+	fmt.Print(util.GetDeprecatedNotice(config.Config.Provider, "list releases", "get releases", "https://docs.giantswarm.io/ui-api/kubectl-gs/get-releases/"))
 
 	arguments = collectArguments()
 	err := listReleasesPreconditions(&arguments)

--- a/util/deprecated.go
+++ b/util/deprecated.go
@@ -1,0 +1,10 @@
+package util
+
+import "fmt"
+
+func Deprecated(gsctlCmd string, kubectlgsCmd string, docsURL string) string {
+	return fmt.Sprintf(`Command "%s" is deprecated, gsctl is being phased out in favor of our 'kubectl gs' plugin.
+We recommend you familiarize yourself with the "kubectl gs %s" command as a replacement for this.
+For more details see: %s
+`, gsctlCmd, kubectlgsCmd, docsURL)
+}

--- a/util/deprecated.go
+++ b/util/deprecated.go
@@ -1,10 +1,19 @@
 package util
 
-import "fmt"
+import (
+	"fmt"
 
-func Deprecated(gsctlCmd string, kubectlgsCmd string, docsURL string) string {
+	p "github.com/giantswarm/gsctl/pkg/provider"
+)
+
+func GetDeprecatedNotice(provider, gsctlCmd, kubectlgsCmd, docsURL string) string {
+	if provider == p.KVM {
+		return ""
+	}
+
 	return fmt.Sprintf(`Command "%s" is deprecated, gsctl is being phased out in favor of our 'kubectl gs' plugin.
 We recommend you familiarize yourself with the "kubectl gs %s" command as a replacement for this.
 For more details see: %s
+
 `, gsctlCmd, kubectlgsCmd, docsURL)
 }

--- a/util/deprecated.go
+++ b/util/deprecated.go
@@ -3,6 +3,7 @@ package util
 import (
 	"fmt"
 
+	"github.com/fatih/color"
 	p "github.com/giantswarm/gsctl/pkg/provider"
 )
 
@@ -11,9 +12,9 @@ func GetDeprecatedNotice(provider, gsctlCmd, kubectlgsCmd, docsURL string) strin
 		return ""
 	}
 
-	return fmt.Sprintf(`Command "%s" is deprecated, gsctl is being phased out in favor of our 'kubectl gs' plugin.
-We recommend you familiarize yourself with the "kubectl gs %s" command as a replacement for this.
+	return fmt.Sprintf(`Command %s is deprecated, gsctl is being phased out in favor of our kubectl-gs plugin.
+We recommend you familiarize yourself with the %s command as a replacement for this.
 For more details see: %s
 
-`, gsctlCmd, kubectlgsCmd, docsURL)
+`, color.YellowString(gsctlCmd), color.YellowString("kubectl gs "+kubectlgsCmd), docsURL)
 }

--- a/util/deprecated_test.go
+++ b/util/deprecated_test.go
@@ -1,0 +1,54 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/giantswarm/gsctl/pkg/provider"
+)
+
+func TestGetDeprecatedNotice(t *testing.T) {
+	var testCases = []struct {
+		provider     string
+		gsctlCmd     string
+		kubectlgsCmd string
+		docsURL      string
+		output       string
+	}{
+		{
+			provider:     provider.AWS,
+			gsctlCmd:     "list something",
+			kubectlgsCmd: "get something",
+			docsURL:      "https://docs.giantswarm.io/ui-api/kubectl-gs/get-something/",
+			output: `Command "list something" is deprecated, gsctl is being phased out in favor of our 'kubectl gs' plugin.
+We recommend you familiarize yourself with the "kubectl gs get something" command as a replacement for this.
+For more details see: https://docs.giantswarm.io/ui-api/kubectl-gs/get-something/
+
+`,
+		},
+		{
+			provider:     provider.Azure,
+			gsctlCmd:     "list something",
+			kubectlgsCmd: "get something",
+			docsURL:      "https://docs.giantswarm.io/ui-api/kubectl-gs/get-something/",
+			output: `Command "list something" is deprecated, gsctl is being phased out in favor of our 'kubectl gs' plugin.
+We recommend you familiarize yourself with the "kubectl gs get something" command as a replacement for this.
+For more details see: https://docs.giantswarm.io/ui-api/kubectl-gs/get-something/
+
+`,
+		},
+		{
+			provider:     provider.KVM,
+			gsctlCmd:     "list anotherthing",
+			kubectlgsCmd: "get anotherthing",
+			docsURL:      "https://docs.giantswarm.io/ui-api/kubectl-gs/get-anotherthing/",
+			output:       "",
+		},
+	}
+
+	for _, tc := range testCases {
+		notice := GetDeprecatedNotice(tc.provider, tc.gsctlCmd, tc.kubectlgsCmd, tc.docsURL)
+		if notice != tc.output {
+			t.Errorf("Got '%s', wanted '%s'", notice, tc.output)
+		}
+	}
+}

--- a/util/deprecated_test.go
+++ b/util/deprecated_test.go
@@ -19,8 +19,8 @@ func TestGetDeprecatedNotice(t *testing.T) {
 			gsctlCmd:     "list something",
 			kubectlgsCmd: "get something",
 			docsURL:      "https://docs.giantswarm.io/ui-api/kubectl-gs/get-something/",
-			output: `Command "list something" is deprecated, gsctl is being phased out in favor of our 'kubectl gs' plugin.
-We recommend you familiarize yourself with the "kubectl gs get something" command as a replacement for this.
+			output: `Command list something is deprecated, gsctl is being phased out in favor of our kubectl-gs plugin.
+We recommend you familiarize yourself with the kubectl gs get something command as a replacement for this.
 For more details see: https://docs.giantswarm.io/ui-api/kubectl-gs/get-something/
 
 `,
@@ -30,8 +30,8 @@ For more details see: https://docs.giantswarm.io/ui-api/kubectl-gs/get-something
 			gsctlCmd:     "list something",
 			kubectlgsCmd: "get something",
 			docsURL:      "https://docs.giantswarm.io/ui-api/kubectl-gs/get-something/",
-			output: `Command "list something" is deprecated, gsctl is being phased out in favor of our 'kubectl gs' plugin.
-We recommend you familiarize yourself with the "kubectl gs get something" command as a replacement for this.
+			output: `Command list something is deprecated, gsctl is being phased out in favor of our kubectl-gs plugin.
+We recommend you familiarize yourself with the kubectl gs get something command as a replacement for this.
 For more details see: https://docs.giantswarm.io/ui-api/kubectl-gs/get-something/
 
 `,


### PR DESCRIPTION
Closes https://github.com/giantswarm/roadmap/issues/765.

We currently display deprecation notices for `gsctl` commands that have a direct `kubectl gs` replacement. However, `kubectl gs` does not work for KVM installations, and so we should not show the deprecation notices there.

This PR adds a check for the installation's provider before displaying a command as deprecated. It also aligns the spelling of the word "favor" to use the American spelling.

An example of the deprecation notice shown:
<img width="849" alt="Screen Shot 2022-02-01 at 10 02 47" src="https://user-images.githubusercontent.com/62935115/151940098-bb3c2c12-8779-4495-9798-67fa68d5a947.png">


