### PR TITLE
Add deprecation notices to `show RESOURCE` commands

### DIFF
--- a/commands/show/cluster/command.go
+++ b/commands/show/cluster/command.go
@@ -89,6 +89,8 @@ func collectArguments() Arguments {
 }
 
 func printValidation(cmd *cobra.Command, cmdLineArgs []string) {
+	fmt.Print(util.GetDeprecatedNotice(config.Config.Provider, "show cluster", "get clusters", "https://docs.giantswarm.io/ui-api/kubectl-gs/get-clusters/"))
+
 	arguments = collectArguments()
 	err := verifyPreconditions(arguments, cmdLineArgs)
 

--- a/commands/show/nodepool/command.go
+++ b/commands/show/nodepool/command.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/giantswarm/gsctl/clustercache"
+	"github.com/giantswarm/gsctl/util"
 
 	"github.com/giantswarm/gsctl/client"
 	"github.com/giantswarm/gsctl/commands/errors"
@@ -105,6 +106,8 @@ func verifyPreconditions(args *Arguments) error {
 }
 
 func printValidation(cmd *cobra.Command, positionalArgs []string) {
+	fmt.Print(util.GetDeprecatedNotice(config.Config.Provider, "show nodepool", "get nodepools", "https://docs.giantswarm.io/ui-api/kubectl-gs/get-nodepools/"))
+
 	args, err := collectArguments(positionalArgs)
 	if err == nil {
 		err = verifyPreconditions(args)

--- a/commands/show/release/command.go
+++ b/commands/show/release/command.go
@@ -70,6 +70,8 @@ func collectArguments() Arguments {
 }
 
 func printValidation(cmd *cobra.Command, cmdLineArgs []string) {
+	fmt.Print(util.GetDeprecatedNotice(config.Config.Provider, "show release", "get releases", "https://docs.giantswarm.io/ui-api/kubectl-gs/get-releases/"))
+
 	arguments = collectArguments()
 	err := verifyShowReleasePreconditions(arguments, cmdLineArgs)
 

--- a/commands/show/release/command_test.go
+++ b/commands/show/release/command_test.go
@@ -3,6 +3,7 @@ package release
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/giantswarm/gscliauth/config"
@@ -209,7 +210,7 @@ selected_endpoint: ` + releasesMockServer.URL
 		ShowReleaseCommand.Execute()
 	})
 	//t.Logf("%q\n", output)
-	if output != expected {
+	if !strings.Contains(output, expected) {
 		t.Errorf("Command output did not match expectations:\n%q", output)
 	}
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/22453.

This PR adds deprecation notices to the `show cluster`, `show nodepool`, and `show release` commands. Similar to the notices for the `list RESOURCES` commands, these notices will only be shown for non-KVM installations.

Example for the `show cluster` command:
![Screen Shot 2022-06-29 at 12 54 40](https://user-images.githubusercontent.com/62935115/176420181-78827acc-fab2-4397-aa19-016ef3886fe2.png)


The equivalent `kubectl-gs` commands are sourced from our [gsctl migration docs](https://docs.giantswarm.io/ui-api/gsctl/migrate/).
